### PR TITLE
smol: add alias support to type syntax

### DIFF
--- a/smol/ltree.ml
+++ b/smol/ltree.ml
@@ -24,6 +24,7 @@ and type_desc =
   | LT_forall of { var : Name.t; return : type_ }
   | LT_pair of { left : type_; right : type_ }
   | LT_exists of { var : Name.t; right : type_ }
+  | LT_alias of { type_ : type_ }
 
 (* and kind = LK_type | LK_arrow of { param : kind; return : kind } *)
 
@@ -56,3 +57,4 @@ let lt_arrow loc ~param ~return = lt loc (LT_arrow { param; return })
 let lt_forall loc ~var ~return = lt loc (LT_forall { var; return })
 let lt_pair loc ~left ~right = lt loc (LT_pair { left; right })
 let lt_exists loc ~var ~right = lt loc (LT_exists { var; right })
+let lt_alias loc ~type_ = lt loc (LT_alias { type_ })

--- a/smol/ltree.mli
+++ b/smol/ltree.mli
@@ -42,6 +42,8 @@ and type_desc =
   | LT_pair of { left : type_; right : type_ }
   (* (x: k, y: t) *)
   | LT_exists of { var : Name.t; right : type_ }
+  (* =t *)
+  | LT_alias of { type_ : type_ }
 
 (* expr *)
 val le_var : Location.t -> var:Name.t -> expr
@@ -67,3 +69,4 @@ val lt_arrow : Location.t -> param:type_ -> return:type_ -> type_
 val lt_forall : Location.t -> var:Name.t -> return:type_ -> type_
 val lt_pair : Location.t -> left:type_ -> right:type_ -> type_
 val lt_exists : Location.t -> var:Name.t -> right:type_ -> type_
+val lt_alias : Location.t -> type_:type_ -> type_

--- a/smol/parser.mly
+++ b/smol/parser.mly
@@ -124,6 +124,7 @@ let type_funct :=
 
 let type_atom :=
   | type_var
+  | type_alias(type_atom)
   | type_parens
 
 let type_parens :=
@@ -152,3 +153,7 @@ let type_pair ==
 let type_exists ==
   | var = var; COLON; ASTERISK; COMMA; var; COLON; right = type_;
     { lt_exists (mk $loc) ~var ~right }
+let type_alias(self) ==
+  | EQUAL; type_ = self;
+    { lt_alias (mk $loc) ~type_ }
+

--- a/smol/test.ml
+++ b/smol/test.ml
@@ -81,7 +81,11 @@ let annot_pack =
   type_expr "annot_pack" ~type_:"(A: *, x: A)"
     ~expr:"((A = Int, x = one): (A: *, x: A))"
 
-let utils = [ id; sequence; choose; pair (* ;pack *) ]
+let alias_apply =
+  type_expr "alias_function" ~type_:"Int -> Int"
+    ~expr:"((A := Int) => (x: A) => incr x) Int"
+
+let utils = [ id; sequence; choose; pair (* ;pack *); incr ]
 
 let tests =
   [
@@ -105,6 +109,8 @@ let tests =
     right_unpair;
     (* exists_a_a; *)
     annot_pack;
+    (* alias *)
+    alias_apply;
   ]
 
 open Smol

--- a/smol/transl_type.ml
+++ b/smol/transl_type.ml
@@ -42,3 +42,6 @@ let rec transl_type env type_ =
       in
       let right = transl_type env right in
       tt_exists ~var ~right
+  | LT_alias { type_ } ->
+      let type_ = transl_type env type_ in
+      tt_alias ~type_

--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -25,6 +25,7 @@ and type_desc =
   | TT_forall of { var : Var.t; return : type_ }
   | TT_pair of { left : type_; right : type_ }
   | TT_exists of { var : Var.t; right : type_ }
+  | TT_alias of { type_ : type_ }
 
 (* helpers *)
 open Type
@@ -139,3 +140,10 @@ let tt_exists ~var ~right =
     t_pair ~var ~left ~right
   in
   tt type_ (TT_exists { var; right })
+
+let tt_alias ~type_ =
+  let type_alias =
+    let (TT { type_; desc = _ }) = type_ in
+    t_alias ~type_
+  in
+  tt type_alias (TT_alias { type_ })

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -25,6 +25,7 @@ and type_desc = private
   | TT_forall of { var : Var.t; return : type_ }
   | TT_pair of { left : type_; right : type_ }
   | TT_exists of { var : Var.t; right : type_ }
+  | TT_alias of { type_ : type_ }
 
 (* expr *)
 val te_var : Type.t -> var:Var.t -> expr
@@ -50,3 +51,4 @@ val tt_arrow : param:type_ -> return:type_ -> type_
 val tt_forall : var:Var.t -> return:type_ -> type_
 val tt_pair : left:type_ -> right:type_ -> type_
 val tt_exists : var:Var.t -> right:type_ -> type_
+val tt_alias : type_:type_ -> type_


### PR DESCRIPTION
## Goals

Support alias on the type syntax.

## Context

Aliases on Smol are used to describe types of literals, such as lets or pairs `(T = Int, x = (1: T))`, but currently there is no syntax for aliases, which means the previous expression doesn't have a syntax type that can describe it.

The chosen notation here was `=t` so that code such as `(A := Int) => e` can be written, meaning that the parameter is literally the Int type. Same for pairs, `(T := Int, x: t)` which means a pair where T is literally Int the int type.