### PR TITLE
teika: make ltree locs a metadata term

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -4,8 +4,8 @@ type error = CError of { loc : Location.t; desc : error_desc }
 
 and error_desc =
   (* typer *)
-  | CError_typer_pat_not_annotated of { pat : Ltree.pat_desc }
-  | CError_typer_pat_not_pair of { pat : Ltree.pat_desc; expected : type_ }
+  | CError_typer_pat_not_annotated of { pat : Ltree.pat }
+  | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : type_ }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
   | CError_unify_type_clash of { expected : term_desc; received : term_desc }

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -4,8 +4,8 @@ type error = private CError of { loc : Location.t; desc : error_desc }
 
 and error_desc = private
   (* typer *)
-  | CError_typer_pat_not_annotated of { pat : Ltree.pat_desc }
-  | CError_typer_pat_not_pair of { pat : Ltree.pat_desc; expected : type_ }
+  | CError_typer_pat_not_annotated of { pat : Ltree.pat }
+  | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : type_ }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
   | CError_unify_type_clash of { expected : term_desc; received : term_desc }
@@ -129,10 +129,10 @@ end) : sig
   val ( let+ ) : 'a typer_context -> ('a -> 'b) -> 'b typer_context
 
   (* errors *)
-  val error_pat_not_annotated : pat:Ltree.pat_desc -> 'a typer_context
+  val error_pat_not_annotated : pat:Ltree.pat -> 'a typer_context
 
   val error_typer_pat_not_pair :
-    pat:Ltree.pat_desc -> expected:type_ -> 'a typer_context
+    pat:Ltree.pat -> expected:type_ -> 'a typer_context
 
   (* vars *)
   val instance : var:Name.t -> (Offset.t * type_) typer_context

--- a/teika/lparser.ml
+++ b/teika/lparser.ml
@@ -5,96 +5,105 @@ exception Invalid_notation of { loc : Location.t }
 
 let invalid_notation loc = raise (Invalid_notation { loc })
 
-let rec from_stree term =
+let rec parse_term term =
   let (ST { loc; desc }) = term in
-  match desc with
-  | ST_var { var } -> lt_var loc ~var
-  | ST_forall { param; return } ->
-      let param = extract_pat param in
-      let return = from_stree return in
-      lt_forall loc ~param ~return
-  | ST_lambda { param; return } ->
-      let param = extract_pat param in
-      let return = from_stree return in
-      lt_lambda loc ~param ~return
-  | ST_apply { lambda; arg } ->
-      let lambda = from_stree lambda in
-      let arg = from_stree arg in
-      lt_apply loc ~lambda ~arg
-  | ST_pair { left; right } -> (
-      let (ST { loc; desc }) = left in
-      match desc with
-      | ST_bind _ ->
-          let left = extract_bind left in
-          let right = extract_bind right in
-          lt_pair loc ~left ~right
-      | ST_annot _ ->
-          let left = extract_annot left in
-          let right = extract_annot right in
-          lt_exists loc ~left ~right
-      | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _
-      | ST_both _ | ST_semi _ | ST_parens _ | ST_braces _ ->
-          invalid_notation loc)
-  | ST_both _ -> invalid_notation loc
-  | ST_bind _ -> invalid_notation loc
-  | ST_semi { left; right } -> (
-      let (ST { loc = left_loc; desc = left }) = left in
-      match left with
-      | ST_bind { bound = pat; value } ->
-          let bound =
-            let pat = extract_pat pat in
-            let value = from_stree value in
-            lbind left_loc ~pat ~value
-          in
-          let return = from_stree right in
-          lt_let loc ~bound ~return
-      | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _
-      | ST_both _ | ST_semi _ | ST_annot _ | ST_parens _ | ST_braces _ ->
-          invalid_notation left_loc)
-  | ST_annot { value; annot } ->
-      let value = from_stree value in
-      let annot = from_stree annot in
-      lt_annot loc ~value ~annot
-  | ST_parens { content } -> from_stree content
-  | ST_braces _ -> invalid_notation loc
+  let term =
+    match desc with
+    | ST_parens { content } -> parse_term content
+    | ST_var { var } -> LT_var { var }
+    | ST_forall { param; return } ->
+        let param = parse_pat param in
+        let return = parse_term return in
+        LT_forall { param; return }
+    | ST_lambda { param; return } ->
+        let param = parse_pat param in
+        let return = parse_term return in
+        LT_lambda { param; return }
+    | ST_apply { lambda; arg } ->
+        let lambda = parse_term lambda in
+        let arg = parse_term arg in
+        LT_apply { lambda; arg }
+    | ST_pair { left; right } -> (
+        let (ST { loc; desc }) = left in
+        match desc with
+        | ST_bind _ ->
+            let left = parse_bind left in
+            let right = parse_bind right in
+            LT_pair { left; right }
+        | ST_annot _ ->
+            let left = parse_annot left in
+            let right = parse_annot right in
+            LT_exists { left; right }
+        | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _
+        | ST_both _ | ST_semi _ | ST_parens _ | ST_braces _ ->
+            invalid_notation loc)
+    | ST_both _ -> invalid_notation loc
+    | ST_bind _ -> invalid_notation loc
+    | ST_semi { left; right } -> (
+        let (ST { loc = left_loc; desc = left }) = left in
+        match left with
+        | ST_bind { bound = pat; value } ->
+            let bound =
+              let pat = parse_pat pat in
+              let value = parse_term value in
+              LBind { loc = left_loc; pat; value }
+            in
+            let return = parse_term right in
+            LT_let { bound; return }
+        | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _
+        | ST_both _ | ST_semi _ | ST_annot _ | ST_parens _ | ST_braces _ ->
+            invalid_notation left_loc)
+    | ST_annot { value; annot } ->
+        let term = parse_term value in
+        let annot = parse_term annot in
+        LT_annot { term; annot }
+    | ST_braces _ -> invalid_notation loc
+  in
+  LT_loc { term; loc }
 
