### PR TITLE
smol: move to strict evaluation

### DIFF
--- a/smol/machinery.ml
+++ b/smol/machinery.ml
@@ -72,7 +72,6 @@ let rec normalize term =
       t_arrow ~var ~param ~return
   | T_lambda { var; param; return } ->
       let param = normalize param in
-      let return = normalize return in
       t_lambda ~var ~param ~return
   | T_apply { lambda; arg } -> (
       let lambda = normalize lambda in


### PR DESCRIPTION
## Goals

Make it easier to predict the runtime behaviour and easier to integrate with linear types.

## Context

Smol currently does full beta reduction, reducing arguments and internal terms of lambdas, while this is okay in a pure system, it becomes slightly messier when effects are added(even if only for debugging), but also when handling linear types.