### PR TITLE
teika: define initial typed tree

### DIFF
--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -1,0 +1,66 @@
+(* TODO: use hole var so that x => x, the hole var is something like _X
+   to print as (x : _X) => x
+
+   Maybe (x : ?X) => x *)
+
+type term = TTerm of { loc : Location.t; desc : term_desc; type_ : type_ }
+and type_ = TType of { loc : Location.t; desc : term_desc }
+
+and term_desc =
+  | TT_var of { var : Var.t }
+  | TT_forall of { param : annot; return : type_ }
+  | TT_lambda of { param : annot; return : term }
+  | TT_apply of { lambda : term; arg : term }
+  | TT_exists of { left : annot; right : annot }
+  | TT_pair of { left : bind; right : bind }
+  | TT_unpair of { left : Var.t; right : Var.t; pair : term; return : term }
+  | TT_let of { bound : bind; return : term }
+  | TT_annot of { value : term; annot : type_ }
+
+and annot = TAnnot of { loc : Location.t; var : Var.t; annot : type_ }
+and bind = TBind of { loc : Location.t; var : Var.t; value : term }
+
+(* term *)
+
+let tterm loc type_ desc = TTerm { loc; desc; type_ }
+let ttype loc desc = TType { loc; desc }
+
+let tt_type =
+  (* TODO: Locations *)
+  ttype Location.none (TT_var { var = Var.type_ })
+
+let tt_var loc type_ ~var = tterm loc type_ (TT_var { var })
+let tt_forall loc ~param ~return = ttype loc (TT_forall { param; return })
+
+let tt_lambda loc type_ ~param ~return =
+  tterm loc type_ (TT_lambda { param; return })
+
+let tt_apply loc type_ ~lambda ~arg = tterm loc type_ (TT_apply { lambda; arg })
+let tt_exists loc ~left ~right = ttype loc (TT_exists { left; right })
+let tt_pair loc type_ ~left ~right = tterm loc type_ (TT_pair { left; right })
+
+let tt_unpair loc type_ ~left ~right ~pair ~return =
+  tterm loc type_ (TT_unpair { left; right; pair; return })
+
+let tt_let loc type_ ~bound ~return = tterm loc type_ (TT_let { bound; return })
+let tt_annot loc ~value ~annot = tterm loc annot (TT_annot { value; annot })
+
+(* annot *)
+let tannot loc ~var ~annot = TAnnot { loc; var; annot }
+
+(* bind *)
+let tbind loc ~var ~value = TBind { loc; var; value }
+
+(* utils *)
+exception Not_a_type of { term : term }
+
+let term_of_type type_ =
+  let (TType { loc; desc }) = type_ in
+  tterm loc tt_type desc
+
+let type_of_term term =
+  let (TTerm { loc; desc; type_ }) = term in
+  (* TODO: is this safe? *)
+  match type_ == tt_type with
+  | true -> ttype loc desc
+  | false -> raise (Not_a_type { term })

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,0 +1,60 @@
+type term = private
+  | TTerm of { loc : Location.t; desc : term_desc; type_ : type_ }
+
+and type_ = private TType of { loc : Location.t; desc : term_desc }
+
+and term_desc = private
+  (* x *)
+  | TT_var of { var : Var.t }
+  (* (x : A) -> B *)
+  | TT_forall of { param : annot; return : type_ }
+  (* (x : A) => e *)
+  | TT_lambda of { param : annot; return : term }
+  (* l a *)
+  | TT_apply of { lambda : term; arg : term }
+  (* (x : A, y : B) *)
+  | TT_exists of { left : annot; right : annot }
+  (* (x = 0, y = 0) *)
+  | TT_pair of { left : bind; right : bind }
+  (* (x, y) = v; r *)
+  | TT_unpair of { left : Var.t; right : Var.t; pair : term; return : term }
+  (* x = v; r *)
+  | TT_let of { bound : bind; return : term }
+  (* v : T *)
+  | TT_annot of { value : term; annot : type_ }
+
+and annot = private TAnnot of { loc : Location.t; var : Var.t; annot : type_ }
+and bind = private TBind of { loc : Location.t; var : Var.t; value : term }
+
+(* term & type_*)
+val tt_type : type_
+val tt_var : Location.t -> type_ -> var:Var.t -> term
+val tt_forall : Location.t -> param:annot -> return:type_ -> type_
+val tt_lambda : Location.t -> type_ -> param:annot -> return:term -> term
+val tt_apply : Location.t -> type_ -> lambda:term -> arg:term -> term
+val tt_exists : Location.t -> left:annot -> right:annot -> type_
+val tt_pair : Location.t -> type_ -> left:bind -> right:bind -> term
+
+val tt_unpair :
+  Location.t ->
+  type_ ->
+  left:Var.t ->
+  right:Var.t ->
+  pair:term ->
+  return:term ->
+  term
+
+val tt_let : Location.t -> type_ -> bound:bind -> return:term -> term
+val tt_annot : Location.t -> value:term -> annot:type_ -> term
+
+(* annot *)
+val tannot : Location.t -> var:Var.t -> annot:type_ -> annot
+
+(* bind *)
+val tbind : Location.t -> var:Var.t -> value:term -> bind
+
+(* utils *)
+exception Not_a_type of { term : term }
+
+val term_of_type : type_ -> term
+val type_of_term : term -> type_


### PR DESCRIPTION
## Goals

Have a defined canonical representation of Teika so that it can easily be compiled and analyzed.

## Context

Teika front end pipeline should end on a typed tree, representing the canonical version of Teika. This PR defines such tree and the needed helpers.

Unlike Ltree, Ttree includes two different base types, `type_` and `term`, this is needed because every term has the form of `Term : Type`, without such separation a cycle is present due to `Term : Term` and while technically a type also has a type, this is not tracked in the same way as the type of a term to prevent such cycles.