-and extract_pat term =
+and parse_pat term =
   let (ST { loc; desc }) = term in
-  match desc with
-  | ST_parens { content } -> extract_pat content
-  | ST_var { var } -> lp_var loc ~var
-  | ST_pair { left; right } ->
-      let left = extract_pat left in
-      let right = extract_pat right in
-      lp_pair loc ~left ~right
-  | ST_annot { value = pat; annot } ->
-      let pat = extract_pat pat in
-      let annot = from_stree annot in
-      lp_annot loc ~pat ~annot
-  | ST_forall _ | ST_lambda _ | ST_apply _ | ST_both _ | ST_bind _ | ST_semi _
-  | ST_braces _ ->
-      invalid_notation loc
+  let pat =
+    match desc with
+    | ST_parens { content } -> parse_pat content
+    | ST_var { var } -> LP_var { var }
+    | ST_pair { left; right } ->
+        let left = parse_pat left in
+        let right = parse_pat right in
+        LP_pair { left; right }
+    | ST_annot { value = pat; annot } ->
+        let pat = parse_pat pat in
+        let annot = parse_term annot in
+        LP_annot { pat; annot }
+    | ST_forall _ | ST_lambda _ | ST_apply _ | ST_both _ | ST_bind _ | ST_semi _
+    | ST_braces _ ->
+        invalid_notation loc
+  in
+  LP_loc { pat; loc }
 
-and extract_annot annot =
+and parse_annot annot =
   let (ST { loc; desc }) = annot in
   match desc with
-  | ST_parens { content } -> extract_annot content
+  | ST_parens { content } -> parse_annot content
   | ST_annot { value = pat; annot } ->
-      let pat = extract_pat pat in
-      let annot = from_stree annot in
-      lannot loc ~pat ~annot
+      let pat = parse_pat pat in
+      let annot = parse_term annot in
+      LAnnot { loc; pat; annot }
   | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _ | ST_both _
   | ST_bind _ | ST_semi _ | ST_braces _ ->
       invalid_notation loc
 
-and extract_bind bind =
+and parse_bind bind =
   let (ST { loc; desc }) = bind in
   match desc with
-  | ST_parens { content } -> extract_bind content
+  | ST_parens { content } -> parse_bind content
   | ST_bind { bound; value } ->
-      let pat = extract_pat bound in
-      let value = from_stree value in
-      lbind loc ~pat ~value
+      let pat = parse_pat bound in
+      let value = parse_term value in
+      LBind { loc; pat; value }
   | ST_var _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_pair _ | ST_both _
   | ST_semi _ | ST_annot _ | ST_braces _ ->
       invalid_notation loc
+
+(* TODO: rename this*)
+let from_stree = parse_term

--- a/teika/ltree.ml
+++ b/teika/ltree.ml
@@ -1,6 +1,4 @@
-type term = LTerm of { loc : Location.t; [@opaque] desc : term_desc }
-
-and term_desc =
+type term =
   | LT_var of { var : Name.t }
   | LT_forall of { param : pat; return : term }
   | LT_lambda of { param : pat; return : term }
@@ -8,42 +6,16 @@ and term_desc =
   | LT_exists of { left : annot; right : annot }
   | LT_pair of { left : bind; right : bind }
   | LT_let of { bound : bind; return : term }
-  | LT_annot of { value : term; annot : term }
+  | LT_annot of { term : term; annot : term }
+  | LT_loc of { term : term; loc : Location.t [@opaque] }
 
