### PR TITLE
smol: add a type to represent types

### DIFF
--- a/smol/machinery.mli
+++ b/smol/machinery.mli
@@ -3,7 +3,7 @@ open Type
 exception Var_clash of { expected : Var.t; received : Var.t }
 exception Type_clash of { expected : type_; received : type_ }
 exception Not_a_function of { funct : type_ }
-exception Not_a_type of { type_ : type_ }
+exception Not_a_wrapped_type of { type_ : type_ }
 
 val subtype : expected:type_ -> received:type_ -> unit
 val extract : wrapped:type_ -> type_

--- a/smol/type.ml
+++ b/smol/type.ml
@@ -1,4 +1,5 @@
 type type_ =
+  | T_type
   | T_var of { var : Var.t }
   | T_arrow of { param : type_; return : type_ }
   | T_forall of { var : Var.t; return : type_ }
@@ -9,6 +10,7 @@ type type_ =
 
 type t = type_ [@@deriving show]
 
+let t_type = T_type
 let t_var ~var = T_var { var }
 let t_arrow ~param ~return = T_arrow { param; return }
 let t_forall ~var ~return = T_forall { var; return }

--- a/smol/type.mli
+++ b/smol/type.mli
@@ -1,4 +1,5 @@
 type type_ = private
+  | T_type
   | T_var of { var : Var.t }
   | T_arrow of { param : type_; return : type_ }
   | T_forall of { var : Var.t; return : type_ }
@@ -8,6 +9,7 @@ type type_ = private
 
 type t = type_ [@@deriving show]
 
+val t_type : type_
 val t_var : var:Var.t -> type_
 val t_arrow : param:type_ -> return:type_ -> type_
 val t_forall : var:Var.t -> return:type_ -> type_


### PR DESCRIPTION
## Goals

This adds a proper way to describe any type on the Smol typer, this is also so that types can describe kinds, for a more CoC like typer.