### PR TITLE
smol: make Type a predefined Type

### DIFF
--- a/smol/env.ml
+++ b/smol/env.ml
@@ -5,8 +5,6 @@ exception Unbound_variable of { var : Name.t }
 type env = Term.t Name_map.t
 type t = env
 
-let empty = Name_map.empty
-
 let enter var type_ env =
   let name = Var.name var in
   let env = Name_map.add name type_ env in
@@ -16,3 +14,7 @@ let lookup name env =
   match Name_map.find_opt name env with
   | Some type_ -> type_
   | None -> raise (Unbound_variable { var = name })
+
+let initial =
+  let env = Name_map.empty in
+  enter Var.type_ Term.t_type env

--- a/smol/env.mli
+++ b/smol/env.mli
@@ -3,6 +3,6 @@ exception Unbound_variable of { var : Name.t }
 type env
 type t = env
 
-val empty : env
+val initial : env
 val enter : Var.t -> Term.t -> env -> env
 val lookup : Name.t -> env -> Term.t

--- a/smol/lparser.ml
+++ b/smol/lparser.ml
@@ -10,22 +10,21 @@ let extract_var term =
   let (ST { loc; desc }) = term in
   match desc with
   | ST_var { var } -> var
-  | ST_type | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _ | ST_bind _
-  | ST_semi _ | ST_annot _ ->
+  | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _ | ST_bind _ | ST_semi _
+  | ST_annot _ ->
       invalid_notation loc
 
 let extract_annot param =
   let (ST { loc; desc }) = param in
   match desc with
   | ST_annot { value; type_ = param } -> (value, param)
-  | ST_type | ST_var _ | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _
-  | ST_bind _ | ST_semi _ ->
+  | ST_var _ | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _ | ST_bind _
+  | ST_semi _ ->
       invalid_notation loc
 
 let rec from_stree term =
   let (ST { loc; desc }) = term in
   match desc with
-  | ST_type -> lt_type loc
   | ST_var { var } -> lt_var loc ~var
   | ST_arrow { param; return } ->
       let var, param = extract_annot param in
@@ -58,8 +57,8 @@ let rec from_stree term =
           let left = from_stree left in
           let right = from_stree right in
           lt_sigma loc ~var ~left ~right
-      | ST_type | ST_var _ | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _
-      | ST_semi _ ->
+      | ST_var _ | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _ | ST_semi _
+        ->
           invalid_notation loc)
   | ST_bind _ ->
       Format.eprintf "%a" Stree.pp_term term;
@@ -69,7 +68,7 @@ let rec from_stree term =
         let (ST { loc; desc }) = left in
         match desc with
         | ST_bind { bound; value } -> (bound, value)
-        | ST_type | ST_var _ | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _
+        | ST_var _ | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_pair _
         | ST_semi _ | ST_annot _ ->
             invalid_notation loc
       in
@@ -84,7 +83,7 @@ let rec from_stree term =
           let right = extract_var right in
           let pair = from_stree value in
           lt_unpair loc ~left ~right ~pair ~return
-      | ST_type | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_semi _ | ST_bind _
+      | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_semi _ | ST_bind _
       | ST_annot _ ->
           invalid_notation loc)
   | ST_annot { value; type_ } ->

--- a/smol/ltree.ml
+++ b/smol/ltree.ml
@@ -1,7 +1,6 @@
 type term = LT of { loc : Location.t; [@opaque] desc : term_desc }
 
 and term_desc =
-  | LT_type
   | LT_var of { var : Name.t }
   | LT_arrow of { var : Name.t; param : term; return : term }
   | LT_lambda of { var : Name.t; param : term; return : term }
@@ -14,7 +13,6 @@ and term_desc =
 [@@deriving show { with_path = false }]
 
 let lt loc desc = LT { loc; desc }
-let lt_type loc = lt loc LT_type
 let lt_var loc ~var = lt loc (LT_var { var })
 let lt_arrow loc ~var ~param ~return = lt loc (LT_arrow { var; param; return })
 

