### PR TITLE
teika: define unique variable module

### DIFF
--- a/teika/dune
+++ b/teika/dune
@@ -4,7 +4,7 @@
  (modules
   (:standard \ Test))
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq sedlex.ppx)))
+  (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord sedlex.ppx)))
 
 (menhir
  (modules sparser)
@@ -15,7 +15,7 @@
  (modules Test)
  (libraries alcotest teika)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord)))
 
 (rule
  (alias runtest)

--- a/teika/name.ml
+++ b/teika/name.ml
@@ -1,8 +1,6 @@
-type t = string [@@deriving show]
+type t = string [@@deriving show, eq, ord]
 
 let make t = t
-let equal = String.equal
-let compare = String.compare
 let repr t = t
 
 module Map = Map.Make (String)

--- a/teika/name.mli
+++ b/teika/name.mli
@@ -1,8 +1,6 @@
-type t [@@deriving show]
+type t [@@deriving show, eq, ord]
 
 val make : string -> t
-val equal : t -> t -> bool
-val compare : t -> t -> int
 val repr : t -> string
 
 (* TODO: stop exposing this *)

--- a/teika/var.ml
+++ b/teika/var.ml
@@ -1,0 +1,49 @@
+module Id : sig
+  type t [@@deriving show]
+
+  val next : unit -> t
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+end = struct
+  type t = int [@@deriving show]
+
+  let acc = Atomic.make 0
+  let next () = Atomic.fetch_and_add acc 1
+  let equal = Int.equal
+  let compare = Int.compare
+end
+
+let _ = Id.show
+
+type var = { id : Id.t; name : Name.t }
+type t = var
+
+let pp fmt var =
+  let { id; name } = var in
+  Format.fprintf fmt "\\%a/%a" Name.pp name Id.pp id
+
+let show var = Format.asprintf "%a" pp var
+
+let create name =
+  let id = Id.next () in
+  { id; name }
+
+let equal a b =
+  let { id = a; name = _ } = a in
+  let { id = b; name = _ } = b in
+  Id.equal a b
+
+let compare a b =
+  let { id = a; name = _ } = a in
+  let { id = b; name = _ } = b in
+  Id.compare a b
+
+let name var =
+  let { id = _; name } = var in
+  name
+
+module Map = Map.Make (struct
+  type t = var
+
+  let compare = compare
+end)

--- a/teika/var.mli
+++ b/teika/var.mli
@@ -1,0 +1,7 @@
+type var
+type t = var [@@deriving show, eq, ord]
+
+val make : Name.t -> var
+val name : var -> Name.t
+
+module Map : Map.S with type key = var


### PR DESCRIPTION
## Goals

Have an easy way to guarantee that variables are unique, aka alpha renaming.

## Context

When typing Teika will be doing alpha renaming, for this the easiest solution is just to assign an unique id to every variable during typing. This module does exactly that.


## **Warning**

This currently uses mutation, which makes it not bootstrap friendly, but it should be a relatively straight patch to fix this in the future. So technical debt.

But it is still thread safe, so parallelism should still work.