### PR TITLE
teika: implement syntax stage

### DIFF
--- a/teika/dune
+++ b/teika/dune
@@ -1,0 +1,25 @@
+(library
+ (name teika)
+ (libraries menhirLib compiler-libs.common)
+ (modules
+  (:standard \ Test))
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq sedlex.ppx)))
+
+(menhir
+ (modules sparser)
+ (flags --dump --explain))
+
+(executable
+ (name test)
+ (modules Test)
+ (libraries alcotest teika)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq)))
+
+(rule
+ (alias runtest)
+ (deps
+  (:exe ./test.exe))
+ (action
+  (run %{exe})))

--- a/teika/name.ml
+++ b/teika/name.ml
@@ -1,0 +1,8 @@
+type t = string [@@deriving show]
+
+let make t = t
+let equal = String.equal
+let compare = String.compare
+let repr t = t
+
+module Map = Map.Make (String)

--- a/teika/name.mli
+++ b/teika/name.mli
@@ -1,0 +1,9 @@
+type t [@@deriving show]
+
+val make : string -> t
+val equal : t -> t -> bool
+val compare : t -> t -> int
+val repr : t -> string
+
+(* TODO: stop exposing this *)
+module Map : Map.S with type key = t

--- a/teika/slexer.ml
+++ b/teika/slexer.ml
@@ -1,0 +1,39 @@
+open Sparser
+open Sedlexing.Utf8
+
+(* TODO: more information *)
+exception Lexer_unknown_token
+
+let whitespace = [%sedlex.regexp? Plus (' ' | '\t' | '\n')]
+let alphabet = [%sedlex.regexp? 'a' .. 'z' | 'A' .. 'Z']
+let digit = [%sedlex.regexp? '0' .. '9']
+let variable = [%sedlex.regexp? (alphabet | '_'), Star (alphabet | digit | '_')]
+
+let rec tokenizer buf =
+  match%sedlex buf with
+  | whitespace -> tokenizer buf
+  | variable -> VAR (lexeme buf)
+  | ":" -> COLON
+  | "->" -> ARROW
+  | "=>" -> FAT_ARROW
+  | "=>" -> FAT_ARROW
+  | "=" -> EQUAL
+  | "," -> COMMA
+  | "&" -> AMPERSAND
+  | ";" -> SEMICOLON
+  | "(" -> LEFT_PARENS
+  | ")" -> RIGHT_PARENS
+  | "{" -> LEFT_BRACE
+  | "}" -> RIGHT_BRACE
+  | eof -> EOF
+  | _ -> raise Lexer_unknown_token
+
+let provider buf () =
+  let token = tokenizer buf in
+  let start, stop = Sedlexing.lexing_positions buf in
+  (token, start, stop)
+
+let from_string parser string =
+  let buf = from_string string in
+  let provider = provider buf in
+  MenhirLib.Convert.Simplified.traditional2revised parser provider

