### PR TITLE
smol: unify arrow and forall in a single type

### DIFF
--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -41,14 +41,15 @@ let te_lambda ~var ~param ~return =
   let type_ =
     let (TT { type_ = param; desc = _ }) = param in
     let (TE { type_ = return; desc = _ }) = return in
-    t_arrow ~param ~return
+    t_arrow ~var ~param ~return
   in
   te type_ (TE_lambda { var; param; return })
 
 let te_forall ~var ~return =
   let type_ =
     let (TE { type_ = return; desc = _ }) = return in
-    t_forall ~var ~return
+    let param = t_type in
+    t_arrow ~var ~param ~return
   in
   te type_ (TE_forall { var; return })
 
@@ -104,16 +105,19 @@ let tt_var type_ ~var = tt type_ (TT_var { var })
 
 let tt_arrow ~param ~return =
   let type_ =
+    (* TODO: this is weird *)
+    let var = Var.create (Name.make "_") in
     let (TT { type_ = param; desc = _ }) = param in
     let (TT { type_ = return; desc = _ }) = return in
-    t_arrow ~param ~return
+    t_arrow ~var ~param ~return
   in
   tt type_ (TT_arrow { param; return })
 
 let tt_forall ~var ~return =
   let type_ =
     let (TT { type_ = return; desc = _ }) = return in
-    t_forall ~var ~return
+    let param = t_type in
+    t_arrow ~var ~param ~return
   in
   tt type_ (TT_forall { var; return })
 

--- a/smol/type.ml
+++ b/smol/type.ml
@@ -1,8 +1,7 @@
 type type_ =
   | T_type
   | T_var of { var : Var.t }
-  | T_arrow of { param : type_; return : type_ }
-  | T_forall of { var : Var.t; return : type_ }
+  | T_arrow of { var : Var.t; param : type_; return : type_ }
   | T_pair of { left : type_; right : type_ }
   | T_exists of { var : Var.t; right : type_ }
   | T_alias of { type_ : type_ }
@@ -12,8 +11,7 @@ type t = type_ [@@deriving show]
 
 let t_type = T_type
 let t_var ~var = T_var { var }
-let t_arrow ~param ~return = T_arrow { param; return }
-let t_forall ~var ~return = T_forall { var; return }
+let t_arrow ~var ~param ~return = T_arrow { var; param; return }
 let t_pair ~left ~right = T_pair { left; right }
 let t_exists ~var ~right = T_exists { var; right }
 let t_alias ~type_ = T_alias { type_ }

--- a/smol/type.mli
+++ b/smol/type.mli
@@ -1,8 +1,7 @@
 type type_ = private
   | T_type
   | T_var of { var : Var.t }
-  | T_arrow of { param : type_; return : type_ }
-  | T_forall of { var : Var.t; return : type_ }
+  | T_arrow of { var : Var.t; param : type_; return : type_ }
   | T_pair of { left : type_; right : type_ }
   | T_exists of { var : Var.t; right : type_ }
   | T_alias of { type_ : type_ }
@@ -11,8 +10,7 @@ type t = type_ [@@deriving show]
 
 val t_type : type_
 val t_var : var:Var.t -> type_
-val t_arrow : param:type_ -> return:type_ -> type_
-val t_forall : var:Var.t -> return:type_ -> type_
+val t_arrow : var:Var.t -> param:type_ -> return:type_ -> type_
 val t_pair : left:type_ -> right:type_ -> type_
 val t_exists : var:Var.t -> right:type_ -> type_
 val t_alias : type_:type_ -> type_


### PR DESCRIPTION
## Goals

By having only one kind of arrow, this reduces the number of interactions that may happen, this also allows the typer to describe both higher kinded types and dependent types.