--- a/smol/ltree.mli
+++ b/smol/ltree.mli
@@ -1,8 +1,6 @@
 type term = private LT of { loc : Location.t; desc : term_desc }
 
 and term_desc = private
-  (* * *)
-  | LT_type
   (* x *)
   | LT_var of { var : Name.t }
   (* (x: a) -> b *)
@@ -23,7 +21,6 @@ and term_desc = private
   | LT_annot of { value : term; type_ : term }
 [@@deriving show]
 
-val lt_type : Location.t -> term
 val lt_var : Location.t -> var:Name.t -> term
 val lt_arrow : Location.t -> var:Name.t -> param:term -> return:term -> term
 val lt_lambda : Location.t -> var:Name.t -> param:term -> return:term -> term

--- a/smol/machinery.ml
+++ b/smol/machinery.ml
@@ -8,7 +8,7 @@ exception Not_a_pair of { pair : term }
 let rec subst ~from ~to_ term =
   let subst term = subst ~from ~to_ term in
   match term with
-  | T_type -> t_type
+  | T_type { var = _ } -> t_type
   | T_var { var; type_ } -> (
       let type_ = subst type_ in
       match Var.equal var from with
@@ -62,7 +62,7 @@ let expand ~from ~to_ term =
 
 let rec normalize term =
   match term with
-  | T_type -> t_type
+  | T_type { var = _ } -> t_type
   | T_var { var; type_ } ->
       let type_ = normalize type_ in
       t_var ~var ~type_
@@ -102,7 +102,7 @@ let rec normalize term =
 
 let rec equal ~expected ~received =
   match (expected, received) with
-  | T_type, T_type -> ()
+  | T_type { var = expected }, T_type { var = received }
   | T_var { var = expected; type_ = _ }, T_var { var = received; type_ = _ } ->
       if Var.equal expected received then ()
       else raise (Var_clash { expected; received })
@@ -173,9 +173,9 @@ let rec equal ~expected ~received =
         rename ~from:received_right ~to_:expected_right received_return
       in
       equal ~expected:expected_return ~received:received_return
-  | ( ( T_type | T_var _ | T_arrow _ | T_lambda _ | T_apply _ | T_sigma _
+  | ( ( T_type _ | T_var _ | T_arrow _ | T_lambda _ | T_apply _ | T_sigma _
       | T_pair _ | T_unpair _ ),
-      ( T_type | T_var _ | T_arrow _ | T_lambda _ | T_apply _ | T_sigma _
+      ( T_type _ | T_var _ | T_arrow _ | T_lambda _ | T_apply _ | T_sigma _
       | T_pair _ | T_unpair _ ) ) ->
       raise (Type_clash { expected; received })
 
@@ -186,7 +186,7 @@ let equal ~expected ~received =
 
 let rec typeof term =
   match term with
-  | T_type -> t_type
+  | T_type { var = _ } -> t_type
   | T_var { var = _; type_ } -> type_
   | T_arrow { var = _; param = _; return = _ } -> t_type
   | T_lambda { var; param; return } ->

--- a/smol/repl.ml
+++ b/smol/repl.ml
@@ -18,7 +18,7 @@ let write_term buf term =
 let term_of_string string =
   match Slexer.from_string Sparser.term_opt string with
   | Some term ->
-      let env = Env.empty in
+      let env = Env.initial in
       let term = Lparser.from_stree term in
       Some (Typer.type_term env term)
   | None -> None

--- a/smol/slexer.ml
+++ b/smol/slexer.ml
@@ -16,7 +16,6 @@ let rec tokenizer buf =
   | "," -> COMMA
   | ":" -> COLON
   | ";" -> SEMICOLON
-  | "*" -> ASTERISK
   | "(" -> LEFT_PARENS
   | ")" -> RIGHT_PARENS
   | eof -> EOF

--- a/smol/sparser.mly
+++ b/smol/sparser.mly
@@ -12,7 +12,6 @@ let mk (loc_start, loc_end) =
 %token COMMA (* , *)
 %token COLON (* : *)
 %token SEMICOLON (* ; *)
-%token ASTERISK (* * *)
 %token LEFT_PARENS (* ( *)
 %token RIGHT_PARENS (* ) *)
 
@@ -50,7 +49,6 @@ let term_rec_apply :=
   | term_apply(term_rec_apply, term_atom)
 
 let term_atom :=
-  | term_type
   | term_var
   | term_parens(term_parens_maybe_pair)
 
@@ -62,9 +60,6 @@ let term_parens_maybe_annot :=
   | term
   | term_annot(term_parens_maybe_annot, term)
 
-let term_type ==
-  | ASTERISK;
-    { st_type (mk $loc) }
 let term_var ==
   | var = VAR;
     { st_var (mk $loc) ~var:(Name.make var) }

--- a/smol/stree.ml
+++ b/smol/stree.ml
@@ -1,7 +1,6 @@
 type term = ST of { loc : Location.t; [@opaque] desc : term_desc }
 
 and term_desc =
-  | ST_type
   | ST_var of { var : Name.t }
   | ST_arrow of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
@@ -13,7 +12,6 @@ and term_desc =
 [@@deriving show { with_path = false }]
 
 let st loc desc = ST { loc; desc }
-let st_type loc = st loc ST_type
 let st_var loc ~var = st loc (ST_var { var })
 let st_arrow loc ~param ~return = st loc (ST_arrow { param; return })
 let st_lambda loc ~param ~return = st loc (ST_lambda { param; return })

--- a/smol/stree.mli
+++ b/smol/stree.mli
@@ -1,7 +1,6 @@
 type term = private ST of { loc : Location.t; desc : term_desc }
 
 and term_desc = private
-  | ST_type
   | ST_var of { var : Name.t }
   | ST_arrow of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
@@ -12,7 +11,6 @@ and term_desc = private
   | ST_annot of { value : term; type_ : term }
 [@@deriving show]
 
-val st_type : Location.t -> term
 val st_var : Location.t -> var:Name.t -> term
 val st_arrow : Location.t -> param:term -> return:term -> term
 val st_lambda : Location.t -> param:term -> return:term -> term

--- a/smol/term.ml
+++ b/smol/term.ml
@@ -1,5 +1,5 @@
 type term =
-  | T_type
+  | T_type of { var : Var.t }
   | T_var of { var : Var.t; type_ : term }
   | T_arrow of { var : Var.t; param : term; return : term }
   | T_lambda of { var : Var.t; param : term; return : term }
@@ -11,7 +11,10 @@ type term =
 
 type t = term [@@deriving show]
 
-let t_type = T_type
+let t_type =
+  let var = Var.type_ in
+  T_type { var }
+
 let t_var ~var ~type_ = T_var { var; type_ }
 let t_arrow ~var ~param ~return = T_arrow { var; param; return }
 let t_lambda ~var ~param ~return = T_lambda { var; param; return }

--- a/smol/term.mli
+++ b/smol/term.mli
@@ -1,5 +1,5 @@
 type term = private
-  | T_type
+  | T_type of { var : Var.t }
   | T_var of { var : Var.t; type_ : term }
   | T_arrow of { var : Var.t; param : term; return : term }
   | T_lambda of { var : Var.t; param : term; return : term }

--- a/smol/test.ml
+++ b/smol/test.ml
@@ -4,25 +4,25 @@ let type_expr ?(wrapper = true) name ~type_ ~expr =
   { name; expr; type_; wrapper }
 
 let id =
-  type_expr "id" ~wrapper:false ~type_:"(A: *) -> (x: A) -> A"
-    ~expr:"(A: *) => (x: A) => x"
+  type_expr "id" ~wrapper:false ~type_:"(A: Type) -> (x: A) -> A"
+    ~expr:"(A: Type) => (x: A) => x"
 
 let sequence =
   type_expr "sequence" ~wrapper:false
-    ~type_:"(A: *) -> (x: A) -> (B: *) -> (y: B) -> B"
-    ~expr:"(A: *) => (x: A) => (B: *) => (y: B) => y"
+    ~type_:"(A: Type) -> (x: A) -> (B: Type) -> (y: B) -> B"
+    ~expr:"(A: Type) => (x: A) => (B: Type) => (y: B) => y"
 
 let bool =
-  type_expr "bool" ~wrapper:false ~type_:"(A: *) -> (x: A) -> (y: A) -> A"
-    ~expr:"(A: *) => (x: A) => (y: A) => x"
+  type_expr "bool" ~wrapper:false ~type_:"(A: Type) -> (x: A) -> (y: A) -> A"
+    ~expr:"(A: Type) => (x: A) => (y: A) => x"
 
 let true_ =
-  type_expr "true" ~wrapper:false ~type_:"(A: *) -> (x: A) -> (y: A) -> A"
-    ~expr:"(A: *) => (x: A) => (y: A) => x"
+  type_expr "true" ~wrapper:false ~type_:"(A: Type) -> (x: A) -> (y: A) -> A"
+    ~expr:"(A: Type) => (x: A) => (y: A) => x"
 
 let false_ =
-  type_expr "false" ~wrapper:false ~type_:"(A: *) -> (x: A) -> (y: A) -> A"
-    ~expr:"(A: *) => (x: A) => (y: A) => y"
+  type_expr "false" ~wrapper:false ~type_:"(A: Type) -> (x: A) -> (y: A) -> A"
+    ~expr:"(A: Type) => (x: A) => (y: A) => y"
 
 let incr = type_expr "incr" ~type_:"(x: Int) -> Int" ~expr:"(x: Int) => x"
 let id_int = type_expr "id_int" ~type_:"(x: Int) -> Int" ~expr:"id Int"
@@ -37,33 +37,34 @@ let bool_id_id =
 let bool_id_id_id = type_expr "bool_id_id_id" ~type_:"Id" ~expr:"bool Id id id"
 
 let true_type =
-  type_expr "true_type" ~type_:"(x: *) -> (y: *) -> *" ~expr:"true *"
+  type_expr "true_type" ~type_:"(x: Type) -> (y: Type) -> Type"
+    ~expr:"true Type"
 
 let true_type_int =
-  type_expr "true_type_int" ~type_:"(y: *) -> *" ~expr:"true * Int"
+  type_expr "true_type_int" ~type_:"(y: Type) -> Type" ~expr:"true Type Int"
 
 let true_type_int_id =
-  type_expr "true_type_int_id" ~type_:"*" ~expr:"true * Int Id"
+  type_expr "true_type_int_id" ~type_:"Type" ~expr:"true Type Int Id"
 
 let pred_dependent_type =
   type_expr "pred_dependent_type"
-    ~type_:"(pred: Bool) -> (x: pred * Int Id) -> pred * Int Id"
-    ~expr:"(pred: Bool) => (x: pred * Int Id) => x"
+    ~type_:"(pred: Bool) -> (x: pred Type Int Id) -> pred Type Int Id"
+    ~expr:"(pred: Bool) => (x: pred Type Int Id) => x"
 
 let true_dependent_type =
   type_expr "true_dependent_type" ~type_:"(x: Int) -> Int"
-    ~expr:"((pred: Bool) => (x: pred * Int Id) => x) true"
+    ~expr:"((pred: Bool) => (x: pred Type Int Id) => x) true"
 
 let pair =
   type_expr "pair" ~wrapper:false
-    ~type_:"(A: *) -> (B: *) -> (x: A) -> (y: B) -> (x: A, B)"
-    ~expr:"(A: *) => (B: *) => (x: A) => (y: B) => (x = x, y : B)"
+    ~type_:"(A: Type) -> (B: Type) -> (x: A) -> (y: B) -> (x: A, B)"
+    ~expr:"(A: Type) => (B: Type) => (x: A) => (y: B) => (x = x, y : B)"
 
 let left_unpair =
   type_expr "left_unpair" ~wrapper:false
-    ~type_:"(A: *) -> (B: *) -> (x: A) -> (y: B) -> A"
+    ~type_:"(A: Type) -> (B: Type) -> (x: A) -> (y: B) -> A"
     ~expr:
-      {|(A: *) => (B: *) => (x: A) => (y: B) => (
+      {|(A: Type) => (B: Type) => (x: A) => (y: B) => (
           p = (x = x, y : B);
           (y, x) = p;
           y
@@ -71,9 +72,9 @@ let left_unpair =
 
 let right_unpair =
   type_expr "right_unpair" ~wrapper:false
-    ~type_:"(A: *) -> (B: *) -> (x: A) -> (y: B) -> B"
+    ~type_:"(A: Type) -> (B: Type) -> (x: A) -> (y: B) -> B"
     ~expr:
-      {|(A: *) => (B: *) => (x: A) => (y: B) => (
+      {|(A: Type) => (B: Type) => (x: A) => (y: B) => (
           p = (x = x, y : B);
           (y, x) = p;
           x
@@ -82,12 +83,12 @@ let right_unpair =
 (* TODO: something like pack *)
 (* let pack =
    type_expr "pack" ~wrapper:false
-     ~type_:"(R: *) -> (A: *, r: R) -> (A: *, r: R)"
-     ~expr:"(R: *) => (p: (A: *, x: R)) => p" *)
+     ~type_:"(R: Type) -> (A: Type, r: R) -> (A: Type, r: R)"
+     ~expr:"(R: Type) => (p: (A: Type, x: R)) => p" *)
 
 let pair_int =
-  type_expr "pair_int" ~type_:"(A: *) -> (fst: Int) -> (snd: A) -> (x: Int, A)"
-    ~expr:"pair Int"
+  type_expr "pair_int"
+    ~type_:"(A: Type) -> (fst: Int) -> (snd: A) -> (x: Int, A)" ~expr:"pair Int"
 
 let pair_int_int =
   type_expr "pair_int_int" ~type_:"(fst: Int) -> (snd: Int) -> (x: Int, Int)"
@@ -102,7 +103,7 @@ let pair_int_int_one_one =
     ~expr:"pair Int Int one one"
 
 let exists_a_a =
-  type_expr "exists_a_a" ~type_:"(A : *, A)" ~expr:"(A = Int, one : A)"
+  type_expr "exists_a_a" ~type_:"(A : Type, A)" ~expr:"(A = Int, one : A)"
 
 let utils = [ id; sequence; bool; true_; false_; pair (* ;pack *); incr ]
 
@@ -163,7 +164,7 @@ let wrapped_env =
     (let open Term in
     let open Env in
     let var s = Var.create (Name.make s) in
-    let env = empty in
+    let env = initial in
 
     let env =
       let int_var = var "Int" in
@@ -186,7 +187,7 @@ let wrapped_env =
 
 let test { name; type_; expr; wrapper } =
   let check () =
-    let env = Env.empty in
+    let env = Env.initial in
     let env = if wrapper then Lazy.force wrapped_env else env in
 
     let type_ = type_term env type_ in

--- a/smol/typer.ml
+++ b/smol/typer.ml
@@ -12,7 +12,6 @@ let rec type_term env term =
   (* TODO: use location *)
   let (LT { loc = _; desc = term }) = term in
   match term with
-  | LT_type -> t_type
   | LT_var { var } -> lookup var env
   | LT_arrow { var; param; return } ->
       let var = Var.create var in

--- a/smol/var.ml
+++ b/smol/var.ml
@@ -41,3 +41,7 @@ let compare a b =
 let name var =
   let { id = _; name } = var in
   name
+
+let type_ =
+  let name = Name.make "Type" in
+  create name

--- a/smol/var.mli
+++ b/smol/var.mli
@@ -5,3 +5,7 @@ val create : Name.t -> var
 val equal : var -> var -> bool
 val compare : var -> var -> int
 val name : var -> Name.t
+
+(* predefined *)
+(* Type *)
+val type_ : var


### PR DESCRIPTION
## Goals

Avoid conflicts due to `*` being used for types

## Context

Currently the type of all types is defined by the standard `*` notation, this is not ideal as it also conflicts with the `*` used by multiplication, while this problem could probably be worked around there will be additional types of things in the future.

Here I introduce the concept of a predefined variable, which is by default in the Env and make `Type` a predefined Type.