### PR TITLE
typer: makes so that records always carries 

### DIFF
--- a/src/typer/helpers.ml
+++ b/src/typer/helpers.ml
@@ -39,11 +39,7 @@ let rec free_vars foralls vars type_ =
       List.fold_left
         (fun vars field ->
           let (T_field { forall; name = _; type_ }) = field in
-          let foralls =
-            match forall with
-            | Some forall -> forall :: foralls
-            | None -> foralls
-          in
+          let foralls = forall :: foralls in
           free_vars foralls vars type_)
         vars fields
   | T_type type_ -> free_vars foralls vars type_

--- a/src/typer/instance.ml
+++ b/src/typer/instance.ml
@@ -55,12 +55,9 @@ and instance_desc env ~bound_when_free ~forall foralls types type_ =
             let (T_field { forall; name; type_ }) = field in
 
             let forall =
-              match forall with
-              | Some forall ->
-                  let forall' = Forall.generic () in
-                  foralls := (forall, forall') :: !foralls;
-                  Some forall'
-              | None -> None
+              let forall' = Forall.generic () in
+              foralls := (forall, forall') :: !foralls;
+              forall'
             in
 
             let type_ = instance type_ in

--- a/src/typer/tree.ml
+++ b/src/typer/tree.ml
@@ -50,7 +50,7 @@ and type_bind =
       (* exposed env *)
       env : Env.t;
       loc : Location.t;
-      type_ : Type.t;
+      field : Type.field;
       var : Ident.t;
       annot : annot;
     }

--- a/src/typer/type.ml
+++ b/src/typer/type.ml
@@ -18,7 +18,7 @@ and type_var =
 
 and field =
   (* { Name: Type; } *)
-  | T_field of { forall : Forall.t option; name : Name.t; type_ : type_ }
+  | T_field of { forall : Forall.t; name : Name.t; type_ : type_ }
 
 type t = type_
 

--- a/src/typer/type.mli
+++ b/src/typer/type.mli
@@ -18,7 +18,7 @@ and var = private
   | Bound of { mutable forall : Forall.t }
 
 and field = private
-  | T_field of { forall : Forall.t option; name : Name.t; type_ : type_ }
+  | T_field of { forall : Forall.t; name : Name.t; type_ : type_ }
 
 and link
 
@@ -42,5 +42,5 @@ val new_weak_var : Forall.t -> type_
 val new_bound_var : Forall.t -> type_
 val new_arrow : param:type_ -> return:type_ -> type_
 val new_record : fields:field list -> type_
-val new_field : forall:Forall.t option -> name:Name.t -> type_:type_ -> field
+val new_field : forall:Forall.t -> name:Name.t -> type_:type_ -> field
 val new_type : type_:type_ -> type_

--- a/src/typer/unify.ml
+++ b/src/typer/unify.ml
@@ -108,30 +108,23 @@ and unify_desc env rank ~expected ~received =
               =
             expected_field
           in
-          let expected =
-            match expected_forall with
-            | Some expected_forall ->
-                instance_weaken env ~forall:expected_forall expected
-            | None -> expected
-          in
+          let expected = instance_weaken env ~forall:expected_forall expected in
 
           let (T_field { forall = received_forall; name = _; type_ = received })
               =
             received_field
           in
-          match received_forall with
-          | Some received_forall ->
-              (* TODO: tag + clear is weird *)
-              let rank = Rank.next rank in
-              let env =
-                (* TODO: neede because instance_weaken below, is this right? *)
-                let forall = Forall.weak rank in
-                Env.with_forall forall env
-              in
-              Forall.with_rank
-                (fun () -> unify env rank ~expected ~received)
-                rank received_forall
-          | None -> unify env rank ~expected ~received)
+
+          (* TODO: tag + clear is weird *)
+          let rank = Rank.next rank in
+          let env =
+            (* TODO: neede because instance_weaken below, is this right? *)
+            let forall = Forall.weak rank in
+            Env.with_forall forall env
+          in
+          Forall.with_rank
+            (fun () -> unify env rank ~expected ~received)
+            rank received_forall)
         expected_fields received_fields
   | T_type expected, T_type received ->
       (* TODO: proper unification of types? *)


### PR DESCRIPTION
## Goals

I'm trying to reduce the number of branches that we need to keep track on the typer and this one is not really useful, maybe as an optimization, but if so it should not be done here.

Essentially the forall is just gonna be empty if it's not binding a kind.