### PR TITLE
typer: rename struct to record

### DIFF
--- a/src/typer/helpers.ml
+++ b/src/typer/helpers.ml
@@ -9,7 +9,7 @@ and in_type_desc ~var type_ =
   | T_var _ -> false
   | T_forall { forall = _; body } -> in_type body
   | T_arrow { param; return } -> in_type param || in_type return
-  | T_struct { fields } ->
+  | T_record { fields } ->
       List.exists (fun { name = _; type_ } -> in_type type_) fields
   | T_type { forall = _; type_ } -> in_type type_
 
@@ -31,7 +31,7 @@ let rec free_vars foralls vars type_ =
   | T_arrow { param; return } ->
       let vars = free_vars foralls vars param in
       free_vars foralls vars return
-  | T_struct { fields } ->
+  | T_record { fields } ->
       List.fold_left
         (fun vars { name = _; type_ } -> free_vars foralls vars type_)
         vars fields

--- a/src/typer/instance.ml
+++ b/src/typer/instance.ml
@@ -48,7 +48,7 @@ and instance_desc env ~bound_when_free ~forall foralls types type_ =
       let return = instance return in
       new_arrow ~param ~return
   (* TODO: should this type_ be also copied? *)
-  | T_struct { fields } ->
+  | T_record { fields } ->
       let fields =
         List.map
           (fun { name; type_ } ->
@@ -56,7 +56,7 @@ and instance_desc env ~bound_when_free ~forall foralls types type_ =
             { name; type_ })
           fields
       in