--- a/teika/slexer.mli
+++ b/teika/slexer.mli
@@ -1,0 +1,2 @@
+val from_string :
+  (Sparser.token, 'a) MenhirLib.Convert.traditional -> string -> 'a

--- a/teika/sparser.mly
+++ b/teika/sparser.mly
@@ -1,0 +1,108 @@
+%{
+open Stree
+
+let mk (loc_start, loc_end) =
+  Location.{ loc_start; loc_end; loc_ghost = false }
+
+%}
+%token <string> VAR (* x *)
+%token COLON (* : *)
+%token ARROW (* -> *)
+%token FAT_ARROW (* => *)
+%token EQUAL (* = *)
+%token COMMA (* , *)
+%token AMPERSAND (* & *)
+%token SEMICOLON (* ; *)
+%token LEFT_PARENS (* ( *)
+%token RIGHT_PARENS (* ) *)
+%token LEFT_BRACE (* { *)
+%token RIGHT_BRACE (* } *)
+
+%token EOF
+
+%start <Stree.term option> term_opt
+
+%%
+
+let term_opt :=
+  | EOF;
+    { None }
+  | term = term; EOF;
+    { Some term }
+
+let term := term_rec_semi
+
+let term_rec_semi :=
+  | term_rec_bind
+  | term_semi(term_rec_semi, term_rec_bind)
+
+let term_rec_bind :=
+  | term_rec_funct
+  | term_bind(term_rec_funct, term_rec_funct)
+
+let term_rec_funct :=
+  | term_rec_apply
+  | term_forall(term_rec_funct, term_rec_apply)
+  | term_lambda(term_rec_funct, term_rec_apply)
+
+let term_rec_apply :=
+  | term_atom
+  | term_apply(term_rec_apply, term_atom)
+
+let term_atom :=
+  | term_var
+  | term_parens(term_wrapped)
+  | term_braces(term_wrapped)
+
+let term_wrapped :=
+  | term
+  | term_annot(term_rec_annot, term_rec_funct)
+  | term_pair(term_rec_pair, term_rec_bind)
+  | term_both(term_rec_both, term_rec_bind)
+
+let term_rec_annot :=
+  (* TODO: why not term_rec_bind? *)
+  | term_rec_funct
+  | term_annot(term_rec_annot, term_rec_funct)
+
+let term_rec_pair :=
+  | term_rec_bind
+  | term_pair(term_rec_pair, term_rec_bind)
+
+let term_rec_both :=
+  | term_rec_bind
+  | term_both(term_rec_both, term_rec_bind)
+
+let term_var ==
+  | var = VAR;
+    { st_var (mk $loc) ~var:(Name.make var) }
+let term_forall(self, lower) ==
+  | param = lower; ARROW; return = self;
+    { st_forall (mk $loc) ~param ~return }
+let term_lambda(self, lower) ==
+  | param = lower; FAT_ARROW; return = self;
+    { st_lambda (mk $loc) ~param ~return }
+let term_apply(self, lower) ==
+  | lambda = self; arg = lower;
+    { st_apply (mk $loc) ~lambda ~arg }
+let term_pair(self, lower) ==
+  | left = lower; COMMA; right = self;
+    { st_pair (mk $loc) ~left ~right }
+let term_both(self, lower) ==
+  | left = lower; AMPERSAND; right = self;
+    { st_both (mk $loc) ~left ~right }
+let term_bind(self, lower) ==
+  | bound = lower; EQUAL; value = lower;
+    { st_bind (mk $loc) ~bound ~value }
+let term_semi(self, lower) ==
+  | left = lower; SEMICOLON; right = self;
+    { st_semi (mk $loc) ~left ~right }
+let term_annot(self, lower) ==
+  | value = lower; COLON; type_ = self;
+    { st_annot (mk $loc) ~value ~type_ }
+let term_parens(content) ==
+  | LEFT_PARENS; content = content; RIGHT_PARENS;
+    { st_parens (mk $loc) ~content }
+let term_braces(content) ==
+  | LEFT_BRACE; content = content; RIGHT_BRACE;
+    { st_braces (mk $loc) ~content }

--- a/teika/stree.ml
+++ b/teika/stree.ml
@@ -1,0 +1,28 @@
+type term = ST of { loc : Location.t; [@opaque] desc : term_desc }
+
+and term_desc =
+  | ST_var of { var : Name.t }
+  | ST_forall of { param : term; return : term }
+  | ST_lambda of { param : term; return : term }
+  | ST_apply of { lambda : term; arg : term }
+  | ST_pair of { left : term; right : term }
+  | ST_both of { left : term; right : term }
+  | ST_bind of { bound : term; value : term }
+  | ST_semi of { left : term; right : term }
+  | ST_annot of { value : term; type_ : term }
+  | ST_parens of { content : term }
+  | ST_braces of { content : term }
+[@@deriving show { with_path = false }]
+
+let st loc desc = ST { loc; desc }
+let st_var loc ~var = st loc (ST_var { var })
+let st_forall loc ~param ~return = st loc (ST_forall { param; return })
+let st_lambda loc ~param ~return = st loc (ST_lambda { param; return })
+let st_apply loc ~lambda ~arg = st loc (ST_apply { lambda; arg })
+let st_pair loc ~left ~right = st loc (ST_pair { left; right })
+let st_both loc ~left ~right = st loc (ST_both { left; right })
+let st_bind loc ~bound ~value = st loc (ST_bind { bound; value })
+let st_semi loc ~left ~right = st loc (ST_semi { left; right })
+let st_annot loc ~value ~type_ = st loc (ST_annot { value; type_ })
+let st_parens loc ~content = st loc (ST_parens { content })
+let st_braces loc ~content = st loc (ST_braces { content })

--- a/teika/stree.mli
+++ b/teika/stree.mli
@@ -1,0 +1,27 @@
+type term = private ST of { loc : Location.t; desc : term_desc }
+
+and term_desc = private
+  | ST_var of { var : Name.t }
+  | ST_forall of { param : term; return : term }
+  | ST_lambda of { param : term; return : term }
+  | ST_apply of { lambda : term; arg : term }
+  | ST_pair of { left : term; right : term }
+  | ST_both of { left : term; right : term }
+  | ST_bind of { bound : term; value : term }
+  | ST_semi of { left : term; right : term }
+  | ST_annot of { value : term; type_ : term }
+  | ST_parens of { content : term }
+  | ST_braces of { content : term }
+[@@deriving show]
+
+val st_var : Location.t -> var:Name.t -> term
+val st_forall : Location.t -> param:term -> return:term -> term
+val st_lambda : Location.t -> param:term -> return:term -> term
+val st_apply : Location.t -> lambda:term -> arg:term -> term
+val st_pair : Location.t -> left:term -> right:term -> term
+val st_both : Location.t -> left:term -> right:term -> term
+val st_bind : Location.t -> bound:term -> value:term -> term
+val st_semi : Location.t -> left:term -> right:term -> term
+val st_annot : Location.t -> value:term -> type_:term -> term
+val st_parens : Location.t -> content:term -> term
+val st_braces : Location.t -> content:term -> term

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -1,0 +1,90 @@
+open Teika
+
+module Stree_utils = struct
+  open Stree
+
+  module Location = struct
+    include Location
+
+    let equal _ _ = true
+  end
+
+  type term = Stree.term = private
+    | ST of { loc : Location.t; desc : term_desc }
+
+  and term_desc = Stree.term_desc = private
+    | ST_var of { var : Name.t }
+    | ST_forall of { param : term; return : term }
+    | ST_lambda of { param : term; return : term }
+    | ST_apply of { lambda : term; arg : term }
+    | ST_pair of { left : term; right : term }
+    | ST_both of { left : term; right : term }
+    | ST_bind of { bound : term; value : term }
+    | ST_semi of { left : term; right : term }
+    | ST_annot of { value : term; type_ : term }
+    | ST_parens of { content : term }
+    | ST_braces of { content : term }
+  [@@deriving eq]
+
+  (* TODO: ppx? *)
+  let loc = Location.none
+
+  let var ?(loc = loc) var =
+    let var = Name.make var in
+    st_var loc ~var
+
+  let ( @-> ) ?(loc = loc) param return = st_forall loc ~param ~return
+  let ( @=> ) ?(loc = loc) param return = st_lambda loc ~param ~return
+  let ( @@ ) ?(loc = loc) lambda arg = st_apply loc ~lambda ~arg
+  let ( + ) ?(loc = loc) left right = st_pair loc ~left ~right
+  let ( & ) ?(loc = loc) left right = st_both loc ~left ~right
+  let ( = ) ?(loc = loc) bound value = st_bind loc ~bound ~value
+  let ( * ) ?(loc = loc) left right = st_semi loc ~left ~right
+  let ( @: ) ?(loc = loc) value type_ = st_annot loc ~value ~type_
+  let parens ?(loc = loc) content = st_parens loc ~content
+  let braces ?(loc = loc) content = st_braces loc ~content
+end
+
+module Sparser = struct
+  open Stree_utils
+
+  type test = Works of { expected : term; input : string }
+
+  let works input expected = Works { expected; input }
+
+  (* TODO: generative tests*)
+  let tests =
+    [
+      ("variable", works "x" (var "x"));
+      ("arrow", works "x -> x" (var "x" @-> var "x"));
+      ("lambda", works "x => x" (var "x" @=> var "x"));
+      ("apply", works "x y z" ((var "x" @@ var "y") @@ var "z"));
+      ("pair", works "(x, y, z)" (parens (var "x" + (var "y" + var "z"))));
+      ("both", works "(x & y & z)" (parens (var "x" & var "y" & var "z")));
+      ("bind", works "x = y" (var "x" = var "y"));
+      ("semi", works "x; y; z" (var "x" * (var "y" * var "z")));
+      ("annot", works "(x : y)" (parens (var "x" @: var "y")));
+      ("parens", works "(x)" (parens (var "x")));
+      ("braces", works "{x}" (braces (var "x")));
+      ( "let",
+        works "x = y; z = x; z"
+          ((var "x" = var "y") * ((var "z" = var "x") * var "z")) );
+    ]
+
+  (* alcotest *)
+  let equal_stree = Alcotest.testable Stree.pp_term Stree_utils.equal_term
+
+  let test (name, test) =
+    let check () =
+      let (Works { expected; input }) = test in
+      let actual = Slexer.from_string Sparser.term_opt input in
+      Alcotest.(
+        check' (option equal_stree) ~msg:"works" ~expected:(Some expected)
+          ~actual)
+    in
+    Alcotest.test_case name `Quick check
+
+  let tests = ("sparser", List.map test tests)
+end
+
+let () = Alcotest.run "Teika" [ Sparser.tests ]


### PR DESCRIPTION
## Goals

Being able to parse Teika core features into a syntax tree.

## Context

I have more or less a design for Teika, so it is time to implement it, the pipeline will be similar to the Smol one, Syntax -> Language -> Typed. So this implements the first step of it.