### PR TITLE
teika: reenable term substitution

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -1,225 +1,63 @@
 open Ttree
 
-type var_info =
-  | V_rigid of { level : Level.t }
-  | V_alias of { var : Var.t }
-  | V_link of { type_ : term_desc }
-  | V_hole of { level : Level.t }
-
 type error = CError of { loc : Location.t; desc : error_desc }
+and error_desc = |
 
-and error_desc =
-  | CError_occurs_check of { var : Var.t; in_ : Var.t }
-  | CError_escape_check of { var : Var.t; to_ : Var.t }
-  | CError_var_constrained of { var : Var.t; by_ : term_desc }
-  | CError_var_clash of { expected : Var.t; received : Var.t }
-  | CError_type_clash of { expected : term_desc; received : term_desc }
-  (* invariants *)
-  | CError_unknown_var_repr of { var : Var.t }
-  | CError_unknown_var_link of { var : Var.t }
-  | CError_unknown_var_lower of { var : Var.t }
-  | CError_unknown_var_alias of { var : Var.t }
-  | CError_duplicated_var_rigid of { var : Var.t }
-  | CError_duplicated_var_alias of { var : Var.t }
-  | CError_duplicated_var_hole of { var : Var.t }
-  | CError_invalid_var_link of { var : Var.t; info : var_info }
-  | CError_invalid_var_lower of { var : Var.t; info : var_info }
-  | CError_invalid_var_alias of { var : Var.t; info : var_info }
-  | CError_lowering_to_higher_level of { var : Var.t }
+module Subst_context = struct
+  type 'a subst_context = {
+    (* TODO: accumulate locations during substitutions *)
+    context :
+      'k.
+      from:Offset.t ->
+      to_:term_desc ->
+      ok:('a -> 'k) ->
+      error:(error_desc -> 'k) ->
+      'k;
+  }
+  [@@ocaml.unboxed]
 
-type data = {
-  loc : Location.t;
-  (* unification *)
-  level : Level.t;
-  (* TODO: for variables this could be done using an array
-      as even in big programs the number of variables is relatively
-      small, unless we start generating variables during typing *)
-  vars : var_info Var.Map.t;
-}
+  type 'a t = 'a subst_context
 
-(* TODO: I'm bad with monads *)
-type 'a context = Context of (data -> ('a * data, error * data) result)
-[@@ocaml.unboxed]
+  let[@inline always] test ~loc ~from ~to_ f =
+    let { context } = f () in
+    let ok value = Ok value in
+    let error desc = Error (CError { loc; desc }) in
+    context ~from ~to_ ~ok ~error
 
-type 'a t = 'a context
+  let[@inline always] return value =
+    let context ~from:_ ~to_:_ ~ok ~error:_ = ok value in
+    { context }
 
-let return content = Context (fun data -> Ok (content, data))
+  let[@inline always] bind context f =
+    let { context } = context in
+    let context ~from ~to_ ~ok ~error =
+      let ok data =
+        let { context } = f data in
+        context ~from ~to_ ~ok ~error
+      in
+      context ~from ~to_ ~ok ~error
+    in
+    { context }
 
-let fail desc =
-  Context
-    (fun data ->
-      let { loc; level = _; vars = _ } = data in
-      Error (CError { loc; desc }, data))
+  let ( let* ) = bind
 
-let apply context data f =
-  let (Context context) = context in
-  match context data with
-  | Ok (content, data) -> f content data
-  | Error _error as error -> error
+  let[@inline always] ( let+ ) context f =
+    let* value = context in
+    return @@ f value
 
-let ( >>= ) context f =
-  Context
-    (fun data ->
-      let (Context context) = context in
-      match context data with
-      | Ok (content, data) ->
-          let (Context f) = f content in
-          f data
-      | Error _error as error -> error)
+  let[@inline always] from () =
+    let context ~from ~to_:_ ~ok ~error:_ = ok from in
+    { context }
 
-let fail_occurs_check var ~in_ = fail (CError_occurs_check { var; in_ })
-let fail_escape_check var ~to_ = fail (CError_escape_check { var; to_ })
-let fail_var_constrained var ~by_ = fail (CError_var_constrained { var; by_ })
+  let[@inline always] to_ () =
+    let context ~from:_ ~to_ ~ok ~error:_ = ok to_ in
+    { context }
 
