### PR TITLE
teika: add simple type propagation

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -4,6 +4,7 @@ type error = CError of { loc : Location.t; desc : error_desc }
 
 and error_desc =
   (* typer *)
+  | CError_typer_pat_not_annotated of { pat : Ltree.pat_desc }
   | CError_typer_pat_not_pair of { pat : Ltree.pat_desc; expected : type_ }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
@@ -282,6 +283,12 @@ struct
   let[@inline always] ( let+ ) context f =
     let* value = context in
     return @@ f value
+
+  let[@inline always] error_pat_not_annotated ~pat =
+    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+      error (CError_typer_pat_not_annotated { pat })
+    in
+    { context }
 
   let[@inline always] error_typer_pat_not_pair ~pat ~expected =
     let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -4,6 +4,7 @@ type error = private CError of { loc : Location.t; desc : error_desc }
 
 and error_desc = private
   (* typer *)
+  | CError_typer_pat_not_annotated of { pat : Ltree.pat_desc }
   | CError_typer_pat_not_pair of { pat : Ltree.pat_desc; expected : type_ }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
@@ -128,6 +129,7 @@ end) : sig
   val ( let+ ) : 'a typer_context -> ('a -> 'b) -> 'b typer_context
 
   (* errors *)
+  val error_pat_not_annotated : pat:Ltree.pat_desc -> 'a typer_context
 
   val error_typer_pat_not_pair :
     pat:Ltree.pat_desc -> expected:type_ -> 'a typer_context
@@ -148,8 +150,8 @@ end) : sig
   (* ttree *)
   val tt_type : unit -> type_ typer_context
   val tt_var : type_ -> offset:Offset.t -> term typer_context
-  val tt_forall : param:annot -> return:type_ -> type_ typer_context
-  val tt_lambda : type_ -> param:annot -> return:term -> term typer_context
+  val tt_forall : param:pat -> return:type_ -> type_ typer_context
+  val tt_lambda : type_ -> param:pat -> return:term -> term typer_context
   val tt_apply : type_ -> lambda:term -> arg:term -> term typer_context
   val tt_exists : left:annot -> right:annot -> type_ typer_context
   val tt_pair : type_ -> left:bind -> right:bind -> term typer_context
@@ -164,6 +166,6 @@ end) : sig
   (* utils *)
   val term_of_type : type_ -> term typer_context
   val type_of_term : term -> type_ typer_context
-  val split_forall : type_ -> (annot * type_) typer_context
+  val split_forall : type_ -> (pat * type_) typer_context
   val split_exists : type_ -> (annot * annot) typer_context
 end

--- a/teika/lparser.ml
+++ b/teika/lparser.ml
@@ -10,11 +10,11 @@ let rec from_stree term =
   match desc with
   | ST_var { var } -> lt_var loc ~var
   | ST_forall { param; return } ->
-      let param = extract_annot param in
+      let param = extract_pat param in
       let return = from_stree return in
       lt_forall loc ~param ~return
   | ST_lambda { param; return } ->
-      let param = extract_annot param in
+      let param = extract_pat param in
       let return = from_stree return in
       lt_lambda loc ~param ~return
   | ST_apply { lambda; arg } ->

--- a/teika/ltree.ml
+++ b/teika/ltree.ml
@@ -2,8 +2,8 @@ type term = LTerm of { loc : Location.t; [@opaque] desc : term_desc }
 
 and term_desc =
   | LT_var of { var : Name.t }
-  | LT_forall of { param : annot; return : term }
-  | LT_lambda of { param : annot; return : term }
+  | LT_forall of { param : pat; return : term }
+  | LT_lambda of { param : pat; return : term }
   | LT_apply of { lambda : term; arg : term }
   | LT_exists of { left : annot; right : annot }
   | LT_pair of { left : bind; right : bind }

--- a/teika/ltree.mli
+++ b/teika/ltree.mli
@@ -4,9 +4,9 @@ and term_desc = private
   (* x *)
   | LT_var of { var : Name.t }
   (* (x : A) -> (z : B) *)
-  | LT_forall of { param : annot; return : term }
+  | LT_forall of { param : pat; return : term }
   (* (x : A) => e *)
