### PR TITLE
teika: reenable term normalization

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -30,3 +30,40 @@ module Subst_context : sig
   (* to_ *)
   val to_ : unit -> term_desc subst_context
 end
+
+module Normalize_context (Subst : sig
+  val subst_term : term -> term Subst_context.t
+  val subst_type : type_ -> type_ Subst_context.t
+  val subst_desc : term_desc -> term_desc Subst_context.t
+  val subst_annot : annot -> annot Subst_context.t
+  val subst_bind : bind -> bind Subst_context.t
+end) : sig
+  type 'a normalize_context
+  type 'a t = 'a normalize_context
+
+  (* monad *)
+  val test : loc:Warnings.loc -> (unit -> 'a t) -> ('a, error) result
+  val return : 'a -> 'a normalize_context
+
+  val bind :
+    'a normalize_context -> ('a -> 'b normalize_context) -> 'b normalize_context
+
+  val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+  val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+
+  (* subst *)
+  val subst_term :
+    from:Offset.t -> to_:term_desc -> term -> term normalize_context
+
+  val subst_type :
+    from:Offset.t -> to_:term_desc -> type_ -> type_ normalize_context
+
+  val subst_desc :
+    from:Offset.t -> to_:term_desc -> term_desc -> term_desc normalize_context
+
+  val subst_annot :
+    from:Offset.t -> to_:term_desc -> annot -> annot normalize_context
+
+  val subst_bind :
+    from:Offset.t -> to_:term_desc -> bind -> bind normalize_context
+end

--- a/teika/dune
+++ b/teika/dune
@@ -2,7 +2,7 @@
  (name teika)
  (libraries menhirLib compiler-libs.common)
  (modules
-  (:standard \ Test Unify Normalize))
+  (:standard \ Test Unify))
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord sedlex.ppx)))
 

--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -1,42 +1,43 @@
 open Ttree
-open Subst
+module Normalize_context = Context.Normalize_context (Subst)
+open Normalize_context
 
 let rec normalize_term term =
   let (TTerm { loc; desc; type_ }) = term in
-  let type_ = normalize_type type_ in
-  let desc = normalize_desc desc in
+  let* type_ = normalize_type type_ in
+  let+ desc = normalize_desc desc in
   TTerm { loc; desc; type_ }
 
 and normalize_type type_ =
   let (TType { loc; desc }) = type_ in
-  let desc = normalize_desc desc in
+  let+ desc = normalize_desc desc in
   TType { loc; desc }
 
 and normalize_annot annot =
   let (TAnnot { loc; var; annot }) = annot in
-  let annot = normalize_type annot in
+  let+ annot = normalize_type annot in
   tannot loc ~var ~annot
 
 and normalize_bind bind =
   let (TBind { loc; var; value }) = bind in
-  let value = normalize_term value in
+  let+ value = normalize_term value in
   let (TTerm { loc = _; desc = value_desc; type_ = _ }) = value in
-  (var, value_desc, tbind loc ~var ~value)
+  (value_desc, tbind loc ~var ~value)
 
 and normalize_desc desc =
   match desc with
-  | TT_var { var } -> TT_var { var }
+  | TT_var { offset } -> return @@ TT_var { offset }
   | TT_forall { param; return } ->
-      let param = normalize_annot param in
-      let return = normalize_type return in
+      let* param = normalize_annot param in
+      let+ return = normalize_type return in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = normalize_annot param in
-      let return = normalize_term return in
+      let* param = normalize_annot param in
+      let+ return = normalize_term return in
       TT_lambda { param; return }
   | TT_apply { lambda; arg } -> (
-      let lambda = normalize_term lambda in
-      let arg = normalize_term arg in
+      let* lambda = normalize_term lambda in
+      let* arg = normalize_term arg in
       match
         let (TTerm { loc = _; desc; type_ = _ }) = lambda in
         desc
@@ -44,21 +45,22 @@ and normalize_desc desc =
       | TT_lambda { param; return } ->
           let (TTerm { loc = _; desc = return; type_ = _ }) = return in
           let (TTerm { loc = _; desc = arg; type_ = _ }) = arg in
-          let (TAnnot { loc = _; var; annot = _ }) = param in
-          normalize_desc @@ subst_desc ~from:var ~to_:arg return
-      | _ -> TT_apply { lambda; arg })
+          let (TAnnot { loc = _; var = _; annot = _ }) = param in
+          let* return = subst_desc ~from:Offset.zero ~to_:arg return in
+          normalize_desc return
+      | _ -> return @@ TT_apply { lambda; arg })
   | TT_exists { left; right } ->
-      let left = normalize_annot left in
-      let right = normalize_annot right in
+      let* left = normalize_annot left in
+      let+ right = normalize_annot right in
       TT_exists { left; right }
   | TT_pair { left; right } ->
-      let var, desc, left = normalize_bind left in
-      let right = subst_bind ~from:var ~to_:desc right in
-      let _var, _desc, right = normalize_bind right in
+      let* desc, left = normalize_bind left in
+      let* right = subst_bind ~from:Offset.zero ~to_:desc right in
+      let+ _desc, right = normalize_bind right in
       TT_pair { left; right }
   | TT_unpair { left; right; pair; return } -> (
-      let pair = normalize_term pair in
-      let return = normalize_term return in
+      let* pair = normalize_term pair in
+      let* return = normalize_term return in
       match
         let (TTerm { loc = _; desc; type_ = _ }) = pair in
         desc
@@ -69,13 +71,15 @@ and normalize_desc desc =
           let (TBind { loc = _; var = _; value = right_value }) = right_bind in
           let (TTerm { loc = _; desc = right_desc; type_ = _ }) = right_value in
           let (TTerm { loc = _; desc = return; type_ = _ }) = return in
-          let return = subst_desc ~from:left ~to_:left_desc return in
-          subst_desc ~from:right ~to_:right_desc return
-      | _ -> TT_unpair { left; right; pair; return })
+          let* return = subst_desc ~from:Offset.one ~to_:left_desc return in
+          subst_desc ~from:Offset.zero ~to_:right_desc return
+      | _ -> Normalize_context.return @@ TT_unpair { left; right; pair; return }
+      )
   | TT_let { bound; return } ->
-      let var, desc, _bound = normalize_bind bound in
+      let* desc, _bound = normalize_bind bound in
       let (TTerm { loc = _; desc = return; type_ = _ }) = return in
-      normalize_desc @@ subst_desc ~from:var ~to_:desc return
+      let* return = subst_desc ~from:Offset.zero ~to_:desc return in
+      normalize_desc return
   | TT_annot { value; annot = _ } ->
       let (TTerm { loc = _; desc = value; type_ = _ }) = value in
       normalize_desc value

--- a/teika/normalize.mli
+++ b/teika/normalize.mli
@@ -1,4 +1,5 @@
 open Ttree
+open Context
 
-val normalize_term : term -> term
-val normalize_type : type_ -> type_
+val normalize_term : term -> term Normalize_context(Subst).t
+val normalize_type : type_ -> type_ Normalize_context(Subst).t


### PR DESCRIPTION
## Goals

Fix the regression introduced by https://github.com/teikalang/teika/pull/72.

## Context

#72 disabled a couple modules, due to the major change in tree representation. This PR enables substitution again and add a context specific for normalization, while this context is not useful now as soon as we add unification back, it will drastically simplify the code.