-let fail_var_clash ~expected ~received =
-  fail (CError_var_clash { expected; received })
-
-let fail_type_clash ~expected ~received =
-  fail (CError_type_clash { expected; received })
-
-let loc =
-  Context
-    (fun data ->
-      let { loc; level = _; vars = _ } = data in
-      Ok (loc, data))
-
-let level =
-  Context
-    (fun data ->
-      let { loc = _; level; vars = _ } = data in
-      Ok (level, data))
-
-let repr var =
-  Context
-    (fun data ->
-      let { loc; level = _; vars } = data in
-      match Var.Map.find_opt var vars with
-      | Some var_info -> Ok (var_info, data)
-      | None ->
-          let desc = CError_unknown_var_repr { var } in
-          Error (CError { loc; desc }, data))
-
-let with_loc loc f =
-  Context
-    (fun data ->
-      let { loc = initial_loc; level; vars } = data in
-      apply (f ()) { loc; level; vars } @@ fun content data ->
-      let { loc = _closing_loc; level; vars } = data in
-      Ok (content, { loc = initial_loc; level; vars }))
-
-let with_region f =
-  Context
-    (fun data ->
-      let { loc; level = initial_level; vars } = data in
-      let level = Level.next initial_level in
-      apply (f ()) { loc; level; vars } @@ fun content data ->
-      let { loc; level = _closing_level; vars } = data in
-      (* TODO: check no variable remaining on the level before closing *)
-      Ok (content, { loc; level = initial_level; vars }))
-
-(* TODO: duplicated code *)
-let with_var_rigid var f =
-  Context
-    (fun data ->
-      let { loc; level; vars } = data in
-      match Var.Map.mem var vars with
-      | true ->
-          let desc = CError_duplicated_var_rigid { var } in
-          Error (CError { loc; desc }, data)
-      | false ->
-          let info = V_rigid { level } in
-          let vars = Var.Map.add var info vars in
-          apply (f ()) { loc; level; vars } @@ fun content data ->
-          let { loc; level; vars } = data in
-          (* TODO: check variable did not escape it's scope *)
-          let vars = Var.Map.remove var vars in
-          Ok (content, { loc; level; vars }))
-
-(* TODO: duplicated code *)
-let with_var_alias var ~of_ f =
-  Context
-    (fun data ->
-      let { loc; level; vars } = data in
-      match Var.Map.mem var vars with
-      | true ->
-          let desc = CError_duplicated_var_alias { var } in
-          Error (CError { loc; desc }, data)
-      | false ->
-          let info = V_alias { var = of_ } in
-          let vars = Var.Map.add var info vars in
-          apply (f ()) { loc; level; vars } @@ fun content data ->
-          let { loc; level; vars } = data in
-          (* TODO: check variable did not escape it's scope *)
-          let vars = Var.Map.remove var vars in
-          Ok (content, { loc; level; vars }))
-
-let enter_var_hole var =
-  Context
-    (fun data ->
-      let { loc; level; vars } = data in
-      match Var.Map.mem var vars with
-      | true ->
-          let desc = CError_duplicated_var_hole { var } in
-          Error (CError { loc; desc }, data)
-      | false ->
-          let info = V_hole { level } in
-          let vars = Var.Map.add var info vars in
-          Ok ((), { loc; level; vars }))
-
-let var_link var ~to_ =
-  (* TODO: path compression *)
-  Context
-    (fun data ->
-      let { loc; level; vars } = data in
-      (* TODO: we could track substitution locations here for LSP *)
-      match Var.Map.find_opt var vars with
-      | Some (V_hole { level = _ }) ->
-          let info = V_link { type_ = to_ } in
-          let vars = Var.Map.add var info vars in
-          Ok ((), { loc; level; vars })
-      | Some ((V_rigid _ | V_alias _ | V_link _) as info) ->
-          let desc = CError_invalid_var_link { var; info } in
-          Error (CError { loc; desc }, data)
-      | None ->
-          let desc = CError_unknown_var_link { var } in
-          Error (CError { loc; desc }, data))
-
-let var_lower var ~to_ =
-  Context
-    (fun data ->
-      let { loc; level; vars } = data in
-      (* TODO: we could track lowering locations here for LSP *)
-      match Var.Map.find_opt var vars with
-      | Some (V_hole { level = hole_level }) -> (
-          match Level.(hole_level < to_) with
-          | true ->
-              let desc = CError_lowering_to_higher_level { var } in
-              Error (CError { loc; desc }, data)
-          | false ->
-              let info = V_hole { level = to_ } in
-              let vars = Var.Map.add var info vars in
-              Ok ((), { loc; level; vars }))
-      | Some ((V_rigid _ | V_alias _ | V_link _) as info) ->
-          let desc = CError_invalid_var_lower { var; info } in
-          Error (CError { loc; desc }, data)
-      | None ->
-          let desc = CError_unknown_var_lower { var } in
-          Error (CError { loc; desc }, data))
-
-let var_alias var ~of_ =
-  Context
-    (fun data ->
-      let { loc; level; vars } = data in
-      (* TODO: we could track lowering locations here for LSP *)
-      match Var.Map.find_opt var vars with
-      | Some (V_hole { level = _ }) ->
-          (* TODO: check level is equal or higher than of_ *)
-          let info = V_alias { var = of_ } in
-          let vars = Var.Map.add var info vars in
-          Ok ((), { loc; level; vars })
-      | Some ((V_rigid _ | V_alias _ | V_link _) as info) ->
-          let desc = CError_invalid_var_alias { var; info } in
-          Error (CError { loc; desc }, data)
-      | None ->
-          let desc = CError_unknown_var_alias { var } in
-          Error (CError { loc; desc }, data))
+  let[@inline always] with_binder f =
+    let context ~from ~to_ ~ok ~error =
+      let from = Offset.(from + one) in
+      let { context } = f () in
+      context ~from ~to_ ~ok ~error
+    in
+    { context }
+end

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -1,68 +1,32 @@
 open Ttree
 
-(* TODO: maybe call it var_desc? *)
-
-(** This describes which kind of variable are we dealing with
-      - V_rigid are universal variables, they cannot move
-      - V_alias are used when binding two rigid variables
-          it is also used when unifying two hole variables
-      - V_link are hole variables that were unified 
-      - V_hole are existential variables, they can move 
-          they can also be linked *)
-type var_info = private
-  | V_rigid of { level : Level.t }
-  | V_alias of { var : Var.t }
-  (* TODO: this shouldy be type_ : type_ *)
-  | V_link of { type_ : term_desc }
-  | V_hole of { level : Level.t }
-
 type error = private CError of { loc : Location.t; desc : error_desc }
+and error_desc = private |
 
-and error_desc = private
-  (* unification *)
-  | CError_occurs_check of { var : Var.t; in_ : Var.t }
-  | CError_escape_check of { var : Var.t; to_ : Var.t }
-  | CError_var_constrained of { var : Var.t; by_ : term_desc }
-  | CError_var_clash of { expected : Var.t; received : Var.t }
-  | CError_type_clash of { expected : term_desc; received : term_desc }
-  (* invariants *)
-  | CError_unknown_var_repr of { var : Var.t }
-  | CError_unknown_var_link of { var : Var.t }
-  | CError_unknown_var_lower of { var : Var.t }
-  | CError_unknown_var_alias of { var : Var.t }
-  | CError_duplicated_var_rigid of { var : Var.t }
-  | CError_duplicated_var_alias of { var : Var.t }
-  | CError_duplicated_var_hole of { var : Var.t }
-  | CError_invalid_var_link of { var : Var.t; info : var_info }
-  | CError_invalid_var_lower of { var : Var.t; info : var_info }
-  | CError_invalid_var_alias of { var : Var.t; info : var_info }
-  | CError_lowering_to_higher_level of { var : Var.t }
+module Subst_context : sig
+  type 'a subst_context
+  type 'a t = 'a subst_context
 
-type 'a context
-type 'a t = 'a context
+  (* monad *)
+  val test :
+    loc:Warnings.loc ->
+    from:Offset.offset ->
+    to_:term_desc ->
+    (unit -> 'a t) ->
+    ('a, error) result
 
-val return : 'a -> 'a context
-val ( >>= ) : 'a context -> ('a -> 'b context) -> 'b context
-val fail_occurs_check : Var.t -> in_:Var.t -> 'a context
-val fail_escape_check : Var.t -> to_:Var.t -> 'a context
-val fail_var_constrained : Var.t -> by_:term_desc -> 'a context
-val fail_var_clash : expected:Var.t -> received:Var.t -> 'a context
-val fail_type_clash : expected:term_desc -> received:term_desc -> 'a context
+  val return : 'a -> 'a subst_context
+  val bind : 'a subst_context -> ('a -> 'b subst_context) -> 'b subst_context
 
-(* read *)
-val loc : Location.t context
-val level : Level.t context
-val repr : Var.t -> var_info context
+  val ( let* ) :
+    'a subst_context -> ('a -> 'b subst_context) -> 'b subst_context
 
-(* update *)
-val with_loc : Location.t -> (unit -> 'a context) -> 'a context
-val with_region : (unit -> 'a context) -> 'a context
-val with_var_rigid : Var.t -> (unit -> 'a context) -> 'a context
-val with_var_alias : Var.t -> of_:Var.t -> (unit -> 'a context) -> 'a context
+  val ( let+ ) : 'a subst_context -> ('a -> 'b) -> 'b subst_context
 
-(* unification *)
-val enter_var_hole : Var.t -> unit context
-val var_link : Var.t -> to_:term_desc -> unit context
-val var_lower : Var.t -> to_:Level.t -> unit context
-val var_alias : Var.t -> of_:Var.t -> unit context
-(* TODO: generalize *)
+  (* from *)
+  val from : unit -> Offset.t subst_context
+  val with_binder : (unit -> 'a subst_context) -> 'a subst_context
+
+  (* to_ *)
+  val to_ : unit -> term_desc subst_context
+end

--- a/teika/dune
+++ b/teika/dune
@@ -2,7 +2,7 @@
  (name teika)
  (libraries menhirLib compiler-libs.common)
  (modules
-  (:standard \ Test Context Subst Unify Normalize))
+  (:standard \ Test Subst Unify Normalize))
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord sedlex.ppx)))
 

--- a/teika/dune
+++ b/teika/dune
@@ -2,7 +2,7 @@
  (name teika)
  (libraries menhirLib compiler-libs.common)
  (modules
-  (:standard \ Test Subst Unify Normalize))
+  (:standard \ Test Unify Normalize))
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord sedlex.ppx)))
 

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -1,99 +1,70 @@
 open Ttree
+open Context
+open Subst_context
 
-let rec subst_term ~from ~to_ term =
+(* TODO: also do substitution using mutation *)
+let rec subst_term term =
   let (TTerm { loc; desc; type_ }) = term in
-  let desc = subst_desc ~from ~to_ desc in
+  let+ desc = subst_desc desc in
   TTerm { loc; desc; type_ }
 
-and subst_type ~from ~to_ type_ =
+and subst_type type_ =
   let (TType { loc; desc }) = type_ in
-  let desc = subst_desc ~from ~to_ desc in
+  let+ desc = subst_desc desc in
   TType { loc; desc }
 
-and subst_annot ~from ~to_ annot =
+and subst_annot : type a. _ -> (_ -> a subst_context) -> a subst_context =
+ fun annot k ->
   let (TAnnot { loc; var; annot }) = annot in
-  let annot = subst_type ~from ~to_ annot in
-  (var, tannot loc ~var ~annot)
+  let* annot = subst_type annot in
+  with_binder @@ fun () -> k (tannot loc ~var ~annot)
 
-and subst_bind ~from ~to_ bind =
+and subst_bind : type a. _ -> (_ -> a subst_context) -> a subst_context =
+ fun bind k ->
   let (TBind { loc; var; value }) = bind in
-  let value = subst_term ~from ~to_ value in
-  (var, tbind loc ~var ~value)
+  let* value = subst_term value in
+  with_binder @@ fun () -> k (tbind loc ~var ~value)
 
-and subst_desc ~from ~to_ desc =
-  let subst_term term = subst_term ~from ~to_ term in
-  let subst_type type_ = subst_type ~from ~to_ type_ in
-  let subst_annot annot = subst_annot ~from ~to_ annot in
-  let subst_bind bind = subst_bind ~from ~to_ bind in
+and subst_desc desc =
   match desc with
-  | TT_var { var } -> (
-      match Var.equal from var with true -> to_ | false -> TT_var { var })
+  | TT_var { offset } -> (
+      let* from = from () in
+      let+ to_ = to_ () in
+      match Offset.equal from offset with
+      | true -> to_
+      | false -> TT_var { offset })
   | TT_forall { param; return } ->
-      let var, param = subst_annot param in
-      let return =
-        match Var.equal from var with
-        | true -> return
-        | false -> subst_type return
-      in
+      subst_annot param @@ fun param ->
+      let+ return = subst_type return in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let var, param = subst_annot param in
-      let return =
-        match Var.equal from var with
-        | true -> return
-        | false -> subst_term return
-      in
+      subst_annot param @@ fun param ->
+      let+ return = subst_term return in
       TT_lambda { param; return }
   | TT_apply { lambda; arg } ->
-      let lambda = subst_term lambda in
-      let arg = subst_term arg in
+      let* lambda = subst_term lambda in
+      let+ arg = subst_term arg in
       TT_apply { lambda; arg }
   | TT_exists { left; right } ->
-      let var, left = subst_annot left in
-      let right =
-        match Var.equal from var with
-        | true -> right
-        | false ->
-            let _var, right = subst_annot right in
-            right
-      in
-      TT_exists { left; right }
+      subst_annot left @@ fun left ->
+      subst_annot right @@ fun right -> return @@ TT_exists { left; right }
   | TT_pair { left; right } ->
-      let var, left = subst_bind left in
-      let right =
-        match Var.equal from var with
-        | true -> right
-        | false ->
-            let _var, right = subst_bind right in
-            right
-      in
-      TT_pair { left; right }
+      subst_bind left @@ fun left ->
+      subst_bind right @@ fun right -> return @@ TT_pair { left; right }
   | TT_unpair { left; right; pair; return } ->
-      let pair = subst_term pair in
-      let return =
-        (* TODO: is this guard needed? *)
-        match Var.equal from left || Var.equal from right with
-        | true -> return
-        | false -> subst_term return
-      in
+      let* pair = subst_term pair in
+      with_binder @@ fun () ->
+      with_binder @@ fun () ->
+      let+ return = subst_term return in
       TT_unpair { left; right; pair; return }
   | TT_let { bound; return } ->
-      let var, bound = subst_bind bound in
-      let return =
-        match Var.equal from var with
-        | true -> return
-        | false -> subst_term return
-      in
+      subst_bind bound @@ fun bound ->
+      let+ return = subst_term return in
       TT_let { bound; return }
   | TT_annot { value; annot } ->
-      let annot = subst_type annot in
-      let value = subst_term value in
+      let* annot = subst_type annot in
+      let+ value = subst_term value in
       TT_annot { value; annot }
 
-let subst_annot ~from ~to_ annot =
-  let _var, annot = subst_annot ~from ~to_ annot in
-  annot
-
-let subst_bind ~from ~to_ bind =
-  let _var, bind = subst_bind ~from ~to_ bind in
-  bind
+let subst_annot annot = subst_annot annot @@ fun annot -> return @@ annot
+let subst_bind bind = subst_bind bind @@ fun bind -> return @@ bind

--- a/teika/subst.mli
+++ b/teika/subst.mli
@@ -1,7 +1,8 @@
 open Ttree
+open Context
 
-val subst_term : from:Var.t -> to_:term_desc -> term -> term
-val subst_type : from:Var.t -> to_:term_desc -> type_ -> type_
-val subst_desc : from:Var.t -> to_:term_desc -> term_desc -> term_desc
-val subst_annot : from:Var.t -> to_:term_desc -> annot -> annot
-val subst_bind : from:Var.t -> to_:term_desc -> bind -> bind
+val subst_term : term -> term Subst_context.t
+val subst_type : type_ -> type_ Subst_context.t
+val subst_desc : term_desc -> term_desc Subst_context.t
+val subst_annot : annot -> annot Subst_context.t
+val subst_bind : bind -> bind Subst_context.t


### PR DESCRIPTION
## Goals

Fix the regression introduced by #72.

## Context

#72 disabled a couple modules, due to the major change in tree representation. This PR enables substitution again and add a context specific for unification, while this context is not particularly useful now as soon as we add unification back, it will drastically simplify the code.