### PR TITLE
smol: new typer machinery

### DIFF
--- a/smol/machinery.ml
+++ b/smol/machinery.ml
@@ -1,100 +1,236 @@
-open Type
+open Term
 
 exception Var_clash of { expected : Var.t; received : Var.t }
-exception Type_clash of { expected : type_; received : type_ }
-exception Not_a_function of { funct : type_ }
-exception Not_an_extractable_pair of { pair : type_ }
-exception Not_a_wrapped_type of { type_ : type_ }
+exception Type_clash of { expected : term; received : term }
+exception Not_a_function of { lambda : term }
+exception Not_a_pair of { pair : term }
 
-let rec subst ~from ~to_ type_ =
-  let subst type_ = subst ~from ~to_ type_ in
-  match type_ with
+let rec subst ~from ~to_ term =
+  let subst term = subst ~from ~to_ term in
+  match term with
   | T_type -> t_type
-  | T_var { var } -> if Var.equal var from then to_ else type_
+  | T_var { var; type_ } -> (
+      let type_ = subst type_ in
+      match Var.equal var from with
+      | true -> to_ ~type_
+      | false -> t_var ~var ~type_)
   | T_arrow { var; param; return } ->
       let param = subst param in
-      let return = if Var.equal var from then return else subst return in
+      let return =
+        match Var.equal var from with true -> return | false -> subst return
+      in
       t_arrow ~var ~param ~return
-  | T_pair { var; left; right } ->
+  | T_lambda { var; param; return } ->
+      let param = subst param in
+      let return =
+        match Var.equal var from with true -> return | false -> subst return
+      in
+      t_lambda ~var ~param ~return
+  | T_apply { lambda; arg } ->
+      let lambda = subst lambda in
+      let arg = subst arg in
+      t_apply ~lambda ~arg
+  | T_sigma { var; left; right } ->
       let left = subst left in
-      let right = if Var.equal var from then right else subst right in
-      t_pair ~var ~left ~right
-  | T_alias { type_ } ->
-      let type_ = subst type_ in
-      t_alias ~type_
+      let right =
+        match Var.equal var from with true -> right | false -> subst right
+      in
+      t_sigma ~var ~left ~right
+  | T_pair { var; left; right; annot } ->
+      let left = subst left in
+      let right = subst right in
+      let annot = if Var.equal var from then annot else subst annot in
+      t_pair ~var ~left ~right ~annot
+  | T_unpair { left; right; pair; return } ->
+      let pair = subst pair in
+      let return =
+        match Var.equal left from || Var.equal right from with
+        | true -> return
+        | false -> subst return
+      in
+      t_unpair ~left ~right ~pair ~return
 
-(* TODO: this is undecidable on forget *)
-let rec subtype ~expected ~received =
+let rename ~from ~to_ term =
+  subst ~from ~to_:(fun ~type_ -> t_var ~var:to_ ~type_) term
+
+let expand ~from ~to_ term =
+  subst ~from
+    ~to_:(fun ~type_:_ ->
+      (* TODO: check type? *)
+      to_)
+    term
+
+let rec normalize term =
+  match term with
+  | T_type -> t_type
+  | T_var { var; type_ } ->
+      let type_ = normalize type_ in
+      t_var ~var ~type_
+  | T_arrow { var; param; return } ->
+      let param = normalize param in
+      let return = normalize return in
+      t_arrow ~var ~param ~return
+  | T_lambda { var; param; return } ->
+      let param = normalize param in
+      let return = normalize return in
+      t_lambda ~var ~param ~return
+  | T_apply { lambda; arg } -> (
+      let lambda = normalize lambda in
+      let arg = normalize arg in
+      match lambda with
+      | T_lambda { var; param = _; return } ->
+          let return = expand ~from:var ~to_:arg return in
+          normalize return
+      | lambda -> t_apply ~lambda ~arg)
+  | T_sigma { var; left; right } ->
+      let left = normalize left in
+      let right = normalize right in
+      t_sigma ~var ~left ~right
+  | T_pair { var; left; right; annot } ->
+      let left = normalize left in
+      let right = normalize right in
+      let annot = normalize annot in
+      t_pair ~var ~left ~right ~annot
+  | T_unpair { left; right; pair; return } -> (
+      let return = normalize return in
+      match normalize pair with
+      | T_pair { var = _; left = left_value; right = right_value; annot = _ } ->
+          let return = expand ~from:left ~to_:left_value return in
+          let return = expand ~from:right ~to_:right_value return in
+          normalize return
+      | pair -> t_unpair ~left ~right ~pair ~return)
+
+let rec equal ~expected ~received =
   match (expected, received) with
   | T_type, T_type -> ()
