### PR TITLE
language: disable higher kinded types

### DIFF
--- a/src/language/interpret.ml
+++ b/src/language/interpret.ml
@@ -62,7 +62,7 @@ let la_kind kind = LA_kind kind
 (* kind *)
 let make_kind loc desc = LK { loc; desc }
 let lk_type loc = make_kind loc LK_type
-let lk_arrow loc ~param ~body = make_kind loc (LK_arrow { param; body })
+(* let lk_arrow loc ~param ~body = make_kind loc (LK_arrow { param; body }) *)
 
 (* ambiguities *)
 let _is_implicit ~param =
@@ -324,12 +324,12 @@ and interpret_kind term =
   let { s_loc = loc; s_desc = term } = term in
   match term with
   | S_asterisk -> interpret_kind_asterisk loc
-  | S_arrow { param; body } -> interpret_kind_arrow loc ~param ~body
+  | S_arrow _ -> raise loc Unimplemented
   | _ -> raise loc Unimplemented
 
 and interpret_kind_asterisk loc = lk_type loc
 
-and interpret_kind_arrow loc ~param ~body =
-  let param = interpret_kind param in
-  let body = interpret_kind body in
-  lk_arrow loc ~param ~body
+(* and interpret_kind_arrow loc ~param ~body =
+   let param = interpret_kind param in
+   let body = interpret_kind body in
+   lk_arrow loc ~param ~body *)

--- a/src/language/language.mli
+++ b/src/language/language.mli
@@ -18,6 +18,7 @@ and type_ = LT of { loc : Location.t; desc : type_desc }
 
 and type_desc =
   | LT_var of identifier
+  (* TODO: likely body should be called return? *)
   | LT_forall of { var : identifier; kind : kind; body : type_ }
   | LT_arrow of { param : type_; body : type_ }
   | LT_record of type_bind list
@@ -26,7 +27,10 @@ and type_bind =
   | LT_bind of { loc : Location.t; var : identifier; type_ : type_ }
 
 and kind = LK of { loc : Location.t; desc : kind_desc }
-and kind_desc = LK_type | LK_arrow of { param : kind; body : kind }
+and kind_desc = LK_type
+(* TODO: likely body should be called return? *)
+(* | LK_arrow of { param : kind; body : kind } *)
+
 and annot = LA_type of expr | LA_kind of kind
 and pat = LP of { loc : Location.t; desc : pat_desc }
 

--- a/src/language/tree.ml
+++ b/src/language/tree.ml
@@ -62,8 +62,8 @@ and pat_desc =
 and annot = LA_type of expr | LA_kind of kind
 and kind = LK of { loc : Location.t; desc : kind_desc }
 
-and kind_desc =
-  (* * *)
+and kind_desc = (* * *)
   | LK_type
-  (* kind -> kind *)
-  | LK_arrow of { param : kind; body : kind }
+(* TODO: *)
+(* kind -> kind *)
+(* | LK_arrow of { param : kind; body : kind } *)


### PR DESCRIPTION
## Goals

Reduce the set of changes required to make the typer compile again, implement higher kinded types is "kind" of annoying and especially language already doesn't include LT_apply anyway.