### PR TITLE
smol: rename T_type to T_alias

### DIFF
--- a/smol/machinery.mli
+++ b/smol/machinery.mli
@@ -6,6 +6,6 @@ exception Not_a_function of { funct : type_ }
 exception Not_a_type of { type_ : type_ }
 
 val subtype : expected:type_ -> received:type_ -> unit
-val extract_type : wrapped:type_ -> type_
+val extract : wrapped:type_ -> type_
 val apply : funct:type_ -> arg:type_ -> type_
 val unpair : pair:type_ -> type_ * type_

--- a/smol/test.ml
+++ b/smol/test.ml
@@ -143,7 +143,7 @@ let wrapped_env =
     let env = Env.empty in
     let int = var "Int" in
     let int_type = Type.t_var ~var:int in
-    let env = Env.enter int (t_type ~type_:int_type) env in
+    let env = Env.enter int (t_alias ~type_:int_type) env in
     let env = Env.enter (var "one") int_type env in
 
     List.fold_left
@@ -152,7 +152,7 @@ let wrapped_env =
         let expr = type_expr env expr in
 
         let upper_name = String.capitalize_ascii name in
-        let env = Env.enter (var upper_name) (t_type ~type_) env in
+        let env = Env.enter (var upper_name) (t_alias ~type_) env in
         Env.enter (var name) expr env)
       env utils)
 

--- a/smol/transl_type.ml
+++ b/smol/transl_type.ml
@@ -4,12 +4,12 @@ open Type
 open Machinery
 
 let enter var type_ env =
-  let type_ = t_type ~type_ in
+  let type_ = t_alias ~type_ in
   Env.enter var type_ env
 
 let lookup var env =
-  let var, type_ = Env.lookup var env in
-  let type_ = extract_type ~wrapped:type_ in
+  let var, wrapped = Env.lookup var env in
+  let type_ = extract ~wrapped in
   (var, type_)
 
 let rec transl_type env type_ =

--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -76,7 +76,7 @@ let te_unpair ~unpair ~return =
 let te_type ~type_ =
   let type_type =
     let (TT { type_; desc = _ }) = type_ in
-    t_type ~type_
+    t_alias ~type_
   in
   te type_type (TE_type { type_ })
 

--- a/smol/type.ml
+++ b/smol/type.ml
@@ -4,7 +4,7 @@ type type_ =
   | T_forall of { var : Var.t; return : type_ }
   | T_pair of { left : type_; right : type_ }
   | T_exists of { var : Var.t; right : type_ }
-  | T_type of { type_ : type_ }
+  | T_alias of { type_ : type_ }
 [@@deriving show]
 
 type t = type_ [@@deriving show]
@@ -14,4 +14,4 @@ let t_arrow ~param ~return = T_arrow { param; return }
 let t_forall ~var ~return = T_forall { var; return }
 let t_pair ~left ~right = T_pair { left; right }
 let t_exists ~var ~right = T_exists { var; right }
-let t_type ~type_ = T_type { type_ }
+let t_alias ~type_ = T_alias { type_ }

--- a/smol/type.mli
+++ b/smol/type.mli
@@ -4,7 +4,7 @@ type type_ = private
   | T_forall of { var : Var.t; return : type_ }
   | T_pair of { left : type_; right : type_ }
   | T_exists of { var : Var.t; right : type_ }
-  | T_type of { type_ : type_ }
+  | T_alias of { type_ : type_ }
 
 type t = type_ [@@deriving show]
 
@@ -13,4 +13,4 @@ val t_arrow : param:type_ -> return:type_ -> type_
 val t_forall : var:Var.t -> return:type_ -> type_
 val t_pair : left:type_ -> right:type_ -> type_
 val t_exists : var:Var.t -> right:type_ -> type_
-val t_type : type_:type_ -> type_
+val t_alias : type_:type_ -> type_

--- a/smol/type_expr.ml
+++ b/smol/type_expr.ml
@@ -24,7 +24,7 @@ let rec type_expr env expr =
   | LE_forall { var; return } ->
       let var = Var.create var in
       let env =
-        let param = t_type ~type_:(t_var ~var) in
+        let param = t_alias ~type_:(t_var ~var) in
         enter var param env
       in
       let return = type_expr env return in
@@ -45,7 +45,7 @@ let rec type_expr env expr =
   | LE_exists { var; right } ->
       let var = Var.create var in
       let env =
-        let left = t_type ~type_:(t_var ~var) in
+        let left = t_alias ~type_:(t_var ~var) in
         enter var left env
       in
       let _env, right = type_bind env right in


### PR DESCRIPTION
## Goal

Tries to improve on the nomenclature, what we call a T_type is actually an alias to another type, this is used to be able to carry types on normal variables but also to implement the FORGET logic for modules.