### PR TITLE
teika: use context for elimination on normalize

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -122,40 +122,35 @@ end
 
 module Normalize_context (Instance : sig
   val instance_desc : term_desc -> term_desc Instance_context.t
-end) (Subst : sig
-  val subst_term : term -> term Subst_context(Instance).t
-  val subst_type : type_ -> type_ Subst_context(Instance).t
-  val subst_desc : term_desc -> term_desc Subst_context(Instance).t
-  val subst_annot : annot -> annot Subst_context(Instance).t
-  val subst_bind : bind -> bind Subst_context(Instance).t
 end) =
 struct
   type 'a normalize_context = {
     (* TODO: accumulate locations during normalization *)
-    context : 'k. ok:('a -> 'k) -> error:(error_desc -> 'k) -> 'k;
+    context :
+      'k. vars:term_desc list -> ok:('a -> 'k) -> error:(error_desc -> 'k) -> 'k;
   }
   [@@ocaml.unboxed]
 
   type 'a t = 'a normalize_context
 
-  let[@inline always] test ~loc f =
+  let[@inline always] test ~loc ~vars f =
     let { context } = f () in
     let ok value = Ok value in
     let error desc = Error (CError { loc; desc }) in
-    context ~ok ~error
+    context ~vars ~ok ~error
 
   let[@inline always] return value =
-    let context ~ok ~error:_ = ok value in
+    let context ~vars:_ ~ok ~error:_ = ok value in
     { context }
 
   let[@inline always] bind context f =
     let { context } = context in
-    let context ~ok ~error =
+    let context ~vars ~ok ~error =
       let ok data =
         let { context } = f data in
-        context ~ok ~error
+        context ~vars ~ok ~error
       in
-      context ~ok ~error
+      context ~vars ~ok ~error
     in
     { context }
 
@@ -165,47 +160,45 @@ struct
     let* value = context in
     return @@ f value
 
-  module Subst_context = Subst_context (Instance)
-
-  let[@inline always] with_subst_context ~from ~to_ f =
-    let context ~ok ~error =
-      let Subst_context.{ context } = f () in
-      (* TODO: is this always right? *)
-      let offset = Offset.zero in
-      context ~offset ~from ~to_ ~ok ~error
+  let repr_var ~var =
+    let context ~vars ~ok ~error =
+      match
+        let index = Offset.repr var - 1 in
+        List.nth_opt vars index
+      with
+      | Some desc ->
+          let Instance_context.{ context } = Instance.instance_desc desc in
+          context ~offset:var ~ok ~error
+      | None -> ok (TT_var { offset = var })
     in
     { context }
 
-  let[@inline always] subst_term ~from ~to_ term =
-    with_subst_context ~from ~to_ @@ fun () -> Subst.subst_term term
+  let with_var f =
+    let context ~vars ~ok ~error =
+      let offset = Offset.zero in
+      let vars = TT_var { offset } :: vars in
+      let { context } = f () in
+      context ~vars ~ok ~error
+    in
+    { context }
 
-  let[@inline always] subst_type ~from ~to_ type_ =
-    with_subst_context ~from ~to_ @@ fun () -> Subst.subst_type type_
-
-  let[@inline always] subst_desc ~from ~to_ desc =
-    with_subst_context ~from ~to_ @@ fun () -> Subst.subst_desc desc
-
-  let[@inline always] subst_annot ~from ~to_ annot =
-    with_subst_context ~from ~to_ @@ fun () -> Subst.subst_annot annot
-
-  let[@inline always] subst_bind ~from ~to_ bind =
-    with_subst_context ~from ~to_ @@ fun () -> Subst.subst_bind bind
+  let elim_var ~to_ f =
+    let context ~vars ~ok ~error =
+      let vars = to_ :: vars in
+      let { context } = f () in
+      context ~vars ~ok ~error
+    in
+    { context }
 end
 
 module Unify_context (Instance : sig
   val instance_desc : term_desc -> term_desc Instance_context.t
-end) (Subst : sig
-  val subst_term : term -> term Subst_context(Instance).t
-  val subst_type : type_ -> type_ Subst_context(Instance).t
-  val subst_desc : term_desc -> term_desc Subst_context(Instance).t
-  val subst_annot : annot -> annot Subst_context(Instance).t
-  val subst_bind : bind -> bind Subst_context(Instance).t
 end) (Normalize : sig
-  val normalize_term : term -> term Normalize_context(Instance)(Subst).t
-  val normalize_type : type_ -> type_ Normalize_context(Instance)(Subst).t
+  val normalize_term : term -> term Normalize_context(Instance).t
+  val normalize_type : type_ -> type_ Normalize_context(Instance).t
 end) =
 struct
