### PR TITLE
teika: rename annotation type_ to annot in a couple cases

### DIFF
--- a/teika/lparser.ml
+++ b/teika/lparser.ml
@@ -44,10 +44,10 @@ let rec from_stree term =
       | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _
       | ST_both _ | ST_semi _ | ST_annot _ | ST_parens _ | ST_braces _ ->
           invalid_notation left_loc)
-  | ST_annot { value; type_ } ->
+  | ST_annot { value; annot } ->
       let value = from_stree value in
-      let type_ = from_stree type_ in
-      lt_annot loc ~value ~type_
+      let annot = from_stree annot in
+      lt_annot loc ~value ~annot
   | ST_parens { content } -> from_stree content
   | ST_braces _ -> invalid_notation loc
 
@@ -64,10 +64,10 @@ and extract_annot annot =
   let (ST { loc; desc }) = annot in
   match desc with
   | ST_parens { content } -> extract_annot content
-  | ST_annot { value; type_ } ->
+  | ST_annot { value; annot } ->
       let var = extract_var value in
-      let type_ = from_stree type_ in
-      lannot loc ~var ~type_
+      let annot = from_stree annot in
+      lannot loc ~var ~annot
   | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _ | ST_both _
   | ST_bind _ | ST_semi _ | ST_braces _ ->
       invalid_notation loc

--- a/teika/ltree.ml
+++ b/teika/ltree.ml
@@ -9,10 +9,10 @@ and term_desc =
   | LT_pair of { left : bind; right : bind }
   | LT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
   | LT_let of { bound : bind; return : term }
-  | LT_annot of { value : term; type_ : term }
+  | LT_annot of { value : term; annot : term }
 
 and annot =
-  | LAnnot of { loc : Location.t; [@opaque] var : Name.t; type_ : term }
+  | LAnnot of { loc : Location.t; [@opaque] var : Name.t; annot : term }
 
 and bind = LBind of { loc : Location.t; [@opaque] var : Name.t; value : term }
 [@@deriving show]
@@ -30,10 +30,10 @@ let lt_unpair loc ~left ~right ~pair ~return =
   lterm loc (LT_unpair { left; right; pair; return })
 
 let lt_let loc ~bound ~return = lterm loc (LT_let { bound; return })
-let lt_annot loc ~value ~type_ = lterm loc (LT_annot { value; type_ })
+let lt_annot loc ~value ~annot = lterm loc (LT_annot { value; annot })
 
 (* annot *)
-let lannot loc ~var ~type_ = LAnnot { loc; var; type_ }
+let lannot loc ~var ~annot = LAnnot { loc; var; annot }
 
 (* bind *)
 let lbind loc ~var ~value = LBind { loc; var; value }

--- a/teika/ltree.mli
+++ b/teika/ltree.mli
@@ -18,9 +18,9 @@ and term_desc = private
   (* x = v; r *)
   | LT_let of { bound : bind; return : term }
   (* v : T *)
-  | LT_annot of { value : term; type_ : term }
+  | LT_annot of { value : term; annot : term }
 
-and annot = private LAnnot of { loc : Location.t; var : Name.t; type_ : term }
+and annot = private LAnnot of { loc : Location.t; var : Name.t; annot : term }
 
 and bind = private LBind of { loc : Location.t; var : Name.t; value : term }
 [@@deriving show]
@@ -37,10 +37,10 @@ val lt_unpair :
   Location.t -> left:Name.t -> right:Name.t -> pair:term -> return:term -> term
 
 val lt_let : Location.t -> bound:bind -> return:term -> term
-val lt_annot : Location.t -> value:term -> type_:term -> term
+val lt_annot : Location.t -> value:term -> annot:term -> term
 
 (* annot *)
-val lannot : Location.t -> var:Name.t -> type_:term -> annot
+val lannot : Location.t -> var:Name.t -> annot:term -> annot
 
 (* bind *)
 val lbind : Location.t -> var:Name.t -> value:term -> bind

--- a/teika/sparser.mly
+++ b/teika/sparser.mly
@@ -93,8 +93,8 @@ let term_semi(self, lower) ==
   | left = lower; SEMICOLON; right = self;
     { st_semi (mk $loc) ~left ~right }
 let term_annot(self, lower) ==
-  | value = lower; COLON; type_ = self;
-    { st_annot (mk $loc) ~value ~type_ }
+  | value = lower; COLON; annot = self;
+    { st_annot (mk $loc) ~value ~annot }
 let term_parens(content) ==
   | LEFT_PARENS; content = content; RIGHT_PARENS;
     { st_parens (mk $loc) ~content }

--- a/teika/stree.ml
+++ b/teika/stree.ml
@@ -9,7 +9,7 @@ and term_desc =
   | ST_both of { left : term; right : term }
   | ST_bind of { bound : term; value : term }
   | ST_semi of { left : term; right : term }
-  | ST_annot of { value : term; type_ : term }
+  | ST_annot of { value : term; annot : term }
   | ST_parens of { content : term }
   | ST_braces of { content : term }
 [@@deriving show { with_path = false }]
@@ -23,6 +23,6 @@ let st_pair loc ~left ~right = st loc (ST_pair { left; right })
 let st_both loc ~left ~right = st loc (ST_both { left; right })
 let st_bind loc ~bound ~value = st loc (ST_bind { bound; value })
 let st_semi loc ~left ~right = st loc (ST_semi { left; right })
-let st_annot loc ~value ~type_ = st loc (ST_annot { value; type_ })
+let st_annot loc ~value ~annot = st loc (ST_annot { value; annot })
 let st_parens loc ~content = st loc (ST_parens { content })
 let st_braces loc ~content = st loc (ST_braces { content })

--- a/teika/stree.mli
+++ b/teika/stree.mli
@@ -9,7 +9,7 @@ and term_desc = private
   | ST_both of { left : term; right : term }
   | ST_bind of { bound : term; value : term }
   | ST_semi of { left : term; right : term }
-  | ST_annot of { value : term; type_ : term }
+  | ST_annot of { value : term; annot : term }
   | ST_parens of { content : term }
   | ST_braces of { content : term }
 [@@deriving show]
@@ -22,6 +22,6 @@ val st_pair : Location.t -> left:term -> right:term -> term
 val st_both : Location.t -> left:term -> right:term -> term
 val st_bind : Location.t -> bound:term -> value:term -> term
 val st_semi : Location.t -> left:term -> right:term -> term
-val st_annot : Location.t -> value:term -> type_:term -> term
+val st_annot : Location.t -> value:term -> annot:term -> term
 val st_parens : Location.t -> content:term -> term
 val st_braces : Location.t -> content:term -> term


### PR DESCRIPTION
## Goals

Establish clear terminology for annotated fields.

## Context

When defining an elaborated tree nodes such as `TT_annot` will have two fields named `type_`, this makes it confusing with the `type_` also inside of the annotation. So I defined `annot` as any type annotated on the actual tree and `type_` for the type at the elaborated tree.