### PR TITLE
language: rename {forall,arrow}.body to return

### DIFF
--- a/src/language/interpret.ml
+++ b/src/language/interpret.ml
@@ -42,10 +42,10 @@ let le_bind ~bound ~value =
 let make_typ loc desc = LT { loc; desc }
 let lt_var loc ~var = make_typ loc (LT_var var)
 
-let lt_forall loc ~var ~kind ~body =
-  make_typ loc (LT_forall { var; kind; body })
+let lt_forall loc ~var ~kind ~return =
+  make_typ loc (LT_forall { var; kind; return })
 
-let lt_arrow loc ~param ~body = make_typ loc (LT_arrow { param; body })
+let lt_arrow loc ~param ~return = make_typ loc (LT_arrow { param; return })
 let lt_record loc ~fields = make_typ loc (LT_record fields)
 let lt_bind ~bound_loc ~var ~type_ = LT_bind { loc = bound_loc; var; type_ }
 
@@ -214,10 +214,10 @@ and interpret_type_arrow_ambiguous loc ~param ~body =
   (* TODO: is this lookahead worth it? *)
   match param_desc with
   | S_annot { value = bound; type_ = kind } ->
-      interpret_type_forall loc ~bound ~kind ~body
+      interpret_type_forall loc ~bound ~kind ~return:body
   | _ -> interpret_type_arrow loc ~param ~body
 
-and interpret_type_forall loc ~bound ~kind ~body =
+and interpret_type_forall loc ~bound ~kind ~return =
   let var =
     let { s_loc = loc; s_desc = bound } = bound in
     match bound with
@@ -225,13 +225,13 @@ and interpret_type_forall loc ~bound ~kind ~body =
     | _ -> raise loc Forall_parameter_must_be_var
   in
   let kind = interpret_kind kind in
-  let body = interpret_type body in
-  lt_forall loc ~var ~kind ~body
+  let return = interpret_type return in
+  lt_forall loc ~var ~kind ~return
 
 and interpret_type_arrow loc ~param ~body =
   let param = interpret_type param in
-  let body = interpret_type body in
-  lt_arrow loc ~param ~body
+  let return = interpret_type body in
+  lt_arrow loc ~param ~return
 
 and interpret_type_record loc ~content =
   match content with

--- a/src/language/language.mli
+++ b/src/language/language.mli
@@ -18,9 +18,8 @@ and type_ = LT of { loc : Location.t; desc : type_desc }
 
 and type_desc =
   | LT_var of identifier
-  (* TODO: likely body should be called return? *)
-  | LT_forall of { var : identifier; kind : kind; body : type_ }
-  | LT_arrow of { param : type_; body : type_ }
+  | LT_forall of { var : identifier; kind : kind; return : type_ }
+  | LT_arrow of { param : type_; return : type_ }
   | LT_record of type_bind list
 
 and type_bind =
@@ -28,8 +27,7 @@ and type_bind =
 
 and kind = LK of { loc : Location.t; desc : kind_desc }
 and kind_desc = LK_type
-(* TODO: likely body should be called return? *)
-(* | LK_arrow of { param : kind; body : kind } *)
+(* | LK_arrow of { param : kind; return : kind } *)
 
 and annot = LA_type of expr | LA_kind of kind
 and pat = LP of { loc : Location.t; desc : pat_desc }

--- a/src/language/tree.ml
+++ b/src/language/tree.ml
@@ -35,9 +35,9 @@ and type_desc =
   (* X *)
   | LT_var of identifier
   (* (X: kind) -> typ*)
-  | LT_forall of { var : identifier; kind : kind; body : type_ }
+  | LT_forall of { var : identifier; kind : kind; return : type_ }
   (* typ -> typ *)
-  | LT_arrow of { param : type_; body : type_ }
+  | LT_arrow of { param : type_; return : type_ }
   (* TODO: should LT_record allow any pattern? *)
   (* { X: typ; } *)
   | LT_record of type_bind list
@@ -54,6 +54,7 @@ and pat_desc =
   (* | LP_any *)
   (* x *)
   | LP_var of identifier
+  (* { A; B; }*)
   | LP_record of pat list
   (* pat : type *)
   | LP_annot of { pat : pat; annot : annot }


### PR DESCRIPTION
## Goals

Make the usage of `body` and `return` consistent with typer. In general types have return and expressions have body, but this may just be internal bikeshedding.