### PR TITLE
teika: remove intersection types

### DIFF
--- a/teika/lparser.ml
+++ b/teika/lparser.ml
@@ -35,20 +35,7 @@ let rec from_stree term =
       | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _
       | ST_both _ | ST_semi _ | ST_parens _ | ST_braces _ ->
           invalid_notation loc)
-  | ST_both { left; right } -> (
-      let (ST { loc = left_loc; desc }) = left in
-      match desc with
-      | ST_bind _ ->
-          let left = extract_bind left in
-          let right = extract_bind right in
-          lt_both loc ~left ~right
-      | ST_annot _ ->
-          let left = extract_annot left in
-          let right = extract_annot right in
-          lt_either loc ~left ~right
-      | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _
-      | ST_both _ | ST_semi _ | ST_parens _ | ST_braces _ ->
-          invalid_notation left_loc)
+  | ST_both _ -> invalid_notation loc
   | ST_bind _ -> invalid_notation loc
   | ST_semi { left; right } -> (
       let (ST { loc = left_loc; desc = left }) = left in
@@ -112,12 +99,6 @@ and extract_semi loc ~bound ~value ~return =
       let value = from_stree value in
       let return = from_stree return in
       lt_unpair loc ~left ~right ~pair:value ~return
-  | ST_both { left; right } ->
-      let left = extract_var left in
-      let right = extract_var right in
-      let value = from_stree value in
-      let return = from_stree return in
-      lt_unboth loc ~left ~right ~both:value ~return
-  | ST_forall _ | ST_lambda _ | ST_apply _ | ST_bind _ | ST_semi _ | ST_annot _
-  | ST_braces _ ->
+  | ST_forall _ | ST_lambda _ | ST_apply _ | ST_both _ | ST_bind _ | ST_semi _
+  | ST_annot _ | ST_braces _ ->
       invalid_notation bound_loc

--- a/teika/ltree.ml
+++ b/teika/ltree.ml
@@ -8,9 +8,6 @@ and term_desc =
   | LT_exists of { left : annot; right : annot }
   | LT_pair of { left : bind; right : bind }
   | LT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
-  | LT_either of { left : annot; right : annot }
-  | LT_both of { left : bind; right : bind }
-  | LT_unboth of { left : Name.t; right : Name.t; both : term; return : term }
   | LT_let of { bound : bind; return : term }
   | LT_annot of { value : term; type_ : term }
 
@@ -31,12 +28,6 @@ let lt_pair loc ~left ~right = lterm loc (LT_pair { left; right })
 
 let lt_unpair loc ~left ~right ~pair ~return =
   lterm loc (LT_unpair { left; right; pair; return })
-
-let lt_either loc ~left ~right = lterm loc (LT_either { left; right })
-let lt_both loc ~left ~right = lterm loc (LT_both { left; right })
-
-let lt_unboth loc ~left ~right ~both ~return =
-  lterm loc (LT_unboth { left; right; both; return })
 
 let lt_let loc ~bound ~return = lterm loc (LT_let { bound; return })
 let lt_annot loc ~value ~type_ = lterm loc (LT_annot { value; type_ })

--- a/teika/ltree.mli
+++ b/teika/ltree.mli
@@ -15,12 +15,6 @@ and term_desc = private
   | LT_pair of { left : bind; right : bind }
   (* (x, y) = v; r *)
   | LT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
-  (* (x : A & y : B) *)
-  | LT_either of { left : annot; right : annot }
-  (* (x = 0 & y = 0) *)
-  | LT_both of { left : bind; right : bind }
-  (* (x & y) = v; r *)
-  | LT_unboth of { left : Name.t; right : Name.t; both : term; return : term }
   (* x = v; r *)
   | LT_let of { bound : bind; return : term }
   (* v : T *)
@@ -41,12 +35,6 @@ val lt_pair : Location.t -> left:bind -> right:bind -> term
 
 val lt_unpair :
   Location.t -> left:Name.t -> right:Name.t -> pair:term -> return:term -> term
-
-val lt_either : Location.t -> left:annot -> right:annot -> term
-val lt_both : Location.t -> left:bind -> right:bind -> term
-
-val lt_unboth :
-  Location.t -> left:Name.t -> right:Name.t -> both:term -> return:term -> term
 
 val lt_let : Location.t -> bound:bind -> return:term -> term
 val lt_annot : Location.t -> value:term -> type_:term -> term

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -126,9 +126,6 @@ module Ltree_utils = struct
     | LT_exists of { left : annot; right : annot }
     | LT_pair of { left : bind; right : bind }
     | LT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
-    | LT_either of { left : annot; right : annot }
-    | LT_both of { left : bind; right : bind }
-    | LT_unboth of { left : Name.t; right : Name.t; both : term; return : term }
     | LT_let of { bound : bind; return : term }
     | LT_annot of { value : term; type_ : term }
 
@@ -155,14 +152,6 @@ module Ltree_utils = struct
     let left = Name.make left in
     let right = Name.make right in
     lt_unpair loc ~left ~right ~pair ~return
-
-  let either ?(loc = loc) left right = lt_either loc ~left ~right
-  let both ?(loc = loc) left right = lt_both loc ~left ~right
-
-  let unboth ?(loc = loc) left right both return =
-    let left = Name.make left in
-    let right = Name.make right in
-    lt_unboth loc ~left ~right ~both ~return
 
   let let_ ?(loc = loc) bound return = lt_let loc ~bound ~return
   let ( $ ) left right = left right
@@ -194,10 +183,6 @@ module Lparser = struct
         works "(x : A, y : B)" (exists ("x" @: var "A") ("y" @: var "B")) );
       ("pair", works "(x = l, y = r)" (pair ("x" @= var "l") ("y" @= var "r")));
       ("unpair", works "(x, y) = p; z" (unpair "x" "y" (var "p") $ var "z"));
-      ( "either",
-        works "(x : A & y : B)" (either ("x" @: var "A") ("y" @: var "B")) );
-      ("both", works "(x = l & y = r)" (both ("x" @= var "l") ("y" @= var "r")));
-      ("unboth", works "(x & y) = p; z" (unboth "x" "y" (var "p") $ var "z"));
       ( "let",
         works "x = y; z = x; z"
           (let_ ("x" @= var "y") $ (let_ ("z" @= var "x") $ var "z")) );


### PR DESCRIPTION
## Goals

Prepare Teika to implement the core type checker.

## Context

Currently the Teika language describes formation, introduction and elimination of intersection types, but this is not the correct form for them.