### PR TITLE
typer: remove name from bounded variable

### DIFF
--- a/src/typer/env.ml
+++ b/src/typer/env.ml
@@ -99,7 +99,7 @@ let base, int_type, int_ident =
   in
 
   let int_name = Name.make "Int" in
-  let int_type = new_bound_var ~name:(Some int_name) predef_forall in
+  let int_type = new_bound_var predef_forall in
   let int_ident, predef =
     predef |> add int_name (new_type (Forall.generic ()) ~type_:int_type)
   in

--- a/src/typer/helpers.ml
+++ b/src/typer/helpers.ml
@@ -23,7 +23,7 @@ let rec free_vars foralls vars type_ =
   match desc type_ with
   | T_var (Weak _) ->
       if not (in_vars ~var:type_ vars) then type_ :: vars else vars
-  | T_var (Bound { forall; name = _ }) ->
+  | T_var (Bound { forall }) ->
       if (not (in_foralls ~forall foralls)) && not (in_vars ~var:type_ vars)
       then type_ :: vars
       else vars
@@ -44,8 +44,7 @@ let forall_vars ~forall type_ =
     (fun var ->
       match desc var with
       | T_var (Weak _) -> false
-      | T_var (Bound { forall = var_forall; name = _ }) ->
-          Forall.same forall var_forall
+      | T_var (Bound { forall = var_forall }) -> Forall.same forall var_forall
       | _ -> assert false)
     (free_vars type_)
 

--- a/src/typer/instance.ml
+++ b/src/typer/instance.ml
@@ -27,11 +27,11 @@ and instance_desc env ~bound_when_free ~forall foralls types type_ =
       let body = instance body in
       new_forall forall' ~body
   | T_var (Weak _) -> (* weak not copied *) type_
-  | T_var (Bound { forall = var_forall; name }) -> (
+  | T_var (Bound { forall = var_forall }) -> (
       if Forall.same forall var_forall then
         if bound_when_free then
           let forall = current_forall env in
-          new_bound_var ~name forall
+          new_bound_var forall
         else new_weak_var env
       else
         match
@@ -39,7 +39,7 @@ and instance_desc env ~bound_when_free ~forall foralls types type_ =
             (fun (key, _forall') -> Forall.same key var_forall)
             !foralls
         with
-        | Some (_key, forall') -> new_bound_var ~name forall'
+        | Some (_key, forall') -> new_bound_var forall'
         | None ->
             (* TODO: isn't this breaking an invariant? *)
             type_)

--- a/src/typer/lower.ml
+++ b/src/typer/lower.ml
@@ -5,7 +5,7 @@ let rec lower ~to_ type_ =
 
   match desc type_ with
   | T_forall { forall = _; body } -> lower body
-  | T_var (Weak { forall } | Bound { forall; name = _ }) ->
+  | T_var (Weak { forall } | Bound { forall }) ->
       let to_rank = Forall.rank to_ in
       let var_rank = Forall.rank forall in
       if Rank.(to_rank < var_rank) then lower_var ~to_ type_ else ()

--- a/src/typer/print.ml
+++ b/src/typer/print.ml
@@ -42,7 +42,7 @@ let register_name ctx type_ =
         let is_generic, forall =
           match var with
           | Weak { forall } -> (false, forall)
-          | Bound { forall; name = _ } -> (true, forall)
+          | Bound { forall } -> (true, forall)
         in
         let rank = Forall.rank forall in
         let prefix = if is_generic then "" else "_" in

--- a/src/typer/type.ml
+++ b/src/typer/type.ml
@@ -14,7 +14,7 @@ and type_var =
   (* TODO: should we have this name here? It's duplicated from Tree.t *)
   (* TODO: check name across codebase *)
   (* TODO: rename bound to rigid *)
-  | Bound of { mutable forall : Forall.t; name : Name.t option }
+  | Bound of { mutable forall : Forall.t }
 
 and field = { name : Name.t; type_ : type_ }
 
@@ -30,7 +30,7 @@ type desc =
 
 and var =
   | Weak of { mutable forall : Forall.t }
-  | Bound of { mutable forall : Forall.t; name : Name.t option }
+  | Bound of { mutable forall : Forall.t }
 [@@ocaml.warning "-unused-constructor"]
 
 (* externally opaque *)
@@ -42,8 +42,7 @@ let rec repr (type_ : type_) =
   | T_var ({ var = Weak { forall; link } } as var) ->
       if link == type_ then (
         (* fix outdated weak vars *)
-        if Forall.is_generic forall then
-          var.var <- Bound { forall; name = None };
+        if Forall.is_generic forall then var.var <- Bound { forall };
         type_)
       else repr link
   | _ -> type_
@@ -82,7 +81,7 @@ let new_weak_var forall : type_ =
   let rec var : type_ = T_var { var = Weak { forall; link = var } } in
   var
 
-let new_bound_var ~name forall : type_ = T_var { var = Bound { forall; name } }
+let new_bound_var forall : type_ = T_var { var = Bound { forall } }
 let new_arrow ~param ~return : type_ = T_arrow { param; return }
 let new_struct ~fields : type_ = T_struct { fields }
 let new_type forall ~type_ : type_ = T_type { forall; type_ }

--- a/src/typer/type.mli
+++ b/src/typer/type.mli
@@ -15,7 +15,7 @@ type desc = private
 
 and var = private
   | Weak of { mutable forall : Forall.t }
-  | Bound of { mutable forall : Forall.t; name : Name.t option }
+  | Bound of { mutable forall : Forall.t }
 
 and field = { name : Name.t; type_ : type_ }
 and link
@@ -37,7 +37,7 @@ val lower_var : to_:Forall.t -> type_ -> unit
 (* TODO: are those helpers useful? *)
 val new_forall : Forall.t -> body:type_ -> type_
 val new_weak_var : Forall.t -> type_
-val new_bound_var : name:Name.t option -> Forall.t -> type_
+val new_bound_var : Forall.t -> type_
 val new_arrow : param:type_ -> return:type_ -> type_
 val new_struct : fields:field list -> type_
 val new_type : Forall.t -> type_:type_ -> type_

--- a/src/typer/unify.ml
+++ b/src/typer/unify.ml
@@ -30,7 +30,7 @@ let rec update_rank loc ~var ~max_forall type_ =
       let forall, is_bound =
         match var_desc with
         | Weak { forall } -> (forall, false)
-        | Bound { forall; name = _ } -> (forall, true)
+        | Bound { forall } -> (forall, true)
       in
       (* received is introduced after rank is incremented so >
                generic is the lowest, so it will always match this *)


### PR DESCRIPTION
## Goals

Remove name from bounded variables, bound vars currently may have names, but this is partially implemented in a bad way, but it's not used anywhere and makes noise.

This will come back naturally as a feature at some point, but now I just want my typer to be implemented.