### PR TITLE
smol: introduce language tree

### DIFF
--- a/smol/dune
+++ b/smol/dune
@@ -1,0 +1,25 @@
+(library
+ (name smol)
+ (libraries menhirLib compiler-libs.common)
+ (modules
+  (:standard \ Test))
+ (preprocess
+  (pps ppx_deriving.show sedlex.ppx)))
+
+(menhir
+ (modules parser)
+ (flags --explain))
+
+(executable
+ (name test)
+ (modules Test)
+ (libraries alcotest smol)
+ (preprocess
+  (pps ppx_deriving.show)))
+
+(rule
+ (alias runtest)
+ (deps
+  (:exe ./test.exe))
+ (action
+  (run %{exe})))

--- a/smol/ltree.ml
+++ b/smol/ltree.ml
@@ -1,0 +1,50 @@
+type expr = LE of { loc : Location.t; desc : expr_desc }
+
+and expr_desc =
+  | LE_var of { var : Name.t }
+  | LE_lambda of { var : Name.t; param : type_; return : expr }
+  | LE_forall of { var : Name.t; return : expr }
+  | LE_apply of { funct : expr; arg : expr }
+  | LE_pair of { left : bind; right : bind }
+  | LE_exists of { var : Name.t; right : bind }
+  | LE_type of { type_ : type_ }
+  | LE_let of { bind : bind; return : expr }
+  | LE_annot of { expr : expr; type_ : type_ }
+
+and bind = LB of { loc : Location.t; var : Name.t; value : expr }
+and type_ = LT of { loc : Location.t; desc : type_desc }
+
+and type_desc =
+  | LT_var of { var : Name.t }
+  | LT_arrow of { param : type_; return : type_ }
+  | LT_forall of { var : Name.t; return : type_ }
+  | LT_pair of { left : type_; right : type_ }
+  | LT_exists of { var : Name.t; right : type_ }
+
+(* and kind = LK_type | LK_arrow of { param : kind; return : kind } *)
+
+(* expr *)
+let le loc desc = LE { loc; desc }
+let le_var loc ~var = le loc (LE_var { var })
+
+let le_lambda loc ~var ~param ~return =
+  le loc (LE_lambda { var; param; return })
+
+let le_forall loc ~var ~return = le loc (LE_forall { var; return })
+let le_apply loc ~funct ~arg = le loc (LE_apply { funct; arg })
+let le_pair loc ~left ~right = le loc (LE_pair { left; right })
+let le_exists loc ~var ~right = le loc (LE_exists { var; right })
+let le_type loc ~type_ = le loc (LE_type { type_ })
+let le_let loc ~bind ~return = le loc (LE_let { bind; return })
+let le_annot loc ~expr ~type_ = le loc (LE_annot { expr; type_ })
+
+(* bind *)
+let lb loc ~var ~value = LB { loc; var; value }
+
+(* type *)
+let lt loc desc = LT { loc; desc }
+let lt_var loc ~var = lt loc (LT_var { var })
+let lt_arrow loc ~param ~return = lt loc (LT_arrow { param; return })
+let lt_forall loc ~var ~return = lt loc (LT_forall { var; return })
+let lt_pair loc ~left ~right = lt loc (LT_pair { left; right })
+let lt_exists loc ~var ~right = lt loc (LT_exists { var; right })

--- a/smol/ltree.mli
+++ b/smol/ltree.mli
@@ -1,0 +1,59 @@
+type expr = LE of { loc : Location.t; desc : expr_desc }
+
+and expr_desc =
+  (* x *)
+  | LE_var of { var : Name.t }
+  (* (x: t) => e *)
+  | LE_lambda of { var : Name.t; param : type_; return : expr }
+  (* (x: k) => e *)
+  | LE_forall of { var : Name.t; return : expr }
+  (* e1 e2 *)
+  | LE_apply of { funct : expr; arg : expr }
+  (* (x = e1, y = e2) *)
+  | LE_pair of { left : bind; right : bind }
+  (* (x: k, y = e) *)
+  | LE_exists of { var : Name.t; right : bind }
+  (* #t *)
+  | LE_type of { type_ : type_ }
+  (* x = e1; e2 *)
+  | LE_let of { bind : bind; return : expr }
+  (* (e : t) *)
+  | LE_annot of { expr : expr; type_ : type_ }
+
+and bind = (* x = e *)
+  | LB of { loc : Location.t; var : Name.t; value : expr }
+
+and type_ = LT of { loc : Location.t; desc : type_desc }
+
+and type_desc =
+  (* x *)
+  | LT_var of { var : Name.t }
+  (* t -> t *)
+  | LT_arrow of { param : type_; return : type_ }
+  (* (x: k) -> t *)
+  | LT_forall of { var : Name.t; return : type_ }
+  (* (x: t, y: t) *)
+  | LT_pair of { left : type_; right : type_ }
+  (* (x: k, y: t) *)
+  | LT_exists of { var : Name.t; right : type_ }
+
+(* expr *)
+val le_var : Location.t -> var:Name.t -> expr
+val le_lambda : Location.t -> var:Name.t -> param:type_ -> return:expr -> expr
+val le_forall : Location.t -> var:Name.t -> return:expr -> expr
+val le_apply : Location.t -> funct:expr -> arg:expr -> expr
+val le_pair : Location.t -> left:bind -> right:bind -> expr
+val le_exists : Location.t -> var:Name.t -> right:bind -> expr
+val le_type : Location.t -> type_:type_ -> expr
+val le_let : Location.t -> bind:bind -> return:expr -> expr
+val le_annot : Location.t -> expr:expr -> type_:type_ -> expr
+
+(* bind *)
+val lb : Location.t -> var:Name.t -> value:expr -> bind
+
+(* type *)
+val lt_var : Location.t -> var:Name.t -> type_
+val lt_arrow : Location.t -> param:type_ -> return:type_ -> type_
+val lt_forall : Location.t -> var:Name.t -> return:type_ -> type_
+val lt_pair : Location.t -> left:type_ -> right:type_ -> type_
+val lt_exists : Location.t -> var:Name.t -> right:type_ -> type_

--- a/smol/name.ml
+++ b/smol/name.ml
@@ -1,0 +1,8 @@
+type t = string [@@deriving show]
+
+let make t = t
+let equal = String.equal
+let compare = String.compare
+let repr t = t
+
+module Map = Map.Make (String)

--- a/smol/name.mli
+++ b/smol/name.mli
@@ -1,0 +1,9 @@
+type t [@@deriving show]
+
+val make : string -> t
+val equal : t -> t -> bool
+val compare : t -> t -> int
+val repr : t -> string
+
+(* TODO: stop exposing this *)
+module Map : Map.S with type key = t


### PR DESCRIPTION
## Goals

Define the library and introduce the core of the language used to describe SmolTeika.

## Changes

= The dune file used also contains some stanzas that are only gonna be used on a future PR.

- The Name module is copied so that the Smol library can be independent from the Teika library.

- The Ltree module currently defines a subset of what SmolTeika can do, namely it doesn't provide a way to unpack pairs and existentials