### PR TITLE
teika: add simple patterns aka destructuring

### DIFF
--- a/teika/ltree.ml
+++ b/teika/ltree.ml
@@ -7,14 +7,22 @@ and term_desc =
   | LT_apply of { lambda : term; arg : term }
   | LT_exists of { left : annot; right : annot }
   | LT_pair of { left : bind; right : bind }
-  | LT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
   | LT_let of { bound : bind; return : term }
   | LT_annot of { value : term; annot : term }
 
-and annot =
-  | LAnnot of { loc : Location.t; [@opaque] var : Name.t; annot : term }
+and pat = LPat of { loc : Location.t; [@opaque] desc : pat_desc }
 
-and bind = LBind of { loc : Location.t; [@opaque] var : Name.t; value : term }
+and pat_desc =
+  (* x *)
+  | LP_var of { var : Name.t }
+  (* (x, y) *)
+  | LP_pair of { left : pat; right : pat }
+  (* (p : T) *)
+  | LP_annot of { pat : pat; annot : term }
+
+and annot = LAnnot of { loc : Location.t; [@opaque] pat : pat; annot : term }
+
+and bind = LBind of { loc : Location.t; [@opaque] pat : pat; value : term }
 [@@deriving show]
 
 (* term *)
@@ -25,15 +33,17 @@ let lt_lambda loc ~param ~return = lterm loc (LT_lambda { param; return })
 let lt_apply loc ~lambda ~arg = lterm loc (LT_apply { lambda; arg })
 let lt_exists loc ~left ~right = lterm loc (LT_exists { left; right })
 let lt_pair loc ~left ~right = lterm loc (LT_pair { left; right })
-
-let lt_unpair loc ~left ~right ~pair ~return =
-  lterm loc (LT_unpair { left; right; pair; return })
-
 let lt_let loc ~bound ~return = lterm loc (LT_let { bound; return })
 let lt_annot loc ~value ~annot = lterm loc (LT_annot { value; annot })
 
+(* pattern *)
+let lpat loc desc = LPat { loc; desc }
+let lp_var loc ~var = lpat loc (LP_var { var })
+let lp_pair loc ~left ~right = lpat loc (LP_pair { left; right })
+let lp_annot loc ~pat ~annot = lpat loc (LP_annot { pat; annot })
+
 (* annot *)
-let lannot loc ~var ~annot = LAnnot { loc; var; annot }
+let lannot loc ~pat ~annot = LAnnot { loc; pat; annot }
 
 (* bind *)
-let lbind loc ~var ~value = LBind { loc; var; value }
+let lbind loc ~pat ~value = LBind { loc; pat; value }

--- a/teika/ltree.mli
+++ b/teika/ltree.mli
@@ -13,16 +13,25 @@ and term_desc = private
   | LT_exists of { left : annot; right : annot }
   (* (x = 0, y = 0) *)
   | LT_pair of { left : bind; right : bind }
-  (* (x, y) = v; r *)
-  | LT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
-  (* x = v; r *)
+  (* p = v; r *)
   | LT_let of { bound : bind; return : term }
-  (* v : T *)
+  (* (v : T) *)
   | LT_annot of { value : term; annot : term }
 
-and annot = private LAnnot of { loc : Location.t; var : Name.t; annot : term }
+and pat = private LPat of { loc : Location.t; desc : pat_desc }
 
-and bind = private LBind of { loc : Location.t; var : Name.t; value : term }
+and pat_desc = private
+  (* x *)
+  | LP_var of { var : Name.t }
+  (* (x, y) *)
+  | LP_pair of { left : pat; right : pat }
+  (* (p : T) *)
+  | LP_annot of { pat : pat; annot : term }
+
+(* TODO: rename to LAnnotation? *)
+and annot = private LAnnot of { loc : Location.t; pat : pat; annot : term }
+
+and bind = private LBind of { loc : Location.t; pat : pat; value : term }
 [@@deriving show]
 
 (* term *)
@@ -32,15 +41,16 @@ val lt_lambda : Location.t -> param:annot -> return:term -> term
 val lt_apply : Location.t -> lambda:term -> arg:term -> term
 val lt_exists : Location.t -> left:annot -> right:annot -> term
 val lt_pair : Location.t -> left:bind -> right:bind -> term
-
-val lt_unpair :
-  Location.t -> left:Name.t -> right:Name.t -> pair:term -> return:term -> term
-
 val lt_let : Location.t -> bound:bind -> return:term -> term
 val lt_annot : Location.t -> value:term -> annot:term -> term
 
+(* pattern *)
+val lp_var : Location.t -> var:Name.t -> pat
+val lp_pair : Location.t -> left:pat -> right:pat -> pat
+val lp_annot : Location.t -> pat:pat -> annot:term -> pat
+
 (* annot *)
-val lannot : Location.t -> var:Name.t -> annot:term -> annot
+val lannot : Location.t -> pat:pat -> annot:term -> annot
 
 (* bind *)
-val lbind : Location.t -> var:Name.t -> value:term -> bind
+val lbind : Location.t -> pat:pat -> value:term -> bind

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -15,15 +15,20 @@ and term_desc =
   | TT_apply of { lambda : term; arg : term }
   | TT_exists of { left : annot; right : annot }
   | TT_pair of { left : bind; right : bind }
-  | TT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
   | TT_let of { bound : bind; return : term }
   | TT_annot of { value : term; annot : type_ }
   | TT_offset of { desc : term_desc; offset : Offset.t }
 