-      new_struct ~fields
+      new_record ~fields
   | T_type { forall; type_ } ->
       let forall' = Forall.generic () in
       foralls := (forall, forall') :: !foralls;

--- a/src/typer/lower.ml
+++ b/src/typer/lower.ml
@@ -12,6 +12,6 @@ let rec lower ~to_ type_ =
   | T_arrow { param; return } ->
       lower param;
       lower return
-  | T_struct { fields } ->
+  | T_record { fields } ->
       List.iter (fun { name = _; type_ } -> lower type_) fields
   | T_type { forall = _; type_ } -> lower type_

--- a/src/typer/print.ml
+++ b/src/typer/print.ml
@@ -36,7 +36,7 @@ let register_name ctx type_ =
 
   let name =
     match desc type_ with
-    | T_forall _ | T_arrow _ | T_struct _ | T_type _ -> sprintf "[%d]" id
+    | T_forall _ | T_arrow _ | T_record _ | T_type _ -> sprintf "[%d]" id
     | T_var var ->
         (* TODO: use bound name *)
         let is_generic, forall =
@@ -75,12 +75,12 @@ and pp_type_desc ctx fmt type_ =
       let parens =
         match desc param with
         | T_var _ -> false
-        (* TODO: t_struct should need parens? *)
-        | T_forall _ | T_arrow _ | T_struct _ | T_type _ -> true
+        (* TODO: T_record should need parens? *)
+        | T_forall _ | T_arrow _ | T_record _ | T_type _ -> true
       in
       if parens then fprintf fmt "(%a) -> %a" pp_type param pp_type return
       else fprintf fmt "%a -> %a" pp_type param pp_type return
-  | T_struct { fields } ->
+  | T_record { fields } ->
       let pp_fields fmt fields =
         List.iter
           (fun { name; type_ } ->

--- a/src/typer/test.ml
+++ b/src/typer/test.ml
@@ -84,11 +84,11 @@ let choose_id_hm_incr =
 let number_types =
   equal ~name:"number_types" ~code:"x => 1" ~type_:"{A} -> A -> Int"
 
-let empty_struct_type =
-  equal ~name:"empty_struct_type" ~code:"(x: {}) => x" ~type_:"({}) -> {}"
+let empty_record_type =
+  equal ~name:"empty_record_type" ~code:"(x: {}) => x" ~type_:"({}) -> {}"
 
-let multiple_fields_struct =
-  equal ~name:"multiple_fields_struct" ~code:"(m: { x: Int; y: Int; }) => m"
+let multiple_fields_record =
+  equal ~name:"multiple_fields_record" ~code:"(m: { x: Int; y: Int; }) => m"
     ~type_:"({ x: Int; y: Int; }) -> { x: Int; y: Int; }"
 
 let module_is_not_value =
@@ -145,8 +145,8 @@ let cursed_destruct_arrow_return =
   equal ~name:"cursed_destruct_arrow_return" ~code:"1"
     ~type_:"(F = {A} => {B} => (T: A -> B) => B; f x = 1; F f)"
 
-let simple_struct =
-  equal ~name:"simple_struct" ~code:"{ x = 1; }" ~type_:"{ x: Int; }"
+let simple_record =
+  equal ~name:"simple_record" ~code:"{ x = 1; }" ~type_:"{ x: Int; }"
 
 let explicit_type =
   equal ~name:"explicit_type" ~code:"(A: *) => (x: A) => x"
@@ -169,15 +169,15 @@ let explicit_type_constructor =
     ~type_:"(A: *) -> A"
 
 (* TODO: solve semicolons problem *)
-let type_struct_id =
-  equal ~name:"type_struct_id" ~code:"({ A; }: { A: *; }) => (x: A) => x"
+let type_record_id =
+  equal ~name:"type_record_id" ~code:"({ A; }: { A: *; }) => (x: A) => x"
     ~type_:"({ A; }: { A: *; }) -> A -> A"
 
-let calling_type_struct_id =
-  equal ~name:"calling_type_struct_id"
+let calling_type_record_id =
+  equal ~name:"calling_type_record_id"
     ~code:
-      {|explicit_struct_id = ({ A; }: { A: *; }) => (x: A) => x;
-        explicit_struct_id { A = Int; }|}
+      {|explicit_record_id = ({ A; }: { A: *; }) => (x: A) => x;
+        explicit_record_id { A = Int; }|}
     ~type_:"Int -> Int"
 
 (* TODO: is this unsound even if called with a non struct type? *)
@@ -339,8 +339,8 @@ let tests =
     choose_id_hm;
     choose_id_hm_incr;
     number_types;
-    empty_struct_type;
-    multiple_fields_struct;
+    empty_record_type;
+    multiple_fields_record;
     module_is_not_value;
     term_type_alias;
     type_type_alias;
@@ -352,12 +352,12 @@ let tests =
     dont_lower_var;
     cursed_destruct_arrow_param;
     cursed_destruct_arrow_return;
-    simple_struct;
+    simple_record;
     explicit_type;
     calling_explicit_type;
     escape_scope;
-    type_struct_id;
-    calling_type_struct_id;
+    type_record_id;
+    calling_type_record_id;
     existential_record;
     double_existential_record;
     let_type_existential_record;

--- a/src/typer/type.ml
+++ b/src/typer/type.ml
@@ -4,7 +4,7 @@ type type_ =
   | T_forall of { forall : Forall.t; body : type_ }
   | T_var of { mutable var : type_var }
   | T_arrow of { param : type_; return : type_ }
-  | T_struct of { fields : field list }
+  | T_record of { fields : field list }
   | T_type of { forall : Forall.t; type_ : type_ }
 
 and type_var =
@@ -24,7 +24,7 @@ type desc =
   | T_forall of { forall : Forall.t; body : type_ }
   | T_var of var
   | T_arrow of { param : type_; return : type_ }
-  | T_struct of { fields : field list }
+  | T_record of { fields : field list }
   | T_type of { forall : Forall.t; type_ : type_ }
 [@@ocaml.warning "-unused-constructor"]
 
@@ -83,5 +83,5 @@ let new_weak_var forall : type_ =
 
 let new_bound_var forall : type_ = T_var { var = Bound { forall } }
 let new_arrow ~param ~return : type_ = T_arrow { param; return }
-let new_struct ~fields : type_ = T_struct { fields }
+let new_record ~fields : type_ = T_record { fields }
 let new_type forall ~type_ : type_ = T_type { forall; type_ }

--- a/src/typer/type.mli
+++ b/src/typer/type.mli
@@ -9,7 +9,7 @@ type desc = private
   | T_var of var
   | T_arrow of { param : type_; return : type_ }
   (* TODO: enforce that field list doesn't contain any duplicated name *)
-  | T_struct of { fields : field list }
+  | T_record of { fields : field list }
   (* TODO: T_type is weird *)
   | T_type of { forall : Forall.t; type_ : type_ }
 
@@ -39,5 +39,5 @@ val new_forall : Forall.t -> body:type_ -> type_
 val new_weak_var : Forall.t -> type_
 val new_bound_var : Forall.t -> type_
 val new_arrow : param:type_ -> return:type_ -> type_
-val new_struct : fields:field list -> type_
+val new_record : fields:field list -> type_
 val new_type : Forall.t -> type_:type_ -> type_

--- a/src/typer/unify.ml
+++ b/src/typer/unify.ml
@@ -43,7 +43,7 @@ let rec update_rank loc ~var ~max_forall type_ =
   | T_arrow { param; return } ->
       update_rank param;
       update_rank return
-  | T_struct { fields } ->
+  | T_record { fields } ->
       (* TODO: also check name *)
       List.iter (fun { name = _; type_ } -> update_rank type_) fields
   | T_type { forall = _; type_ } -> (* TODO: is this right? *) update_rank type_
@@ -94,7 +94,7 @@ and unify_desc env rank ~expected ~received =
       T_arrow { param = received_param; return = received_return } ) ->
       unify env rank ~expected:received_param ~received:expected_param;
       unify env rank ~expected:expected_return ~received:received_return
-  | T_struct { fields = expected_fields }, T_struct { fields = received_fields }
+  | T_record { fields = expected_fields }, T_record { fields = received_fields }
     ->
       if List.length expected_fields <> List.length received_fields then
         raise (Env.current_loc env) (Type_clash { expected; received });
@@ -110,8 +110,8 @@ and unify_desc env rank ~expected ~received =
       (* TODO: proper unification of types? *)
       (* TODO: does this make sense *)
       unify env rank ~expected ~received
-  | T_struct _, _
-  | _, T_struct _
+  | T_record _, _
+  | _, T_record _
   | T_var _, _
   | _, T_var _
   | T_type _, _


### PR DESCRIPTION
## Goals

Use more popular name for records, in a both on the literature and on other tools, structs are called records, even when they hold types, in which case they are called an existential record, so this is the name that Teika will be using for it's modules / structs / records.