### PR TITLE
teika: makes sparser a bit more flexible

### DIFF
--- a/teika/sparser.mly
+++ b/teika/sparser.mly
@@ -54,24 +54,19 @@ let term_atom :=
   | term_parens(term_wrapped)
   | term_braces(term_wrapped)
 
-let term_wrapped :=
-  | term
-  | term_annot(term_rec_annot, term_rec_funct)
-  | term_pair(term_rec_pair, term_rec_bind)
-  | term_both(term_rec_both, term_rec_bind)
-
-let term_rec_annot :=
-  (* TODO: why not term_rec_bind? *)
-  | term_rec_funct
-  | term_annot(term_rec_annot, term_rec_funct)
+let term_wrapped := term_rec_pair
 
 let term_rec_pair :=
-  | term_rec_bind
-  | term_pair(term_rec_pair, term_rec_bind)
+  | term_rec_both
+  | term_pair(term_rec_pair, term_rec_both)
 
 let term_rec_both :=
-  | term_rec_bind
-  | term_both(term_rec_both, term_rec_bind)
+  | term_rec_annot
+  | term_both(term_rec_both, term_rec_annot)
+
+let term_rec_annot :=
+  | term
+  | term_annot(term_rec_annot, term_rec_funct)
 
 let term_var ==
   | var = VAR;

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -60,10 +60,29 @@ module Sparser = struct
       ("lambda", works "x => x" (var "x" @=> var "x"));
       ("apply", works "x y z" ((var "x" @@ var "y") @@ var "z"));
       ("pair", works "(x, y, z)" (parens (var "x" + (var "y" + var "z"))));
+      ( "pair annot",
+        works "(x : A, y : B)"
+          (parens ((var "x" @: var "A") + (var "y" @: var "B"))) );
+      ( "pair bind",
+        works "(x = A, y = B)"
+          (parens ((var "x" = var "A") + (var "y" = var "B"))) );
       ("both", works "(x & y & z)" (parens (var "x" & var "y" & var "z")));
+      ( "both annot",
+        works "(x : A & y : B)"
+          (parens ((var "x" @: var "A") & (var "y" @: var "B"))) );
+      ( "both bind",
+        works "(x = A & y = B)" (parens (var "x" = var "A" & var "y" = var "B"))
+      );
+      ( "pair and both",
+        works "(x : A & y : B, z : C)"
+          (parens
+             (((var "x" @: var "A") & (var "y" @: var "B"))
+             + (var "z" @: var "C"))) );
       ("bind", works "x = y" (var "x" = var "y"));
       ("semi", works "x; y; z" (var "x" * (var "y" * var "z")));
       ("annot", works "(x : y)" (parens (var "x" @: var "y")));
+      ( "nested annot",
+        works "(x : A : B)" (parens (var "x" @: var "A" @: var "B")) );
       ("parens", works "(x)" (parens (var "x")));
       ("braces", works "{x}" (braces (var "x")));
       ( "let",


### PR DESCRIPTION
## Goals

Teika pairs should have a higher precedence than `both`.

## Context

This should be valid syntax `(n : Nat & n_eq_1 : Equal n 1, y : Nat)`.