-and annot =
-  | TAnnot of { loc : Location.t; [@opaque] var : Name.t; annot : type_ }
+and pat =
+  | TPat of { loc : Location.t; [@opaque] desc : pat_desc; type_ : type_ }
 
-and bind = TBind of { loc : Location.t; [@opaque] var : Name.t; value : term }
+and pat_desc =
+  | TP_var of { var : Name.t }
+  | TP_pair of { left : pat; right : pat }
+  | TP_annot of { pat : pat; annot : type_ }
+
+and annot = TAnnot of { loc : Location.t; [@opaque] pat : pat; annot : type_ }
+and bind = TBind of { loc : Location.t; [@opaque] pat : pat; value : term }
 
 (* term *)
 let tterm loc type_ desc = TTerm { loc; desc; type_ }
@@ -37,15 +42,17 @@ let tt_lambda loc type_ ~param ~return =
 let tt_apply loc type_ ~lambda ~arg = tterm loc type_ (TT_apply { lambda; arg })
 let tt_exists loc ~left ~right = ttype loc (TT_exists { left; right })
 let tt_pair loc type_ ~left ~right = tterm loc type_ (TT_pair { left; right })
-
-let tt_unpair loc type_ ~left ~right ~pair ~return =
-  tterm loc type_ (TT_unpair { left; right; pair; return })
-
 let tt_let loc type_ ~bound ~return = tterm loc type_ (TT_let { bound; return })
 let tt_annot loc ~value ~annot = tterm loc annot (TT_annot { value; annot })
 
+(* pattern *)
+let tpat loc type_ desc = TPat { loc; desc; type_ }
+let tp_var loc type_ ~var = tpat loc type_ (TP_var { var })
+let tp_pair loc type_ ~left ~right = tpat loc type_ (TP_pair { left; right })
+let tp_annot loc ~pat ~annot = tpat loc annot (TP_annot { pat; annot })
+
 (* annot *)
-let tannot loc ~var ~annot = TAnnot { loc; var; annot }
+let tannot loc ~pat ~annot = TAnnot { loc; pat; annot }
 
 (* bind *)
-let tbind loc ~var ~value = TBind { loc; var; value }
+let tbind loc ~pat ~value = TBind { loc; pat; value }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -18,19 +18,25 @@ and term_desc =
   | TT_exists of { left : annot; right : annot }
   (* (x = 0, y = 0) *)
   | TT_pair of { left : bind; right : bind }
-  (* (x, y) = v; r *)
-  | TT_unpair of { left : Name.t; right : Name.t; pair : term; return : term }
   (* x = v; r *)
   | TT_let of { bound : bind; return : term }
-  (* v : T *)
+  (* (v : T) *)
   | TT_annot of { value : term; annot : type_ }
   (* e+-n *)
   | TT_offset of { desc : term_desc; offset : Offset.t }
 
-and annot = private
-  | TAnnot of { loc : Location.t; var : Name.t; annot : type_ }
+and pat = TPat of { loc : Location.t; desc : pat_desc; type_ : type_ }
 
-and bind = private TBind of { loc : Location.t; var : Name.t; value : term }
+and pat_desc =
+  (* x *)
+  | TP_var of { var : Name.t }
+  (* (p1, p2) *)
+  | TP_pair of { left : pat; right : pat }
+  (* (p : T) *)
+  | TP_annot of { pat : pat; annot : type_ }
+
+and annot = private TAnnot of { loc : Location.t; pat : pat; annot : type_ }
+and bind = private TBind of { loc : Location.t; pat : pat; value : term }
 
 (* term & type_*)
 val tt_var : Location.t -> type_ -> offset:Offset.t -> term
@@ -39,21 +45,16 @@ val tt_lambda : Location.t -> type_ -> param:annot -> return:term -> term
 val tt_apply : Location.t -> type_ -> lambda:term -> arg:term -> term
 val tt_exists : Location.t -> left:annot -> right:annot -> type_
 val tt_pair : Location.t -> type_ -> left:bind -> right:bind -> term
-
-val tt_unpair :
-  Location.t ->
-  type_ ->
-  left:Name.t ->
-  right:Name.t ->
-  pair:term ->
-  return:term ->
-  term
-
 val tt_let : Location.t -> type_ -> bound:bind -> return:term -> term
 val tt_annot : Location.t -> value:term -> annot:type_ -> term
 
+(* pattern *)
+val tp_var : Location.t -> type_ -> var:Name.t -> pat
+val tp_pair : Location.t -> type_ -> left:pat -> right:pat -> pat
+val tp_annot : Location.t -> pat:pat -> annot:type_ -> pat
+
 (* annot *)
-val tannot : Location.t -> var:Name.t -> annot:type_ -> annot
+val tannot : Location.t -> pat:pat -> annot:type_ -> annot
 
 (* bind *)
-val tbind : Location.t -> var:Name.t -> value:term -> bind
+val tbind : Location.t -> pat:pat -> value:term -> bind


### PR DESCRIPTION
## Goals

Support more flexible patterns on functions, both for muti parameter function and for inference.

## Context

Currently Teika doesn't provide any infrastructure for pattern matching and so simple things such as `(a, (b, c)) = p; r` are not supported. Additionally functions must always be defined in terms of a var, so functions such as `(x : Int, y : Int) => x + y` are not supported, nor are functions that will require inference such as `x => x`.

While inference is still not implemented, this is a step in the right direction.