### PR TITLE
nix: move to OCaml 5 and add eio

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.22.2
+version = 0.24.1

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1653714994,
-        "narHash": "sha256-TCNzPQw7mhunWF8dhSRfuvsRWl9lT3l/oWXmof0nhJs=",
+        "lastModified": 1666025805,
+        "narHash": "sha256-rnikBwo7tUtvXsFHtXAD7XOzVkdyKUjuwg4xrsGjBYA=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "cd6f4b7b2d9a3269d547698e31933b30ff97057a",
+        "rev": "8a850936e8134b977bd08938d2815583f6e66697",
         "type": "github"
       },
       "original": {
@@ -51,17 +51,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1653663379,
-        "narHash": "sha256-xzE3+LY0NHk1G7jvJvR6gDu4iNtwpRmHLCiJVVyXUHg=",
+        "lastModified": 1665964938,
+        "narHash": "sha256-hK/2bYlQHu8tdPodZlsqb6wUuy0toSLfHLQ/bcC8ufE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
+        "rev": "946774a4d14af09fa8a5358dcb5f033cc311064b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
+        "rev": "946774a4d14af09fa8a5358dcb5f033cc311064b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
           (import ./nix/overlay.nix)
         ];
       }).extend (self: super: {
-        ocamlPackages = super.ocaml-ng.ocamlPackages_4_14;
+        ocamlPackages = super.ocaml-ng.ocamlPackages_5_00;
       }); in
       let teika = pkgs.callPackage ./nix { doCheck = true; }; in
       rec {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,7 +12,7 @@ with ocamlPackages; buildDunePackage rec {
     files = [ "dune-project" ];
   };
 
-  propagatedBuildInputs = [ menhir menhirLib sedlex ppx_deriving ]
+  propagatedBuildInputs = [ menhir menhirLib sedlex ppx_deriving eio eio_main ]
     # checkInputs are here because when cross compiling dune needs test dependencies
     # but they are not available for the build phase. The issue can be seen by adding strictDeps = true;.
     ++ checkInputs;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,14 +3,41 @@ with super; {
   # ocaml-ng = builtins.mapAttrs (_: ocamlVersion: ocamlVersion) super.ocaml-ng;
   # TODO: this is clearly not right, I should be overriding only 4_14
   ocaml-ng = ocaml-ng // (with ocaml-ng; {
-    ocamlPackages_4_14 = ocamlPackages_4_14.overrideScope'
+    ocamlPackages_5_00 = ocamlPackages_5_00.overrideScope'
       (_: super: {
+        dune-rpc = super.dune-rpc.overrideAttrs (_: {
+          src = fetchFromGitHub {
+            owner = "ocaml";
+            repo = "dune";
+            rev = "3df932f7f91ea68c3fee789f133b4aa8f9bea807";
+            sha256 = "m0HDamHAyOFQlh6P4vbbe8UhARZ4NjwbANInnJ4OZ6U=";
+            fetchSubmodules = true;
+          };
+        });
+        dune = super.dune.overrideAttrs (_: {
+          src = fetchFromGitHub {
+            owner = "ocaml";
+            repo = "dune";
+            rev = "3df932f7f91ea68c3fee789f133b4aa8f9bea807";
+            sha256 = "m0HDamHAyOFQlh6P4vbbe8UhARZ4NjwbANInnJ4OZ6U=";
+            fetchSubmodules = true;
+          };
+        });
         ocaml-lsp = super.ocaml-lsp.overrideAttrs (_: {
           src = fetchFromGitHub {
             owner = "EduardoRFS";
             repo = "ocaml-lsp";
-            rev = "eeb5ff15c6a3e78c897c6f787ce8ebb4ffe10934";
-            sha256 = "+Ax6/fh0Kdlku1XWU2dukerGvvzznR4qjDsm9zG5cLg=";
+            rev = "72202cd2bb9ff65845b623d20f513f6ed5b82ab8";
+            sha256 = "49E7L50i9RZTrQDPmdqyeOaBSXjRo/ijjrsj9oztduM=";
+            fetchSubmodules = true;
+          };
+        });
+        jsonrpc = super.jsonrpc.overrideAttrs (_: {
+          src = fetchFromGitHub {
+            owner = "EduardoRFS";
+            repo = "ocaml-lsp";
+            rev = "72202cd2bb9ff65845b623d20f513f6ed5b82ab8";
+            sha256 = "49E7L50i9RZTrQDPmdqyeOaBSXjRo/ijjrsj9oztduM=";
             fetchSubmodules = true;
           };
         });


### PR DESCRIPTION
## Goals

Enhance the developer experience for IO development.

## Context

OCaml 5 offers untyped algebraic effects, which when combined with a concurrency library such as eio offers a better experience for effectful code.