### PR TITLE
smol: define a syntax tree

### DIFF
--- a/smol/stree.ml
+++ b/smol/stree.ml
@@ -1,0 +1,24 @@
+type term = ST of { loc : Location.t; [@opaque] desc : term_desc }
+
+and term_desc =
+  | ST_type
+  | ST_var of { var : Name.t }
+  | ST_arrow of { param : term; return : term }
+  | ST_lambda of { param : term; return : term }
+  | ST_apply of { lambda : term; arg : term }
+  | ST_pair of { left : term; right : term }
+  | ST_bind of { bound : term; value : term }
+  | ST_semi of { left : term; right : term }
+  | ST_annot of { value : term; type_ : term }
+[@@deriving show { with_path = false }]
+
+let st loc desc = ST { loc; desc }
+let st_type loc = st loc ST_type
+let st_var loc ~var = st loc (ST_var { var })
+let st_arrow loc ~param ~return = st loc (ST_arrow { param; return })
+let st_lambda loc ~param ~return = st loc (ST_lambda { param; return })
+let st_apply loc ~lambda ~arg = st loc (ST_apply { lambda; arg })
+let st_pair loc ~left ~right = st loc (ST_pair { left; right })
+let st_bind loc ~bound ~value = st loc (ST_bind { bound; value })
+let st_semi loc ~left ~right = st loc (ST_semi { left; right })
+let st_annot loc ~value ~type_ = st loc (ST_annot { value; type_ })

--- a/smol/stree.mli
+++ b/smol/stree.mli
@@ -1,0 +1,23 @@
+type term = private ST of { loc : Location.t; desc : term_desc }
+
+and term_desc = private
+  | ST_type
+  | ST_var of { var : Name.t }
+  | ST_arrow of { param : term; return : term }
+  | ST_lambda of { param : term; return : term }
+  | ST_apply of { lambda : term; arg : term }
+  | ST_pair of { left : term; right : term }
+  | ST_bind of { bound : term; value : term }
+  | ST_semi of { left : term; right : term }
+  | ST_annot of { value : term; type_ : term }
+[@@deriving show]
+
+val st_type : Location.t -> term
+val st_var : Location.t -> var:Name.t -> term
+val st_arrow : Location.t -> param:term -> return:term -> term
+val st_lambda : Location.t -> param:term -> return:term -> term
+val st_apply : Location.t -> lambda:term -> arg:term -> term
+val st_pair : Location.t -> left:term -> right:term -> term
+val st_bind : Location.t -> bound:term -> value:term -> term
+val st_semi : Location.t -> left:term -> right:term -> term
+val st_annot : Location.t -> value:term -> type_:term -> term


### PR DESCRIPTION
## Goals

I want to make parsing easier and more predictable.

## Context

I'm not good with parsers and precedence of a complex syntax is not straightforward to me.

To workaround that I define a syntax tree that is straightforward to be parsed and will be converted in the future to the language tree, this syntax tree should include all the "syntax primitives".

This lacks the alias notation because I'm removing it.