-and pat = LPat of { loc : Location.t; [@opaque] desc : pat_desc }
-
-and pat_desc =
-  (* x *)
+and pat =
   | LP_var of { var : Name.t }
-  (* (x, y) *)
   | LP_pair of { left : pat; right : pat }
-  (* (p : T) *)
   | LP_annot of { pat : pat; annot : term }
+  | LP_loc of { pat : pat; loc : Location.t [@opaque] }
 
 and annot = LAnnot of { loc : Location.t; [@opaque] pat : pat; annot : term }
 
 and bind = LBind of { loc : Location.t; [@opaque] pat : pat; value : term }
-[@@deriving show]
-
-(* term *)
-let lterm loc desc = LTerm { loc; desc }
-let lt_var loc ~var = lterm loc (LT_var { var })
-let lt_forall loc ~param ~return = lterm loc (LT_forall { param; return })
-let lt_lambda loc ~param ~return = lterm loc (LT_lambda { param; return })
-let lt_apply loc ~lambda ~arg = lterm loc (LT_apply { lambda; arg })
-let lt_exists loc ~left ~right = lterm loc (LT_exists { left; right })
-let lt_pair loc ~left ~right = lterm loc (LT_pair { left; right })
-let lt_let loc ~bound ~return = lterm loc (LT_let { bound; return })
-let lt_annot loc ~value ~annot = lterm loc (LT_annot { value; annot })
-
-(* pattern *)
-let lpat loc desc = LPat { loc; desc }
-let lp_var loc ~var = lpat loc (LP_var { var })
-let lp_pair loc ~left ~right = lpat loc (LP_pair { left; right })
-let lp_annot loc ~pat ~annot = lpat loc (LP_annot { pat; annot })
-
-(* annot *)
-let lannot loc ~pat ~annot = LAnnot { loc; pat; annot }
-
-(* bind *)
-let lbind loc ~pat ~value = LBind { loc; pat; value }
+[@@deriving show { with_path = false }]

--- a/teika/ltree.mli
+++ b/teika/ltree.mli
@@ -1,6 +1,4 @@
-type term = private LTerm of { loc : Location.t; desc : term_desc }
-
-and term_desc = private
+type term =
   (* x *)
   | LT_var of { var : Name.t }
   (* (x : A) -> (z : B) *)
@@ -16,41 +14,20 @@ and term_desc = private
   (* p = v; r *)
   | LT_let of { bound : bind; return : term }
   (* (v : T) *)
-  | LT_annot of { value : term; annot : term }
+  | LT_annot of { term : term; annot : term }
+  | LT_loc of { term : term; loc : Location.t }
 
-and pat = private LPat of { loc : Location.t; desc : pat_desc }
-
-and pat_desc = private
+and pat =
   (* x *)
   | LP_var of { var : Name.t }
   (* (x, y) *)
   | LP_pair of { left : pat; right : pat }
   (* (p : T) *)
   | LP_annot of { pat : pat; annot : term }
+  | LP_loc of { pat : pat; loc : Location.t }
 
 (* TODO: rename to LAnnotation? *)
-and annot = private LAnnot of { loc : Location.t; pat : pat; annot : term }
+and annot = LAnnot of { loc : Location.t; pat : pat; annot : term }
 
-and bind = private LBind of { loc : Location.t; pat : pat; value : term }
+and bind = LBind of { loc : Location.t; pat : pat; value : term }
 [@@deriving show]
-
-(* term *)
-val lt_var : Location.t -> var:Name.t -> term
-val lt_forall : Location.t -> param:pat -> return:term -> term
-val lt_lambda : Location.t -> param:pat -> return:term -> term
-val lt_apply : Location.t -> lambda:term -> arg:term -> term
-val lt_exists : Location.t -> left:annot -> right:annot -> term
-val lt_pair : Location.t -> left:bind -> right:bind -> term
-val lt_let : Location.t -> bound:bind -> return:term -> term
-val lt_annot : Location.t -> value:term -> annot:term -> term
-
-(* pattern *)
-val lp_var : Location.t -> var:Name.t -> pat
-val lp_pair : Location.t -> left:pat -> right:pat -> pat
-val lp_annot : Location.t -> pat:pat -> annot:term -> pat
-
-(* annot *)
-val lannot : Location.t -> pat:pat -> annot:term -> annot
-
-(* bind *)
-val lbind : Location.t -> pat:pat -> value:term -> bind


### PR DESCRIPTION
## Goals

Makes the language tree easier to manipulate.

## Context

Currently all of Teika trees follow the OCaml pattern of `x = { loc : Location.t; desc : x_desc }`, while this works it makes manipulating the structures during compilation harder and add another indirection for all tree nodes.

This is an alternative layour for the trees, where one of the elements of the tree is responsible for metadata. As seen on the Typer it makes it more natural to operate on those structures.