-  (* TODO: this is very weird *)
-  | T_type, T_alias _ -> ()
-  | T_var { var = expected }, T_var { var = received } ->
+  | T_var { var = expected; type_ = _ }, T_var { var = received; type_ = _ } ->
       if Var.equal expected received then ()
       else raise (Var_clash { expected; received })
   | ( T_arrow
         { var = expected_var; param = expected_param; return = expected_return },
       T_arrow
         { var = received_var; param = received_param; return = received_return }
+    )
+  | ( T_lambda
+        { var = expected_var; param = expected_param; return = expected_return },
+      T_lambda
+        { var = received_var; param = received_param; return = received_return }
     ) ->
-      subtype ~expected:received_param ~received:expected_param;
+      equal ~expected:received_param ~received:expected_param;
 
-      let internal =
-        match received_param with
-        | T_alias { type_ } -> type_
-        | _param -> t_var ~var:expected_var
+      let received_return =
+        rename ~from:received_var ~to_:expected_var received_return
       in
-      let expected_return =
-        subst ~from:expected_var ~to_:internal expected_return
+      equal ~expected:expected_return ~received:received_return
+  | ( T_apply { lambda = expected_lambda; arg = expected_arg },
+      T_apply { lambda = received_lambda; arg = received_arg } ) ->
+      equal ~expected:expected_lambda ~received:received_lambda;
+      equal ~expected:expected_arg ~received:received_arg
+  | ( T_sigma
+        { var = expected_var; left = expected_left; right = expected_right },
+      T_sigma
+        { var = received_var; left = received_left; right = received_right } )
+  | ( T_pair
+        {
+          var = expected_var;
+          left = expected_left;
+          right = _;
+          annot = expected_right;
+        },
+      T_pair
+        {
+          var = received_var;
+          left = received_left;
+          right = _;
+          annot = received_right;
+        } ) ->
+      equal ~expected:expected_left ~received:received_left;
+
+      let received_right =
+        rename ~from:received_var ~to_:expected_var received_right
+      in
+      equal ~expected:expected_right ~received:received_right
+  | ( T_unpair
+        {
+          left = expected_left;
+          right = expected_right;
+          pair = expected_pair;
+          return = expected_return;
+        },
+      T_unpair
+        {
+          left = received_left;
+          right = received_right;
+          pair = received_pair;
+          return = received_return;
+        } ) ->
+      equal ~expected:expected_pair ~received:received_pair;
+
+      let received_return =
+        rename ~from:received_left ~to_:expected_left received_return
       in
       let received_return =
-        subst ~from:received_var ~to_:internal received_return
+        rename ~from:received_right ~to_:expected_right received_return
       in
-      subtype ~expected:expected_return ~received:received_return
-  | ( T_pair { var = expected_var; left = expected_left; right = expected_right },
-      T_pair
-        { var = received_var; left = received_left; right = received_right } )
-    ->
-      subtype ~expected:expected_left ~received:received_left;
-
-      let internal =
-        match received_left with
-        | T_alias { type_ } -> type_
-        | _param -> t_var ~var:expected_var
-      in
-      let expected_right =
-        subst ~from:expected_var ~to_:internal expected_right
-      in
-      let received_right =
-        subst ~from:received_var ~to_:internal received_right
-      in
-      subtype ~expected:expected_right ~received:received_right
-  | T_alias { type_ = expected }, T_alias { type_ = received } ->
-      subtype ~expected ~received
-  | ( (T_type | T_var _ | T_arrow _ | T_pair _ | T_alias _),
-      (T_type | T_var _ | T_arrow _ | T_pair _ | T_alias _) ) ->
+      equal ~expected:expected_return ~received:received_return
+  | ( ( T_type | T_var _ | T_arrow _ | T_lambda _ | T_apply _ | T_sigma _
+      | T_pair _ | T_unpair _ ),
+      ( T_type | T_var _ | T_arrow _ | T_lambda _ | T_apply _ | T_sigma _
+      | T_pair _ | T_unpair _ ) ) ->
       raise (Type_clash { expected; received })
 
