### PR TITLE
smol: unify pair and exists in a single type

### DIFF
--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -57,16 +57,17 @@ let te_apply type_ ~funct ~arg = te type_ (TE_apply { funct; arg })
 
 let te_pair ~left ~right =
   let type_ =
-    let (TB { type_ = left; var = _; value = _ }) = left in
+    let (TB { type_ = left; var; value = _ }) = left in
     let (TB { type_ = right; var = _; value = _ }) = right in
-    t_pair ~left ~right
+    t_pair ~var ~left ~right
   in
   te type_ (TE_pair { left; right })
 
 let te_exists ~var ~right =
   let type_ =
     let (TB { type_ = right; var = _; value = _ }) = right in
-    t_exists ~var ~right
+    let left = t_type in
+    t_pair ~var ~left ~right
   in
   te type_ (TE_exits { var; right })
 
@@ -123,15 +124,18 @@ let tt_forall ~var ~return =
 
 let tt_pair ~left ~right =
   let type_ =
+    (* TODO: this is weird *)
+    let var = Var.create (Name.make "_") in
     let (TT { type_ = left; desc = _ }) = left in
     let (TT { type_ = right; desc = _ }) = right in
-    t_pair ~left ~right
+    t_pair ~var ~left ~right
   in
   tt type_ (TT_pair { left; right })
 
 let tt_exists ~var ~right =
   let type_ =
     let (TT { type_ = right; desc = _ }) = right in
-    t_exists ~var ~right
+    let left = t_type in
+    t_pair ~var ~left ~right
   in
   tt type_ (TT_exists { var; right })

--- a/smol/type.ml
+++ b/smol/type.ml
@@ -2,8 +2,7 @@ type type_ =
   | T_type
   | T_var of { var : Var.t }
   | T_arrow of { var : Var.t; param : type_; return : type_ }
-  | T_pair of { left : type_; right : type_ }
-  | T_exists of { var : Var.t; right : type_ }
+  | T_pair of { var : Var.t; left : type_; right : type_ }
   | T_alias of { type_ : type_ }
 [@@deriving show]
 
@@ -12,6 +11,5 @@ type t = type_ [@@deriving show]
 let t_type = T_type
 let t_var ~var = T_var { var }
 let t_arrow ~var ~param ~return = T_arrow { var; param; return }
-let t_pair ~left ~right = T_pair { left; right }
-let t_exists ~var ~right = T_exists { var; right }
+let t_pair ~var ~left ~right = T_pair { var; left; right }
 let t_alias ~type_ = T_alias { type_ }

--- a/smol/type.mli
+++ b/smol/type.mli
@@ -2,8 +2,7 @@ type type_ = private
   | T_type
   | T_var of { var : Var.t }
   | T_arrow of { var : Var.t; param : type_; return : type_ }
-  | T_pair of { left : type_; right : type_ }
-  | T_exists of { var : Var.t; right : type_ }
+  | T_pair of { var : Var.t; left : type_; right : type_ }
   | T_alias of { type_ : type_ }
 
 type t = type_ [@@deriving show]
@@ -11,6 +10,5 @@ type t = type_ [@@deriving show]
 val t_type : type_
 val t_var : var:Var.t -> type_
 val t_arrow : var:Var.t -> param:type_ -> return:type_ -> type_
-val t_pair : left:type_ -> right:type_ -> type_
-val t_exists : var:Var.t -> right:type_ -> type_
+val t_pair : var:Var.t -> left:type_ -> right:type_ -> type_
 val t_alias : type_:type_ -> type_


### PR DESCRIPTION
## Goals

Same movement as #35 this makes so that we have only one type of pair, it makes the behavior of the system more uniform.