-  module Normalize_context = Normalize_context (Instance) (Subst)
+  module Normalize_context = Normalize_context (Instance)
 
   type 'a unify_context = {
     (* TODO: accumulate locations during unification *)
@@ -257,7 +250,7 @@ struct
   let[@inline always] with_normalize_context f =
     let context ~ok ~error =
       let Normalize_context.{ context } = f () in
-      context ~ok ~error
+      context ~vars:[] ~ok ~error
     in
     { context }
 
@@ -273,19 +266,15 @@ module Typer_context (Instance : sig
   val instance_type : type_ -> type_ Instance_context.t
   val instance_desc : term_desc -> term_desc Instance_context.t
 end) (Subst : sig
-  val subst_term : term -> term Subst_context(Instance).t
   val subst_type : type_ -> type_ Subst_context(Instance).t
-  val subst_desc : term_desc -> term_desc Subst_context(Instance).t
-  val subst_annot : annot -> annot Subst_context(Instance).t
-  val subst_bind : bind -> bind Subst_context(Instance).t
 end) (Normalize : sig
-  val normalize_term : term -> term Normalize_context(Instance)(Subst).t
-  val normalize_type : type_ -> type_ Normalize_context(Instance)(Subst).t
+  val normalize_term : term -> term Normalize_context(Instance).t
+  val normalize_type : type_ -> type_ Normalize_context(Instance).t
 end) (Unify : sig
   val unify_type :
     expected:type_ ->
     received:type_ ->
-    unit Unify_context(Instance)(Subst)(Normalize).t
+    unit Unify_context(Instance)(Normalize).t
 end) =
 struct
   type 'a typer_context = {
@@ -407,7 +396,7 @@ struct
     in
     { context }
 
-  module Unify_context = Unify_context (Instance) (Subst) (Normalize)
+  module Unify_context = Unify_context (Instance) (Normalize)
 
   let unify_type ~expected ~received =
     let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -70,19 +70,16 @@ end
 
 module Normalize_context (Instance : sig
   val instance_desc : term_desc -> term_desc Instance_context.t
-end) (Subst : sig
-  val subst_term : term -> term Subst_context(Instance).t
-  val subst_type : type_ -> type_ Subst_context(Instance).t
-  val subst_desc : term_desc -> term_desc Subst_context(Instance).t
-  val subst_annot : annot -> annot Subst_context(Instance).t
-  val subst_bind : bind -> bind Subst_context(Instance).t
 end) : sig
   type 'a normalize_context
   type 'a t = 'a normalize_context
 
   (* monad *)
   val test :