-let extract ~wrapped:type_ =
-  match type_ with
-  | T_alias { type_ } -> type_
-  | T_type | T_var _ | T_arrow _ | T_pair _ ->
-      raise (Not_a_wrapped_type { type_ })
+let equal ~expected ~received =
+  let expected = normalize expected in
+  let received = normalize received in
+  equal ~expected ~received
 
-let apply ~funct ~arg =
-  match funct with
-  | T_arrow { var; param; return } ->
-      subtype ~expected:param ~received:arg;
-      let arg =
-        (* TODO: super hacky *)
-        match param with
-        | T_type | T_alias _ -> extract ~wrapped:arg
-        | T_var _ | T_arrow _ | T_pair _ -> arg
-      in
-      subst ~from:var ~to_:arg return
-  | T_type | T_var _ | T_pair _ | T_alias _ -> raise (Not_a_function { funct })
+let rec typeof term =
+  match term with
+  | T_type -> t_type
+  | T_var { var = _; type_ } -> type_
+  | T_arrow { var = _; param = _; return = _ } -> t_type
+  | T_lambda { var; param; return } ->
+      let return = typeof return in
+      t_arrow ~var ~param ~return
+  | T_apply { lambda; arg } -> (
+      match typeof lambda with
+      | T_arrow { var; param = _; return } -> expand ~from:var ~to_:arg return
+      | _ -> failwith "bug")
+  | T_sigma { var = _; left = _; right = _ } -> t_type
+  | T_pair { var; left; right = _; annot } ->
+      (* TODO: is this right? *)
+      let left = typeof left in
+      t_sigma ~var ~left ~right:annot
+  | T_unpair { left = _; right = _; pair = _; return } -> typeof return
 
-let unpair ~pair =
-  match pair with
-  | T_pair { var = _; left; right } -> (left, right)
-  | _ -> raise (Not_an_extractable_pair { pair })
+let typeof term =
+  let term = normalize term in
+  typeof term
+
+let apply ~lambda ~arg =
+  match typeof lambda with
+  | T_arrow { var = _; param; return = _ } ->
+      let arg = typeof arg in
+      equal ~expected:param ~received:arg
+  | _ -> raise (Not_a_function { lambda })
+
+let pair ~var ~left ~right ~annot =
+  let right = typeof right in
+  let annot = expand ~from:var ~to_:left annot in
+  equal ~expected:annot ~received:right
+
+let unpair ~left ~pair =
+  let var, left_type, right_type =
+    match
+      let pair = typeof pair in
+      normalize pair
+    with
+    | T_sigma { var; left; right } -> (var, left, right)
+    | _ -> raise (Not_a_pair { pair })
+  in
+  let right_type = rename ~from:var ~to_:left right_type in
+  (left_type, right_type)
+
+let annot ~value ~type_ =
+  let value = typeof value in
+  equal ~expected:type_ ~received:value

--- a/smol/machinery.mli
+++ b/smol/machinery.mli
@@ -1,11 +1,14 @@
-open Type
+open Term
 
 exception Var_clash of { expected : Var.t; received : Var.t }
-exception Type_clash of { expected : type_; received : type_ }
-exception Not_a_function of { funct : type_ }
-exception Not_a_wrapped_type of { type_ : type_ }
+exception Type_clash of { expected : term; received : term }
+exception Not_a_function of { lambda : term }
+exception Not_a_pair of { pair : term }
 
-val subtype : expected:type_ -> received:type_ -> unit
-val extract : wrapped:type_ -> type_
-val apply : funct:type_ -> arg:type_ -> type_
-val unpair : pair:type_ -> type_ * type_
+val normalize : term -> term
+val equal : expected:term -> received:term -> unit
+val typeof : term -> term
+val apply : lambda:term -> arg:term -> unit
+val pair : var:Var.t -> left:term -> right:term -> annot:term -> unit
+val unpair : left:Var.t -> pair:term -> term * term
+val annot : value:term -> type_:term -> unit


### PR DESCRIPTION
## Goals

Implement the needed machinery for a typer that supports {higher-kinded,dependent} types.

## Context

Checking equality of dependent types can be tricky, the most common way to do so is by fully normalizing the terms through beta reduction and then checking for simple equality. This implements equality by normalization and also alpha renaming.

Additionally, some operations may require internal tooling, such as applying, pairing and unpairing.