### PR TITLE
typer: rename T_forall.body to return

### DIFF
--- a/src/typer/helpers.ml
+++ b/src/typer/helpers.ml
@@ -7,7 +7,7 @@ and in_type_desc ~var type_ =
   let in_type type_ = in_type ~var type_ in
   match desc type_ with
   | T_var _ -> false
-  | T_forall { forall = _; body } -> in_type body
+  | T_forall { forall = _; return } -> in_type return
   | T_arrow { param; return } -> in_type param || in_type return
   | T_record { fields } ->
       List.exists (fun { name = _; type_ } -> in_type type_) fields
@@ -27,7 +27,7 @@ let rec free_vars foralls vars type_ =
       if (not (in_foralls ~forall foralls)) && not (in_vars ~var:type_ vars)
       then type_ :: vars
       else vars
-  | T_forall { forall; body } -> free_vars (forall :: foralls) vars body
+  | T_forall { forall; return } -> free_vars (forall :: foralls) vars return
   | T_arrow { param; return } ->
       let vars = free_vars foralls vars param in
       free_vars foralls vars return

--- a/src/typer/instance.ml
+++ b/src/typer/instance.ml
@@ -20,12 +20,12 @@ and instance_desc env ~bound_when_free ~forall foralls types type_ =
     instance env ~bound_when_free ~forall foralls types type_
   in
   match desc type_ with
-  | T_forall { forall; body } ->
+  | T_forall { forall; return } ->
       let forall' = Forall.generic () in
       foralls := (forall, forall') :: !foralls;
 
-      let body = instance body in
-      new_forall forall' ~body
+      let return = instance return in
+      new_forall forall' ~return
   | T_var (Weak _) -> (* weak not copied *) type_
   | T_var (Bound { forall = var_forall }) -> (
       if Forall.same forall var_forall then

--- a/src/typer/lower.ml
+++ b/src/typer/lower.ml
@@ -4,7 +4,7 @@ let rec lower ~to_ type_ =
   let lower type_ = lower ~to_ type_ in
 
   match desc type_ with
-  | T_forall { forall = _; body } -> lower body
+  | T_forall { forall = _; return } -> lower return
   | T_var (Weak { forall } | Bound { forall }) ->
       let to_rank = Forall.rank to_ in
       let var_rank = Forall.rank forall in

--- a/src/typer/print.ml
+++ b/src/typer/print.ml
@@ -73,12 +73,12 @@ and pp_type_desc ctx fmt type_ =
   match desc type_ with
   (* just print name *)
   | T_var _ -> pp_type fmt type_
-  | T_forall { forall; body } ->
-      let vars = forall_vars ~forall body in
+  | T_forall { forall; return } ->
+      let vars = forall_vars ~forall return in
 
       (* not rev_map because order matters here *)
       List.rev vars |> List.iter (fun var -> fprintf fmt "{%a} -> " pp_type var);
-      fprintf fmt "%a" pp_type body
+      fprintf fmt "%a" pp_type return
   | T_arrow { param; return } ->
       let parens =
         match desc param with

--- a/src/typer/test.ml
+++ b/src/typer/test.ml
@@ -279,7 +279,7 @@ let test_match_type ~equal ~name ~code ~type_ =
       let forall, env = Env.enter_forall env in
       let code_type, _code = type_expr env code in
       Typer.Forall.universal forall;
-      Typer.Type.new_forall forall ~body:code_type
+      Typer.Type.new_forall forall ~return:code_type
     in
 
     let checker = if equal then equal_type else subtype_type in

--- a/src/typer/type.ml
+++ b/src/typer/type.ml
@@ -1,7 +1,7 @@
 open Utils
 
 type type_ =
-  | T_forall of { forall : Forall.t; body : type_ }
+  | T_forall of { forall : Forall.t; return : type_ }
   | T_var of { mutable var : type_var }
   | T_arrow of { param : type_; return : type_ }
   | T_record of { fields : field list }
@@ -21,7 +21,7 @@ and field = { name : Name.t; type_ : type_ }
 type t = type_
 
 type desc =
-  | T_forall of { forall : Forall.t; body : type_ }
+  | T_forall of { forall : Forall.t; return : type_ }
   | T_var of var
   | T_arrow of { param : type_; return : type_ }
   | T_record of { fields : field list }
@@ -75,7 +75,7 @@ let lower_var ~to_ type_ =
       bound.forall <- to_
   | _ -> assert false
 
-let new_forall forall ~body : type_ = T_forall { forall; body }
+let new_forall forall ~return : type_ = T_forall { forall; return }
 
 let new_weak_var forall : type_ =
   let rec var : type_ = T_var { var = Weak { forall; link = var } } in

--- a/src/typer/type.mli
+++ b/src/typer/type.mli
@@ -5,7 +5,7 @@ type type_
 type t = type_
 
 type desc = private
-  | T_forall of { forall : Forall.t; body : type_ }
+  | T_forall of { forall : Forall.t; return : type_ }
   | T_var of var
   | T_arrow of { param : type_; return : type_ }
   (* TODO: enforce that field list doesn't contain any duplicated name *)
@@ -35,7 +35,7 @@ val lower_var : to_:Forall.t -> type_ -> unit
 
 (* helpers *)
 (* TODO: are those helpers useful? *)
-val new_forall : Forall.t -> body:type_ -> type_
+val new_forall : Forall.t -> return:type_ -> type_
 val new_weak_var : Forall.t -> type_
 val new_bound_var : Forall.t -> type_
 val new_arrow : param:type_ -> return:type_ -> type_


### PR DESCRIPTION
## Goals

Ensure that everywhere the return of a forall or arrow is called return.

I'm hoping is  the last renaming PRs of the day.