### PR TITLE
smol: add debug primitive

### DIFF
--- a/smol/env.ml
+++ b/smol/env.ml
@@ -16,5 +16,27 @@ let lookup name env =
   | None -> raise (Unbound_variable { var = name })
 
 let initial =
+  let open Term in
   let env = Name_map.empty in
-  enter Var.type_ Term.t_type env
+  let env = enter Var.type_ Term.t_type env in
+
+  let debug_type =
+    (* debug : (M : (A : Type, A)) -> ((A, _) = M; A) *)
+    let var = Var.create (Name.make "M") in
+    let param =
+      let var = Var.create (Name.make "A") in
+      let left = t_type in
+      let right = t_var ~var ~type_:left in
+      t_sigma ~var ~left ~right
+    in
+    let return =
+      let left = Var.create (Name.make "A") in
+      let right = Var.create (Name.make "_") in
+      let pair = t_var ~var ~type_:param in
+      let return = t_var ~var:left ~type_:t_type in
+      t_unpair ~left ~right ~pair ~return
+    in
+    t_arrow ~var ~param ~return
+  in
+  let debug_term = t_var ~var:Var.debug ~type_:debug_type in
+  enter Var.debug debug_term env

--- a/smol/machinery.ml
+++ b/smol/machinery.ml
@@ -80,6 +80,10 @@ let rec normalize term =
       | T_lambda { var; param = _; return } ->
           let return = expand ~from:var ~to_:arg return in
           normalize return
+      (* TODO: primitives *)
+      | T_var { var; type_ = _ } when Var.(equal var debug) ->
+          Format.eprintf "debug: %a\n%!" Term.pp arg;
+          arg
       | lambda -> t_apply ~lambda ~arg)
   | T_sigma { var; left; right } ->
       let left = normalize left in

--- a/smol/var.ml
+++ b/smol/var.ml
@@ -45,3 +45,7 @@ let name var =
 let type_ =
   let name = Name.make "Type" in
   create name
+
+let debug =
+  let name = Name.make "debug" in
+  create name

--- a/smol/var.mli
+++ b/smol/var.mli
@@ -9,3 +9,6 @@ val name : var -> Name.t
 (* predefined *)
 (* Type *)
 val type_ : var
+
+(* debug *)
+val debug : var


### PR DESCRIPTION
## Goals

Make it easier to debug Smol.

## Context

Currently there is no way to print a term during Smol reduction, this is very useful for debugging both on runtime and on the type level, so this PR introduces a debug function.

Note that this is not designed for production it is an effectful function on the type level, which is clearly not a good idea.