-  | LT_lambda of { param : annot; return : term }
+  | LT_lambda of { param : pat; return : term }
   (* l a *)
   | LT_apply of { lambda : term; arg : term }
   (* (x : A, y : B) *)
@@ -36,8 +36,8 @@ and bind = private LBind of { loc : Location.t; pat : pat; value : term }
 
 (* term *)
 val lt_var : Location.t -> var:Name.t -> term
-val lt_forall : Location.t -> param:annot -> return:term -> term
-val lt_lambda : Location.t -> param:annot -> return:term -> term
+val lt_forall : Location.t -> param:pat -> return:term -> term
+val lt_lambda : Location.t -> param:pat -> return:term -> term
 val lt_apply : Location.t -> lambda:term -> arg:term -> term
 val lt_exists : Location.t -> left:annot -> right:annot -> term
 val lt_pair : Location.t -> left:bind -> right:bind -> term

--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -1,6 +1,7 @@
 open Ttree
 open Context.Normalize_context
 
+(* TODO: with subtyping, should normalize be able to recover information? *)
 let rec normalize_term term =
   let (TTerm { loc; desc; type_ }) = term in
   let* type_ = normalize_type type_ in
@@ -12,34 +13,31 @@ and normalize_type type_ =
   let+ desc = normalize_desc desc in
   TType { loc; desc }
 
-and normalize_pat pat =
+and normalize_pat pat f =
   let (TPat { loc; desc; type_ }) = pat in
   let* type_ = normalize_type type_ in
-  let+ desc = normalize_pat_desc desc in
-  TPat { loc; desc; type_ }
+  normalize_pat_desc desc @@ fun desc -> f (TPat { loc; desc; type_ })
 
-and normalize_pat_desc pat_desc =
+and normalize_pat_desc pat_desc f =
   match pat_desc with
-  | TP_var { var } -> return @@ TP_var { var }
+  | TP_var { var } -> with_var @@ fun () -> f (TP_var { var })
   | TP_pair { left; right } ->
-      let* left = normalize_pat left in
-      let+ right = normalize_pat right in
-      TP_pair { left; right }
+      normalize_pat left @@ fun left ->
+      normalize_pat right @@ fun right -> f (TP_pair { left; right })
   | TP_annot { pat; annot = _ } ->
       let (TPat { loc = _; desc; type_ = _ }) = pat in
-      normalize_pat_desc desc
+      normalize_pat_desc desc f
 
 and normalize_annot annot f =
   let (TAnnot { loc; pat; annot }) = annot in
   let* annot = normalize_type annot in
-  let* pat = normalize_pat pat in
-  with_var @@ fun () -> f (tannot loc ~pat ~annot)
+  normalize_pat pat @@ fun pat -> f (tannot loc ~pat ~annot)
 
 and normalize_bind bind f =
   let (TBind { loc; pat; value }) = bind in
   let* value = normalize_term value in
   let (TTerm { loc = _; desc = value_desc; type_ = _ }) = value in
-  let* pat = normalize_pat pat in
+  normalize_pat pat @@ fun pat ->
   elim_var ~to_:value_desc @@ fun () ->
   let bind = tbind loc ~pat ~value in
   f bind
@@ -48,11 +46,11 @@ and normalize_desc desc =
   match desc with
   | TT_var { offset } -> repr_var ~var:offset
   | TT_forall { param; return } ->
-      normalize_annot param @@ fun param ->
+      normalize_pat param @@ fun param ->
       let+ return = normalize_type return in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
-      normalize_annot param @@ fun param ->
+      normalize_pat param @@ fun param ->
       let+ return = normalize_term return in
       TT_lambda { param; return }
   | TT_apply { lambda; arg } -> (
@@ -66,6 +64,7 @@ and normalize_desc desc =
           let (TTerm { loc = _; desc = return; type_ = _ }) = return in
           let (TTerm { loc = _; desc = arg; type_ = _ }) = arg in
           (* TODO: return normalized twice? *)
+          (* TODO: this is clearly not right *)
           with_offset ~offset:Offset.(zero - one) @@ fun () ->
           elim_var ~to_:arg @@ fun () -> normalize_desc return
       | _ -> return @@ TT_apply { lambda; arg })
@@ -78,8 +77,6 @@ and normalize_desc desc =
   | TT_let { bound; return } ->
       normalize_bind bound @@ fun bound ->
       let (TBind { loc = lambda_loc; pat = param; value = arg }) = bound in
