### PR TITLE
teika: implements term instantiation

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -16,7 +16,7 @@ module Subst_context : sig
     loc:Warnings.loc ->
     from:Offset.offset ->
     to_:term_desc ->
-    (unit -> 'a t) ->
+    (unit -> 'a subst_context) ->
     ('a, error) result
 
   val return : 'a -> 'a subst_context
@@ -46,14 +46,18 @@ end) : sig
   type 'a t = 'a normalize_context
 
   (* monad *)
-  val test : loc:Warnings.loc -> (unit -> 'a t) -> ('a, error) result
+  val test :
+    loc:Warnings.loc -> (unit -> 'a normalize_context) -> ('a, error) result
+
   val return : 'a -> 'a normalize_context
 
   val bind :
     'a normalize_context -> ('a -> 'b normalize_context) -> 'b normalize_context
 
-  val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
-  val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+  val ( let* ) :
+    'a normalize_context -> ('a -> 'b normalize_context) -> 'b normalize_context
+
+  val ( let+ ) : 'a normalize_context -> ('a -> 'b) -> 'b normalize_context
 
   (* subst *)
   val subst_term :
@@ -87,7 +91,9 @@ end) : sig
   type 'a t = 'a unify_context
 
   (* monad *)
-  val test : loc:Warnings.loc -> (unit -> 'a t) -> ('a, error) result
+  val test :
+    loc:Warnings.loc -> (unit -> 'a unify_context) -> ('a, error) result
+
   val return : 'a -> 'a unify_context
   val bind : 'a unify_context -> ('a -> 'b unify_context) -> 'b unify_context
 
@@ -106,4 +112,29 @@ end) : sig
   (* normalize *)
   val normalize_term : term -> term unify_context
   val normalize_type : type_ -> type_ unify_context
+end
+
+module Instance_context : sig
+  type 'a instance_context
+  type 'a t = 'a instance_context
+
+  (* monad *)
+  val test :
+    loc:Warnings.loc ->
+    offset:Offset.t ->
+    (unit -> 'a instance_context) ->
+    ('a, error) result
+
+  val return : 'a -> 'a instance_context
+
+  val bind :
+    'a instance_context -> ('a -> 'b instance_context) -> 'b instance_context
+
+  val ( let* ) :
+    'a instance_context -> ('a -> 'b instance_context) -> 'b instance_context
+
+  val ( let+ ) : 'a instance_context -> ('a -> 'b) -> 'b instance_context
+
+  (* monad *)
+  val offset : unit -> Offset.t instance_context
 end

--- a/teika/instance.ml
+++ b/teika/instance.ml
@@ -1,0 +1,63 @@
+open Ttree
+open Context
+open Instance_context
+
+(* TODO: also do substitution using mutation *)
+let rec instance_term term =
+  let (TTerm { loc; desc; type_ }) = term in
+  let+ desc = instance_desc desc in
+  TTerm { loc; desc; type_ }
+
+and instance_type type_ =
+  let (TType { loc; desc }) = type_ in
+  let+ desc = instance_desc desc in
+  TType { loc; desc }
+
+and instance_annot annot =
+  let (TAnnot { loc; var; annot }) = annot in
+  let+ annot = instance_type annot in
+  tannot loc ~var ~annot
+
+and instance_bind bind =
+  let (TBind { loc; var; value }) = bind in
+  let+ value = instance_term value in
+  tbind loc ~var ~value
+
+and instance_desc desc =
+  match desc with
+  | TT_var { offset = var_offset } ->
+      let+ offset = offset () in
+      let offset = Offset.(var_offset + offset) in
+      TT_var { offset }
+  | TT_forall { param; return } ->
+      let* param = instance_annot param in
+      let+ return = instance_type return in
+      TT_forall { param; return }
+  | TT_lambda { param; return } ->
+      let* param = instance_annot param in
+      let+ return = instance_term return in
+      TT_lambda { param; return }
+  | TT_apply { lambda; arg } ->
+      let* lambda = instance_term lambda in
+      let+ arg = instance_term arg in
+      TT_apply { lambda; arg }
+  | TT_exists { left; right } ->
+      let* left = instance_annot left in
+      let* right = instance_annot right in
+      return @@ TT_exists { left; right }
+  | TT_pair { left; right } ->
+      let* left = instance_bind left in
+      let* right = instance_bind right in
+      return @@ TT_pair { left; right }
+  | TT_unpair { left; right; pair; return } ->
+      let* pair = instance_term pair in
+      let+ return = instance_term return in
+      TT_unpair { left; right; pair; return }
+  | TT_let { bound; return } ->
+      let* bound = instance_bind bound in
+      let+ return = instance_term return in
+      TT_let { bound; return }
+  | TT_annot { value; annot } ->
+      let* annot = instance_type annot in
+      let+ value = instance_term value in
+      TT_annot { value; annot }

--- a/teika/instance.mli
+++ b/teika/instance.mli
@@ -1,0 +1,5 @@
+open Ttree
+open Context
+
+val instance_term : term -> term Instance_context.t
+val instance_type : type_ -> type_ Instance_context.t


### PR DESCRIPTION
## Goals

Support proper variable instantiation.

## Context

We use de bruijin index to represent variables this means that whenever a variable is mentioned we need to find the offset to it's declaration, this is done through instantiation. Instantiation will also be used in the future for implicit application of type variables.