### PR TITLE
smol: refactor ltree to be CoC-like

### DIFF
--- a/smol/ltree.ml
+++ b/smol/ltree.ml
@@ -1,60 +1,34 @@
-type expr = LE of { loc : Location.t; desc : expr_desc }
+type term = LT of { loc : Location.t; [@opaque] desc : term_desc }
 
-and expr_desc =
-  | LE_var of { var : Name.t }
-  | LE_lambda of { var : Name.t; param : type_; return : expr }
-  | LE_forall of { var : Name.t; return : expr }
-  | LE_apply of { funct : expr; arg : expr }
-  | LE_pair of { left : bind; right : bind }
-  | LE_exists of { var : Name.t; right : bind }
-  | LE_unpair of { unpair : unpair; return : expr }
-  | LE_type of { type_ : type_ }
-  | LE_let of { bind : bind; return : expr }
-  | LE_annot of { expr : expr; type_ : type_ }
-
-and unpair =
-  | LU of { loc : Location.t; left : Name.t; right : Name.t; value : expr }
-
-and bind = LB of { loc : Location.t; var : Name.t; value : expr }
-and type_ = LT of { loc : Location.t; desc : type_desc }
-
-and type_desc =
+and term_desc =
+  | LT_type
   | LT_var of { var : Name.t }
-  | LT_arrow of { param : type_; return : type_ }
-  | LT_forall of { var : Name.t; return : type_ }
-  | LT_pair of { left : type_; right : type_ }
-  | LT_exists of { var : Name.t; right : type_ }
-  | LT_alias of { type_ : type_ }
+  | LT_arrow of { var : Name.t; param : term; return : term }
+  | LT_lambda of { var : Name.t; param : term; return : term }
+  | LT_apply of { lambda : term; arg : term }
+  | LT_sigma of { var : Name.t; left : term; right : term }
+  | LT_pair of { var : Name.t; left : term; right : term; annot : term }
+  | LT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
+  | LT_let of { var : Name.t; value : term; return : term }
+  | LT_annot of { value : term; type_ : term }
+[@@deriving show { with_path = false }]
 
-(* and kind = LK_type | LK_arrow of { param : kind; return : kind } *)
-
-(* expr *)
-let le loc desc = LE { loc; desc }
-let le_var loc ~var = le loc (LE_var { var })
-
-let le_lambda loc ~var ~param ~return =
-  le loc (LE_lambda { var; param; return })
-
-let le_forall loc ~var ~return = le loc (LE_forall { var; return })
-let le_apply loc ~funct ~arg = le loc (LE_apply { funct; arg })
-let le_pair loc ~left ~right = le loc (LE_pair { left; right })
-let le_exists loc ~var ~right = le loc (LE_exists { var; right })
-let le_unpair loc ~unpair ~return = le loc (LE_unpair { unpair; return })
-let le_type loc ~type_ = le loc (LE_type { type_ })
-let le_let loc ~bind ~return = le loc (LE_let { bind; return })
-let le_annot loc ~expr ~type_ = le loc (LE_annot { expr; type_ })
-
-(* unpair *)
-let lu loc ~left ~right ~value = LU { loc; left; right; value }
-
-(* bind *)
-let lb loc ~var ~value = LB { loc; var; value }
-
-(* type *)
 let lt loc desc = LT { loc; desc }
+let lt_type loc = lt loc LT_type
 let lt_var loc ~var = lt loc (LT_var { var })
-let lt_arrow loc ~param ~return = lt loc (LT_arrow { param; return })
-let lt_forall loc ~var ~return = lt loc (LT_forall { var; return })
-let lt_pair loc ~left ~right = lt loc (LT_pair { left; right })
-let lt_exists loc ~var ~right = lt loc (LT_exists { var; right })
-let lt_alias loc ~type_ = lt loc (LT_alias { type_ })
+let lt_arrow loc ~var ~param ~return = lt loc (LT_arrow { var; param; return })
+
+let lt_lambda loc ~var ~param ~return =
+  lt loc (LT_lambda { var; param; return })
+
+let lt_apply loc ~lambda ~arg = lt loc (LT_apply { lambda; arg })
+let lt_sigma loc ~var ~left ~right = lt loc (LT_sigma { var; left; right })
+
+let lt_pair loc ~var ~left ~right ~annot =
+  lt loc (LT_pair { var; left; right; annot })
+
+let lt_unpair loc ~left ~right ~pair ~return =
+  lt loc (LT_unpair { left; right; pair; return })
+
+let lt_let loc ~var ~value ~return = lt loc (LT_let { var; value; return })
+let lt_annot loc ~value ~type_ = lt loc (LT_annot { value; type_ })


### PR DESCRIPTION
## Goals

To proper support modules, functors and uniformity between types and values, sadly Teika will have dependent types since day one.

## Context

CoC unifies types and values under a single notion of "terms", this drastically simplifies things as we don't need two typers, one for types and one for expressions.

It also keep implicitly keep track of equalities needed for modules, by just computing them on the type level.