-      let (TPat { loc = param_loc; desc = _; type_ = annot }) = param in
-      let param = tannot param_loc ~pat:param ~annot in
       let forall =
         let (TTerm { loc = _; desc = _; type_ = return }) = return in
         tt_forall lambda_loc ~param ~return

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -290,7 +290,8 @@ module Ttree_utils = struct
        let ttree = normalize_term ttree |> Result.get_ok in
        Format.eprintf "%a\n%!" pp_term ttree
 
-     let () = dump "((A : Type) => (x : A) => x) Type" *)
+     let () =
+       dump "((id : (A : Type) -> (x : A) -> A) => id) (A => x => x) Type Type" *)
 end
 
 module Typer = struct
@@ -309,6 +310,10 @@ module Typer = struct
       {|(((A : Type) => (x : A) => x)
         : (A : Type) -> (x : A) -> A)|}
 
+  let id_propagate =
+    check "id_propagate" ~wrapper:false
+      {|((A => x => x) : (A : Type) -> (x : A) -> A)|}
+
   let id_type =
     check "id_type" ~wrapper:false
       {|(((A : Type) => (x : A) => x) Type
@@ -318,6 +323,11 @@ module Typer = struct
     check "id_type_never" ~wrapper:false
       {|(((A : Type) => (x : A) => x) Type ((A : Type) -> A)
         : Type)|}
+
+  let return_id_propagate =
+    check "return_id_propagate" ~wrapper:false
+      {|((((id : (A : Type) -> (x : A) -> A) => id) (A => x => x))
+        : (A : Type) -> (x : A) -> A)|}
 
   let sequence =
     check "sequence" ~wrapper:false
@@ -369,8 +379,10 @@ module Typer = struct
   let tests =
     [
       id;
+      id_propagate;
       id_type;
       id_type_never;
+      return_id_propagate;
       sequence;
       bool;
       true_;

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -10,8 +10,8 @@ and type_ = TType of { loc : Location.t; [@opaque] desc : term_desc }
 
 and term_desc =
   | TT_var of { offset : Offset.t }
-  | TT_forall of { param : annot; return : type_ }
-  | TT_lambda of { param : annot; return : term }
+  | TT_forall of { param : pat; return : type_ }
+  | TT_lambda of { param : pat; return : term }
   | TT_apply of { lambda : term; arg : term }
   | TT_exists of { left : annot; right : annot }
   | TT_pair of { left : bind; right : bind }
@@ -28,7 +28,9 @@ and pat_desc =
   | TP_annot of { pat : pat; annot : type_ }
 
 and annot = TAnnot of { loc : Location.t; [@opaque] pat : pat; annot : type_ }
+
 and bind = TBind of { loc : Location.t; [@opaque] pat : pat; value : term }
+[@@deriving show { with_path = false }]
 
 (* term *)
 let tterm loc type_ desc = TTerm { loc; desc; type_ }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -9,9 +9,9 @@ and term_desc =
   (* x *)
   | TT_var of { offset : Offset.t }
   (* (x : A) -> B *)
-  | TT_forall of { param : annot; return : type_ }
+  | TT_forall of { param : pat; return : type_ }
   (* (x : A) => e *)
-  | TT_lambda of { param : annot; return : term }
+  | TT_lambda of { param : pat; return : term }
   (* l a *)
   | TT_apply of { lambda : term; arg : term }
   (* (x : A, y : B) *)
@@ -36,12 +36,14 @@ and pat_desc =
   | TP_annot of { pat : pat; annot : type_ }
 
 and annot = private TAnnot of { loc : Location.t; pat : pat; annot : type_ }
+
 and bind = private TBind of { loc : Location.t; pat : pat; value : term }
+[@@deriving show]
 
 (* term & type_*)
 val tt_var : Location.t -> type_ -> offset:Offset.t -> term
-val tt_forall : Location.t -> param:annot -> return:type_ -> type_
-val tt_lambda : Location.t -> type_ -> param:annot -> return:term -> term
+val tt_forall : Location.t -> param:pat -> return:type_ -> type_
+val tt_lambda : Location.t -> type_ -> param:pat -> return:term -> term
 val tt_apply : Location.t -> type_ -> lambda:term -> arg:term -> term
 val tt_exists : Location.t -> left:annot -> right:annot -> type_
 val tt_pair : Location.t -> type_ -> left:bind -> right:bind -> term

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -21,6 +21,7 @@ let rec with_pat pat f =
   | TP_pair { left; right } -> with_pat left @@ fun () -> with_pat right f
   | TP_annot { pat; annot = _ } -> with_pat pat f
 
+(* TODO: this function is clearly not ideal *)
 let apply ~lambda ~arg =
   let lambda_type = extract_type lambda in
   let arg_type = extract_type arg in
@@ -100,7 +101,14 @@ and infer_desc desc =
       tt_lambda type_ ~param ~return
   | LT_apply { lambda; arg } ->
       let* lambda = infer_term lambda in
-      let* arg = infer_term arg in
+      let* expected_arg_type =
+        let forall = extract_type lambda in
+        let+ TPat { loc = _; desc = _; type_ = param_type }, _return =
+          split_forall forall
+        in
+        param_type
+      in
+      let* arg = check_term arg ~expected:expected_arg_type in
       apply ~lambda ~arg
   | LT_exists { left; right } ->
       let* exists =
@@ -124,12 +132,33 @@ and infer_desc desc =
   | LT_annot { value; annot } ->
       let* annot = infer_term annot in
       let* annot = type_of_term annot in
-      let* value = infer_term value in
-      let* () =
-        let value = extract_type value in
-        unify_type ~expected:annot ~received:value
-      in
+      let* value = check_term value ~expected:annot in
       tt_annot ~value ~annot
+
+and check_term term ~expected =
+  let (LTerm { loc; desc }) = term in
+  with_loc ~loc @@ fun () -> check_desc desc ~expected
+
+and check_desc desc ~expected =
+  let (TType { loc = _; desc = expected_desc }) = expected in
+  match (desc, expected_desc) with
+  | ( LT_lambda { param; return },
+      TT_forall { param = expected_param; return = expected_return } ) ->
+      let (TPat { loc = _; desc = _; type_ = expected_param }) =
+        expected_param
+      in
+      check_pat param ~expected:expected_param @@ fun param ->
+      let* return = check_term return ~expected:expected_return in
+      let* type_ =
+        let return = extract_type return in
+        tt_forall ~param ~return
+      in
+      tt_lambda type_ ~param ~return
+  | desc, _expected_desc ->
+      let* term = infer_desc desc in
+      let received = extract_type term in
+      let+ () = unify_type ~expected ~received in
+      term
 
 and infer_pat : type a. _ -> (_ -> a typer_context) -> a typer_context =
  fun pat f ->
@@ -148,6 +177,7 @@ and infer_pat_desc : type a. _ -> (_ -> a typer_context) -> a typer_context =
 and check_pat :
     type a. _ -> expected:_ -> (_ -> a typer_context) -> a typer_context =
  fun pat ~expected f ->
+  (* TODO: expected should be a pattern, to achieve strictness *)
   let (LPat { loc; desc }) = pat in
   with_loc ~loc @@ fun () -> check_pat_desc desc ~expected f
 

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -91,12 +91,12 @@ and unify_desc ~expected ~received =
   | ( TT_forall { param = expected_param; return = expected_return },
       TT_forall { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
-      let* () = unify_annot ~expected:expected_param ~received:received_param in
+      let* () = unify_pat ~expected:expected_param ~received:received_param in
       unify_type ~expected:expected_return ~received:received_return
   | ( TT_lambda { param = expected_param; return = expected_return },
       TT_lambda { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
-      let* () = unify_annot ~expected:expected_param ~received:received_param in
+      let* () = unify_pat ~expected:expected_param ~received:received_param in
       unify_term ~expected:expected_return ~received:received_return
   | ( TT_apply { lambda = expected_lambda; arg = expected_arg },
       TT_apply { lambda = received_lambda; arg = received_arg } ) ->


### PR DESCRIPTION
## Goals

Make Teika more ergonomic to use by adding type propagation.

## Context

Currently Teika doesn't propagate annotations, so `((A => x => x) : (A : Type) -> (x : A) -> A)` fails to type, even though obviously we have enough information.

This work allows functions to have not annotated parameters and add a checking mode, which is currently only used to add more information to lambda parameters.