-    loc:Warnings.loc -> (unit -> 'a normalize_context) -> ('a, error) result
+    loc:Warnings.loc ->
+    vars:term_desc list ->
+    (unit -> 'a normalize_context) ->
+    ('a, error) result
 
   val return : 'a -> 'a normalize_context
 
@@ -94,35 +91,20 @@ end) : sig
 
   val ( let+ ) : 'a normalize_context -> ('a -> 'b) -> 'b normalize_context
 
-  (* subst *)
-  val subst_term :
-    from:Offset.t -> to_:term_desc -> term -> term normalize_context
+  (* vars *)
+  val repr_var : var:Offset.t -> term_desc normalize_context
+  val with_var : (unit -> 'a normalize_context) -> 'a normalize_context
 
-  val subst_type :
-    from:Offset.t -> to_:term_desc -> type_ -> type_ normalize_context
-
-  val subst_desc :
-    from:Offset.t -> to_:term_desc -> term_desc -> term_desc normalize_context
-
-  val subst_annot :
-    from:Offset.t -> to_:term_desc -> annot -> annot normalize_context
-
-  val subst_bind :
-    from:Offset.t -> to_:term_desc -> bind -> bind normalize_context
+  val elim_var :
+    to_:term_desc -> (unit -> 'a normalize_context) -> 'a normalize_context
 end
 
 (* TODO: this is bad *)
 module Unify_context (Instance : sig
   val instance_desc : term_desc -> term_desc Instance_context.t
-end) (Subst : sig
-  val subst_term : term -> term Subst_context(Instance).t
-  val subst_type : type_ -> type_ Subst_context(Instance).t
-  val subst_desc : term_desc -> term_desc Subst_context(Instance).t
-  val subst_annot : annot -> annot Subst_context(Instance).t
-  val subst_bind : bind -> bind Subst_context(Instance).t
 end) (Normalize : sig
-  val normalize_term : term -> term Normalize_context(Instance)(Subst).t
-  val normalize_type : type_ -> type_ Normalize_context(Instance)(Subst).t
+  val normalize_term : term -> term Normalize_context(Instance).t
+  val normalize_type : type_ -> type_ Normalize_context(Instance).t
 end) : sig
   type 'a unify_context
   type 'a t = 'a unify_context
@@ -156,19 +138,15 @@ module Typer_context (Instance : sig
   val instance_type : type_ -> type_ Instance_context.t
   val instance_desc : term_desc -> term_desc Instance_context.t
 end) (Subst : sig
-  val subst_term : term -> term Subst_context(Instance).t
   val subst_type : type_ -> type_ Subst_context(Instance).t
-  val subst_desc : term_desc -> term_desc Subst_context(Instance).t
-  val subst_annot : annot -> annot Subst_context(Instance).t
-  val subst_bind : bind -> bind Subst_context(Instance).t
 end) (Normalize : sig
-  val normalize_term : term -> term Normalize_context(Instance)(Subst).t
-  val normalize_type : type_ -> type_ Normalize_context(Instance)(Subst).t
+  val normalize_term : term -> term Normalize_context(Instance).t
+  val normalize_type : type_ -> type_ Normalize_context(Instance).t
 end) (Unify : sig
   val unify_type :
     expected:type_ ->
     received:type_ ->
-    unit Unify_context(Instance)(Subst)(Normalize).t
+    unit Unify_context(Instance)(Normalize).t
 end) : sig
   type 'a typer_context
   type 'a t = 'a typer_context

--- a/teika/normalize.mli
+++ b/teika/normalize.mli
@@ -1,5 +1,5 @@
 open Ttree
 open Context
 
-val normalize_term : term -> term Normalize_context(Instance)(Subst).t
-val normalize_type : type_ -> type_ Normalize_context(Instance)(Subst).t
+val normalize_term : term -> term Normalize_context(Instance).t
+val normalize_type : type_ -> type_ Normalize_context(Instance).t

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,3 +1,6 @@
+(* TODO: to avoid normalizing many times,
+    makes normalization cached, with unification this
+    means that this cache will probably be dependent on holes *)
 (* TODO: make this private again *)
 type term = TTerm of { loc : Location.t; desc : term_desc; type_ : type_ }
 and type_ = TType of { loc : Location.t; desc : term_desc }

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -1,5 +1,5 @@
 open Ttree
-module Unify_context = Context.Unify_context (Instance) (Subst) (Normalize)
+module Unify_context = Context.Unify_context (Instance) (Normalize)
 open Unify_context
 
 (* TODO: ensure this is eliminated *)

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -2,11 +2,7 @@ open Ttree
 open Context
 
 val unify_term :
-  expected:term ->
-  received:term ->
-  unit Unify_context(Instance)(Subst)(Normalize).t
+  expected:term -> received:term -> unit Unify_context(Instance)(Normalize).t
 
 val unify_type :
-  expected:type_ ->
-  received:type_ ->
-  unit Unify_context(Instance)(Subst)(Normalize).t
+  expected:type_ -> received:type_ -> unit Unify_context(Instance)(Normalize).t


### PR DESCRIPTION
## Goals

Optimize normalize and relies less on substitution.

## Context

Currently we do normalization through substitution instead of through context, this makes normalization much slower and complex, probably `O(n²)` as substitution relies on instantiation, additionally relying on substitution means that we have even more code to maintain and ideally substitution should be removed.