### PR TITLE
language: split types and expressions

### DIFF
--- a/src/language/interpret.mli
+++ b/src/language/interpret.mli
@@ -1,2 +1,3 @@
 val interpret_expr : Syntax.term -> Tree.expr
+val interpret_type : Syntax.term -> Tree.type_
 val interpret_pat : Syntax.term -> Tree.pat

--- a/src/language/language.mli
+++ b/src/language/language.mli
@@ -6,15 +6,28 @@ type expr = LE of { loc : Location.t; desc : expr_desc }
 and expr_desc =
   | LE_var of identifier
   | LE_number of number
-  | LE_arrow of { implicit : bool; param : pat; body : expr }
-  | LE_lambda of { implicit : bool; param : pat; body : expr }
+  | LE_lambda of { param : pat; body : expr }
   | LE_apply of { lambda : expr; arg : expr }
-  | LE_let of { bind : le_bind; body : expr }
-  | LE_record of le_bind list
-  | LE_signature of pat list
+  | LE_let of { bind : expr_bind; body : expr }
+  | LE_record of expr_bind list
   | LE_annot of { value : expr; annot : annot }
+  | LE_type of type_
 
-and le_bind = LE_bind of { loc : Location.t; bound : pat; value : expr }
+and expr_bind = LE_bind of { loc : Location.t; bound : pat; value : expr }
+and type_ = LT of { loc : Location.t; desc : type_desc }
+
+and type_desc =
+  | LT_var of identifier
+  | LT_forall of { var : identifier; kind : kind; body : type_ }
+  | LT_arrow of { param : type_; body : type_ }
+  | LT_record of type_bind list
+
+and type_bind =
+  | LT_bind of { loc : Location.t; var : identifier; type_ : type_ }
+
+and kind = LK of { loc : Location.t; desc : kind_desc }
+and kind_desc = LK_type | LK_arrow of { param : kind; body : kind }
+and annot = LA_type of expr | LA_kind of kind
 and pat = LP of { loc : Location.t; desc : pat_desc }
 
 and pat_desc =
@@ -22,9 +35,6 @@ and pat_desc =
   | LP_record of pat list
   | LP_annot of { pat : pat; annot : annot }
 
-and annot = LA_type of expr | LA_kind of kind
-and kind = LK of { loc : Location.t; desc : kind_desc }
-and kind_desc = LK_asterisk | LK_arrow of { param : kind; body : kind }
-
 val interpret_expr : Syntax.term -> expr
+val interpret_type : Syntax.term -> type_
 val interpret_pat : Syntax.term -> pat

--- a/src/language/tree.ml
+++ b/src/language/tree.ml
@@ -11,24 +11,39 @@ and expr_desc =
   | LE_var of identifier
   (* 123 *)
   | LE_number of number
-  (* pat -> expr *)
-  | LE_arrow of { implicit : bool; param : pat; body : expr }
   (* pat => expr *)
-  | LE_lambda of { implicit : bool; param : pat; body : expr }
+  | LE_lambda of { param : pat; body : expr }
   (* expr expr *)
   | LE_apply of { lambda : expr; arg : expr }
   (* pat = expr; expr *)
-  | LE_let of { bind : le_bind; body : expr }
+  | LE_let of { bind : expr_bind; body : expr }
   (* { pat = expr; } *)
-  | LE_record of le_bind list
-  (* TODO: should LE_signature allow any pattern? *)
-  (* { pat; } *)
-  | LE_signature of pat list
+  | LE_record of expr_bind list
   (* expr : type *)
   | LE_annot of { value : expr; annot : annot }
+  (* type_ *)
+  | LE_type of type_
 
-(* TODO: bind directly on parser *)
-and le_bind = LE_bind of { loc : Location.t; bound : pat; value : expr }
+(* TODO: bind directly on parser? *)
+and expr_bind = LE_bind of { loc : Location.t; bound : pat; value : expr }
+and type_ = LT of { loc : Location.t; desc : type_desc }
+
+and type_desc =
+  (* TODO: *)
+  (* _ *)
+  (* | LE_hole *)
+  (* X *)
+  | LT_var of identifier
+  (* (X: kind) -> typ*)
+  | LT_forall of { var : identifier; kind : kind; body : type_ }
+  (* typ -> typ *)
+  | LT_arrow of { param : type_; body : type_ }
+  (* TODO: should LT_record allow any pattern? *)
+  (* { X: typ; } *)
+  | LT_record of type_bind list
+
+and type_bind =
+  | LT_bind of { loc : Location.t; var : identifier; type_ : type_ }
 
 (* TODO: can pattern be unified back on expr? *)
 and pat = LP of { loc : Location.t; desc : pat_desc }
@@ -49,6 +64,6 @@ and kind = LK of { loc : Location.t; desc : kind_desc }
 
 and kind_desc =
   (* * *)
-  | LK_asterisk
+  | LK_type
   (* kind -> kind *)
   | LK_arrow of { param : kind; body : kind }


### PR DESCRIPTION
## Goals

Separating types and expressions to make easier to implement a Teika typer and this also temporarily reduces the language, removing a couple features such as implicit types. 


## Future

This in the future should be removed as there is plans for having dependent types in the language, but as current Core Teika is only System F-Omega, this doesn't limit us that much.
