### PR TITLE
teika: make ttree locs and types a meta term

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -1,22 +1,26 @@
 open Ttree
 
-type error = CError of { loc : Location.t; desc : error_desc }
+type error = CError of { loc : Location.t; [@opaque] desc : error_desc }
 
 and error_desc =
   (* typer *)
   | CError_typer_pat_not_annotated of { pat : Ltree.pat }
-  | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : type_ }
+  | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : term }
+  (* invariant *)
+  | CError_typer_term_var_not_annotated of { var : Offset.t }
+  | CError_typer_pat_var_not_annotated of { var : Name.t }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
-  | CError_unify_type_clash of { expected : term_desc; received : term_desc }
-  | CError_unify_pat_clash of { expected : pat_desc; received : pat_desc }
+  | CError_unify_type_clash of { expected : term; received : term }
+  | CError_unify_pat_clash of { expected : pat; received : pat }
   (* typer *)
   | CError_typer_unknown_var of { var : Name.t }
-  | Cerror_typer_not_a_forall of { type_ : type_ }
-  | Cerror_typer_not_an_exists of { type_ : type_ }
+  | Cerror_typer_not_a_forall of { type_ : term }
+  | Cerror_typer_not_an_exists of { type_ : term }
+[@@deriving show { with_path = false }]
 
 module Normalize_context = struct
-  type var_info = Subst of { to_ : term_desc } | Bound of { base : Offset.t }
+  type var_info = Subst of { to_ : term } | Bound of { base : Offset.t }
 
   type 'a normalize_context = {
     (* TODO: accumulate locations during normalization *)
@@ -68,7 +72,7 @@ module Normalize_context = struct
       with
       | Some (Subst { to_ }) ->
           let offset = Offset.(var + offset) in
-          ok (TT_offset { desc = to_; offset })
+          ok (TT_offset { term = to_; offset })
       | Some (Bound { base }) ->
           let offset = Offset.(var + offset - base) in
           ok (TT_var { offset })
@@ -106,7 +110,6 @@ end
 
 module Unify_context (Normalize : sig
   val normalize_term : term -> term Normalize_context.t
-  val normalize_type : type_ -> type_ Normalize_context.t
 end) =
 struct
   type 'a unify_context = {
@@ -179,9 +182,6 @@ struct
   let[@inline always] normalize_term term =
     with_normalize_context @@ fun () -> Normalize.normalize_term term
 
-  let[@inline always] normalize_type type_ =
-    with_normalize_context @@ fun () -> Normalize.normalize_type type_
-
   let[@inline always] repr_expected_var ~var =
     let context ~expected_offset ~received_offset:_ ~ok ~error:_ =
       ok Offset.(expected_offset + var)
@@ -213,20 +213,18 @@ end
 
 module Typer_context (Normalize : sig
   val normalize_term : term -> term Normalize_context.t
-  val normalize_type : type_ -> type_ Normalize_context.t
 end) (Unify : sig
-  val unify_type :
-    expected:type_ -> received:type_ -> unit Unify_context(Normalize).t
+  val unify_term :
+    expected:term -> received:term -> unit Unify_context(Normalize).t
 end) =
 struct
   type 'a typer_context = {
     (* TODO: accumulate locations during instantiation *)
     context :
       'k.
-      loc:Location.t ->
       type_of_types:Level.t ->
       level:Level.t ->
-      names:(Level.t * type_) Name.Tbl.t ->
+      names:(Level.t * term) Name.Tbl.t ->
       ok:('a -> 'k) ->
       error:(error_desc -> 'k) ->
       'k;
@@ -244,37 +242,32 @@ struct
         - estimate based on the file size *)
     let names = Name.Tbl.create 1024 in
     (let type_name = Name.make "Type" in
-     let type_ =
-       (* TODO: breaking abstraction *)
-       let desc = TT_var { offset = Offset.zero } in
-       TType { loc; desc }
-     in
+     let type_ = TT_var { offset = Offset.zero } in
+     let type_ = TT_annot { term = type_; annot = type_ } in
      (* TODO: better place for constants *)
      Name.Tbl.add names type_name (type_of_types, type_));
     let ok value = Ok value in
     let error desc = Error (CError { loc; desc }) in
-    context ~loc ~type_of_types ~level ~names ~ok ~error
+    context ~type_of_types ~level ~names ~ok ~error
 
   let[@inline always] test ~loc ~type_of_types ~level ~names f =
     let { context } = f () in
     let ok value = Ok value in
     let error desc = Error (CError { loc; desc }) in
-    context ~loc ~type_of_types ~level ~names ~ok ~error
+    context ~type_of_types ~level ~names ~ok ~error
 
   let[@inline always] return value =
-    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok value
-    in
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ = ok value in
     { context }
 
   let[@inline always] bind context f =
     let { context } = context in
-    let context ~loc ~type_of_types ~level ~names ~ok ~error =
+    let context ~type_of_types ~level ~names ~ok ~error =
       let ok data =
         let { context } = f data in
-        context ~loc ~type_of_types ~level ~names ~ok ~error
+        context ~type_of_types ~level ~names ~ok ~error
       in
-      context ~loc ~type_of_types ~level ~names ~ok ~error
+      context ~type_of_types ~level ~names ~ok ~error
     in
     { context }
 
@@ -285,33 +278,42 @@ struct
     return @@ f value
 
   let[@inline always] error_pat_not_annotated ~pat =
-    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
       error (CError_typer_pat_not_annotated { pat })
     in
     { context }
 
-  let[@inline always] error_typer_pat_not_pair ~pat ~expected =
-    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+  let[@inline always] error_pat_not_pair ~pat ~expected =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
       error (CError_typer_pat_not_pair { pat; expected })
     in
     { context }
 
+  let[@inline always] error_term_var_not_annotated ~var =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+      error (CError_typer_term_var_not_annotated { var })
+    in
+    { context }
+
+  let[@inline always] error_pat_var_not_annotated ~var =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+      error (CError_typer_pat_var_not_annotated { var })
+    in
+    { context }
+
   let[@inline always] instance ~var =
-    let context ~loc:_ ~type_of_types:_ ~level ~names ~ok ~error =
+    let context ~type_of_types:_ ~level ~names ~ok ~error =
       match Name.Tbl.find_opt names var with
       | Some (var_level, type_) ->
           let offset = Level.offset ~from:var_level ~to_:level in
-          (* TODO: breaking abstraction *)
-          let (TType { loc; desc }) = type_ in
-          let desc = TT_offset { desc; offset } in
-          let type_ = TType { loc; desc } in
+          let type_ = TT_offset { term = type_; offset } in
           ok (offset, type_)
       | None -> error (CError_typer_unknown_var { var })
     in
     { context }
 
   let[@inline always] with_binder ~var ~type_ f =
-    let context ~loc ~type_of_types ~level ~names ~ok ~error =
+    let context ~type_of_types ~level ~names ~ok ~error =
       Name.Tbl.add names var (level, type_);
       let level = Level.next level in
       let { context } = f () in
@@ -319,184 +321,167 @@ struct
         Name.Tbl.remove names var;
         ok value
       in
-      context ~loc ~type_of_types ~level ~names ~ok ~error
+      context ~type_of_types ~level ~names ~ok ~error
     in
     { context }
 
   module Unify_context = Unify_context (Normalize)
 
-  let unify_type ~expected ~received =
-    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
-      let Unify_context.{ context } = Unify.unify_type ~expected ~received in
+  let[@inline always] unify_term ~expected ~received =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
+      let Unify_context.{ context } = Unify.unify_term ~expected ~received in
       context ~expected_offset:Offset.zero ~received_offset:Offset.zero ~ok
         ~error
     in
     { context }
 
-  let[@inline always] with_loc ~loc f =
-    let context ~loc:_parent_loc ~type_of_types ~level ~names ~ok ~error =
+  let[@inline always] with_tt_loc ~loc f =
+    let context ~type_of_types ~level ~names ~ok ~error =
       let { context } = f () in
-      context ~loc ~type_of_types ~level ~names ~ok ~error
+      let ok term = ok @@ TT_loc { term; loc } in
+      context ~type_of_types ~level ~names ~ok ~error
+    in
+    { context }
+
+  let[@inline always] with_tp_loc ~loc f =
+    let context ~type_of_types ~level ~names ~ok ~error =
+      let { context } =
+        f (fun pat k ->
+            let pat = TP_loc { pat; loc } in
+            k pat)
+      in
+      context ~type_of_types ~level ~names ~ok ~error
     in
     { context }
 
   open Ttree
 
-  let tt_type_offset ~type_of_types ~level =
-    Level.offset ~from:type_of_types ~to_:level
-
-  let tt_type ~loc ~type_of_types ~level =
-    let offset = tt_type_offset ~type_of_types ~level in
-    (* TODO: breaking abstraction *)
-    let desc = TT_var { offset } in
-    TType { loc; desc }
-
-  let[@inline always] term_of_type type_ =
-    let context ~loc:_ ~type_of_types ~level ~names:_ ~ok ~error:_ =
-      let (TType { loc; desc }) = type_ in
-      let type_ = tt_type ~loc ~type_of_types ~level in
-      (* TODO: breaking abstraction *)
-      ok (TTerm { loc; desc; type_ })
-    in
-    { context }
-
-  let[@inline always] type_of_term term =
-    let context ~loc ~type_of_types ~level ~names:_ ~ok ~error =
-      let tt_type = tt_type ~loc ~type_of_types ~level in
-      let (TTerm { loc; desc; type_ }) = term in
-      let Unify_context.{ context } =
-        Unify.unify_type ~expected:tt_type ~received:type_
-      in
-      let ok () =
-        (* TODO: breaking abstraction *)
-        ok (TType { loc; desc })
-      in
-      context ~expected_offset:Offset.zero ~received_offset:Offset.zero ~ok
-        ~error
-    in
-    { context }
+  let[@inline always] tt_type ~type_of_types ~level =
+    let offset = Level.offset ~from:type_of_types ~to_:level in
+    TT_var { offset }
 
   let[@inline always] with_normalize_context f =
-    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
       let Normalize_context.{ context } = f () in
       context ~vars:[] ~offset:Offset.zero ~ok ~error
     in
     { context }
 
-  let[@inline always] normalize_type type_ =
-    with_normalize_context @@ fun () -> Normalize.normalize_type type_
+  let[@inline always] normalize_term type_ =
+    with_normalize_context @@ fun () -> Normalize.normalize_term type_
 
   let[@inline always] split_forall type_ =
-    let* type_ = normalize_type type_ in
+    let* type_ = normalize_term type_ in
     (* TODO: two normalize guarantees no TT_offset? *)
-    let* type_ = normalize_type type_ in
-    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
-      (* TODO: what about this location? *)
-      let (TType { loc = _; desc }) = type_ in
-      match desc with
+    (* TODO: it doesn't *)
+    let* type_ = normalize_term type_ in
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
+      match type_ with
       | TT_forall { param; return } -> ok (param, return)
       | TT_var _ | TT_lambda _ | TT_apply _ | TT_exists _ | TT_pair _ | TT_let _
-      | TT_annot _ | TT_offset _ ->
+      | TT_annot _ | TT_loc _ | TT_offset _ ->
           error (Cerror_typer_not_a_forall { type_ })
     in
     { context }
 
   let[@inline always] split_exists type_ =
-    let* type_ = normalize_type type_ in
+    let* type_ = normalize_term type_ in
     (* TODO: two normalize guarantees no TT_offset? *)
-    let* type_ = normalize_type type_ in
-    let context ~loc:_ ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
-      (* TODO: what about this location? *)
-      let (TType { loc = _; desc }) = type_ in
-      match desc with
+    let* type_ = normalize_term type_ in
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
+      match type_ with
       | TT_exists { left; right } -> ok (left, right)
       | TT_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_pair _ | TT_let _
-      | TT_annot _ | TT_offset _ ->
+      | TT_annot _ | TT_loc _ | TT_offset _ ->
           error (Cerror_typer_not_an_exists { type_ })
     in
     { context }
 
+  let[@inline always] tt_annot ~annot term = TT_annot { term; annot }
+
   let[@inline always] tt_type () =
-    let context ~loc ~type_of_types ~level ~names:_ ~ok ~error:_ =
-      ok (tt_type ~loc ~type_of_types ~level)
+    let context ~type_of_types ~level ~names:_ ~ok ~error:_ =
+      ok @@ tt_type ~type_of_types ~level
     in
     { context }
 
-  let[@inline always] tt_var type_ ~offset =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_var loc type_ ~offset
+  let[@inline always] tt_var ~annot ~offset =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ tt_annot ~annot @@ TT_var { offset }
     in
     { context }
 
   let[@inline always] tt_forall ~param ~return =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_forall loc ~param ~return
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_forall { param; return }
     in
     { context }
 
-  let[@inline always] tt_lambda type_ ~param ~return =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_lambda loc type_ ~param ~return
+  let[@inline always] tt_lambda ~param ~return =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_lambda { param; return }
     in
     { context }
 
-  let[@inline always] tt_apply type_ ~lambda ~arg =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_apply loc type_ ~lambda ~arg
+  let[@inline always] tt_apply ~lambda ~arg =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_apply { lambda; arg }
     in
     { context }
 
   let[@inline always] tt_exists ~left ~right =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_exists loc ~left ~right
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_exists { left; right }
     in
     { context }
 
-  let[@inline always] tt_pair type_ ~left ~right =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_pair loc type_ ~left ~right
+  let[@inline always] tt_pair ~left ~right =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_pair { left; right }
     in
     { context }
 
-  let[@inline always] tt_let type_ ~bound ~return =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_let loc type_ ~bound ~return
+  let[@inline always] tt_let ~bound ~return =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_let { bound; return }
     in
     { context }
 
-  let[@inline always] tt_annot ~value ~annot =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_annot loc ~value ~annot
+  let[@inline always] tt_annot ~term ~annot =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ tt_annot ~annot term
     in
     { context }
 
-  let[@inline always] tp_var type_ ~var =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tp_var loc type_ ~var
+  let[@inline always] tp_annot ~annot pat = TP_annot { pat; annot }
+
+  let[@inline always] tp_var ~annot ~var =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ tp_annot ~annot @@ TP_var { var }
     in
     { context }
 
-  let[@inline always] tp_pair type_ ~left ~right =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tp_pair loc type_ ~left ~right
+  let[@inline always] tp_pair ~left ~right =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TP_pair { left; right }
     in
     { context }
 
   let[@inline always] tp_annot ~pat ~annot =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tp_annot loc ~pat ~annot
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TP_annot { pat; annot }
     in
     { context }
 
-  let[@inline always] tannot ~pat ~annot =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tannot loc ~pat ~annot
+  let[@inline always] tannot ~loc ~pat ~annot =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TAnnot { loc; pat; annot }
     in
     { context }
 
-  let[@inline always] tbind ~pat ~value =
-    let context ~loc ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tbind loc ~pat ~value
+  let[@inline always] tbind ~loc ~pat ~value =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TBind { loc; pat; value }
     in
     { context }
 end

--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -2,52 +2,18 @@ open Ttree
 open Context.Normalize_context
 
 (* TODO: with subtyping, should normalize be able to recover information? *)
+
 let rec normalize_term term =
-  let (TTerm { loc; desc; type_ }) = term in
-  let* type_ = normalize_type type_ in
-  let+ desc = normalize_desc desc in
-  TTerm { loc; desc; type_ }
-
-and normalize_type type_ =
-  let (TType { loc; desc }) = type_ in
-  let+ desc = normalize_desc desc in
-  TType { loc; desc }
-
-and normalize_pat pat f =
-  let (TPat { loc; desc; type_ }) = pat in
-  let* type_ = normalize_type type_ in
-  normalize_pat_desc desc @@ fun desc -> f (TPat { loc; desc; type_ })
-
-and normalize_pat_desc pat_desc f =
-  match pat_desc with
-  | TP_var { var } -> with_var @@ fun () -> f (TP_var { var })
-  | TP_pair { left; right } ->
-      normalize_pat left @@ fun left ->
-      normalize_pat right @@ fun right -> f (TP_pair { left; right })
-  | TP_annot { pat; annot = _ } ->
-      let (TPat { loc = _; desc; type_ = _ }) = pat in
-      normalize_pat_desc desc f
-
-and normalize_annot annot f =
-  let (TAnnot { loc; pat; annot }) = annot in
-  let* annot = normalize_type annot in
-  normalize_pat pat @@ fun pat -> f (tannot loc ~pat ~annot)
-
-and normalize_bind bind f =
-  let (TBind { loc; pat; value }) = bind in
-  let* value = normalize_term value in
-  let (TTerm { loc = _; desc = value_desc; type_ = _ }) = value in
-  normalize_pat pat @@ fun pat ->
-  elim_var ~to_:value_desc @@ fun () ->
-  let bind = tbind loc ~pat ~value in
-  f bind
-
-and normalize_desc desc =
-  match desc with
+  match term with
+  (* TODO: is removing those ok / idea? *)
+  | TT_annot { term; annot = _ } -> normalize_term term
+  | TT_loc { term; loc = _ } -> normalize_term term
+  | TT_offset { term; offset } ->
+      with_offset ~offset @@ fun () -> normalize_term term
   | TT_var { offset } -> repr_var ~var:offset
   | TT_forall { param; return } ->
       normalize_pat param @@ fun param ->
-      let+ return = normalize_type return in
+      let+ return = normalize_term return in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
       normalize_pat param @@ fun param ->
@@ -56,17 +22,10 @@ and normalize_desc desc =
   | TT_apply { lambda; arg } -> (
       let* lambda = normalize_term lambda in
       let* arg = normalize_term arg in
-      match
-        let (TTerm { loc = _; desc; type_ = _ }) = lambda in
-        desc
-      with
-      | TT_lambda { param = _; return } ->
-          let (TTerm { loc = _; desc = return; type_ = _ }) = return in
-          let (TTerm { loc = _; desc = arg; type_ = _ }) = arg in
-          (* TODO: return normalized twice? *)
-          (* TODO: this is clearly not right *)
-          with_offset ~offset:Offset.(zero - one) @@ fun () ->
-          elim_var ~to_:arg @@ fun () -> normalize_desc return
+      match lambda with
+      | TT_lambda { param; return } ->
+          (* TODO: match every case below *)
+          elim_apply ~pat:param ~return ~arg @@ fun () -> normalize_term return
       | _ -> return @@ TT_apply { lambda; arg })
   | TT_exists { left; right } ->
       normalize_annot left @@ fun left ->
@@ -76,16 +35,49 @@ and normalize_desc desc =
       normalize_bind right @@ fun right -> return @@ TT_pair { left; right }
   | TT_let { bound; return } ->
       normalize_bind bound @@ fun bound ->
-      let (TBind { loc = lambda_loc; pat = param; value = arg }) = bound in
-      let forall =
-        let (TTerm { loc = _; desc = _; type_ = return }) = return in
-        tt_forall lambda_loc ~param ~return
-      in
-      let lambda = tt_lambda lambda_loc forall ~param ~return in
-      let apply = TT_apply { lambda; arg } in
-      normalize_desc apply
-  | TT_annot { value; annot = _ } ->
-      let (TTerm { loc = _; desc = value; type_ = _ }) = value in
-      normalize_desc value
-  | TT_offset { desc; offset } ->
-      with_offset ~offset @@ fun () -> normalize_desc desc
+      let (TBind { loc = _lambda_loc; pat = param; value = arg }) = bound in
+      let lambda = TT_lambda { param; return } in
+      normalize_term (TT_apply { lambda; arg })
+
+(* TODO: weird *)
+and elim_apply ~pat ~return ~arg f =
+  match (pat, arg) with
+  | TP_var { var = _ }, arg ->
+      with_offset ~offset:Offset.(zero - one) @@ fun () -> elim_var ~to_:arg f
+  | ( TP_pair { left = left_pat; right = right_pat },
+      TT_pair { left = left_arg; right = right_arg } ) ->
+      (* TODO: what if bind pat is not just var? This is wrong *)
+      let (TBind { loc = _; pat = _; value = left_arg }) = left_arg in
+      let (TBind { loc = _; pat = _; value = right_arg }) = right_arg in
+      elim_apply ~pat:left_pat ~return ~arg:left_arg @@ fun () ->
+      elim_apply ~pat:right_pat ~return ~arg:right_arg f
+  | (TP_pair _ as param), arg ->
+      (* TODO: proper locations? *)
+      let lambda = TT_lambda { param; return } in
+      Context.Normalize_context.return @@ TT_apply { lambda; arg }
+  | TP_annot { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg f
+  | TP_loc { pat; loc = _ }, arg -> elim_apply ~pat ~return ~arg f
+
+and normalize_pat pat f =
+  match pat with
+  | TP_var { var } ->
+      (* TODO: ensure all pat variables are wrapped with annotation *)
+      with_var @@ fun () -> f (TP_var { var })
+  | TP_pair { left; right } ->
+      normalize_pat left @@ fun left ->
+      normalize_pat right @@ fun right -> f (TP_pair { left; right })
+  | TP_annot { pat; annot } ->
+      let* annot = normalize_term annot in
+      normalize_pat pat @@ fun pat -> f (TP_annot { pat; annot })
+  | TP_loc { pat; loc = _ } -> normalize_pat pat f
+
+and normalize_annot annot f =
+  let (TAnnot { loc; pat; annot }) = annot in
+  let* annot = normalize_term annot in
+  normalize_pat pat @@ fun pat -> f (TAnnot { loc; pat; annot })
+
+and normalize_bind bind f =
+  let (TBind { loc; pat; value }) = bind in
+  let* value = normalize_term value in
+  normalize_pat pat @@ fun pat ->
+  elim_var ~to_:value @@ fun () -> f (TBind { loc; pat; value })

--- a/teika/normalize.mli
+++ b/teika/normalize.mli
@@ -2,4 +2,3 @@ open Ttree
 open Context
 
 val normalize_term : term -> term Normalize_context.t
-val normalize_type : type_ -> type_ Normalize_context.t

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -247,55 +247,6 @@ module Ttree_utils = struct
   open Teika
   module Typer_context = Context.Typer_context (Normalize) (Unify)
 
-  type term = Ttree.term =
-    | TTerm of { loc : Location.t; [@opaque] desc : term_desc; type_ : type_ }
-
-  and type_ = Ttree.type_ =
-    | TType of { loc : Location.t; [@opaque] desc : term_desc }
-
-  and term_desc = Ttree.term_desc =
-    | TT_var of { offset : Offset.t }
-    | TT_forall of { param : pat; return : type_ }
-    | TT_lambda of { param : pat; return : term }
-    | TT_apply of { lambda : term; arg : term }
-    | TT_exists of { left : annot; right : annot }
-    | TT_pair of { left : bind; right : bind }
-    | TT_let of { bound : bind; return : term }
-    | TT_annot of { value : term; annot : type_ }
-    | TT_offset of { desc : term_desc; offset : Offset.t }
-
-  and pat = Ttree.pat =
-    | TPat of { loc : Location.t; [@opaque] desc : pat_desc; type_ : type_ }
-
-  and pat_desc = Ttree.pat_desc =
-    | TP_var of { var : Name.t }
-    | TP_pair of { left : pat; right : pat }
-    | TP_annot of { pat : pat; annot : type_ }
-
-  and annot = Ttree.annot = private
-    | TAnnot of { loc : Location.t; [@opaque] pat : pat; annot : type_ }
-
-  and bind = Ttree.bind = private
-    | TBind of { loc : Location.t; [@opaque] pat : pat; value : term }
-  [@@deriving show { with_path = false }]
-
-  type error = Context.error = private
-    | CError of { loc : Location.t; [@opaque] desc : error_desc }
-
-  and error_desc = Context.error_desc = private
-    (* typer *)
-    | CError_typer_pat_not_annotated of { pat : Ltree.pat }
-    | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : type_ }
-    (* unify *)
-    | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
-    | CError_unify_type_clash of { expected : term_desc; received : term_desc }
-    | CError_unify_pat_clash of { expected : pat_desc; received : pat_desc }
-    (* typer *)
-    | CError_typer_unknown_var of { var : Name.t }
-    | Cerror_typer_not_a_forall of { type_ : type_ }
-    | Cerror_typer_not_an_exists of { type_ : type_ }
-  [@@deriving show { with_path = false }]
-
   let infer_term term =
     let open Typer_context in
     let loc = Location.none in
@@ -427,7 +378,8 @@ module Typer = struct
           match infer_term ltree with
           | Ok _ttree -> ()
           | Error error ->
-              failwith @@ Format.asprintf "error: %a\n%!" pp_error error)
+              failwith @@ Format.asprintf "error: %a\n%!" Context.pp_error error
+          )
       | None -> failwith "failed to parse"
     in
     Alcotest.test_case name `Quick check

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -3,58 +3,32 @@
 
    Maybe (x : ?X) => x *)
 
+(* TODO: to avoid normalizing many times,
+   makes normalization cached, with unification this
+   means that this cache will probably be dependent on holes *)
+
 type term =
-  | TTerm of { loc : Location.t; [@opaque] desc : term_desc; type_ : type_ }
-
-and type_ = TType of { loc : Location.t; [@opaque] desc : term_desc }
-
-and term_desc =
   | TT_var of { offset : Offset.t }
-  | TT_forall of { param : pat; return : type_ }
+  | TT_forall of { param : pat; return : term }
   | TT_lambda of { param : pat; return : term }
   | TT_apply of { lambda : term; arg : term }
   | TT_exists of { left : annot; right : annot }
   | TT_pair of { left : bind; right : bind }
   | TT_let of { bound : bind; return : term }
-  | TT_annot of { value : term; annot : type_ }
-  | TT_offset of { desc : term_desc; offset : Offset.t }
+  | TT_annot of { term : term; annot : term }
+  | TT_loc of { term : term; loc : Location.t [@opaque] }
+  | TT_offset of { term : term; offset : Offset.t }
 
 and pat =
-  | TPat of { loc : Location.t; [@opaque] desc : pat_desc; type_ : type_ }
-
-and pat_desc =
+  (* x *)
   | TP_var of { var : Name.t }
+  (* (p1, p2) *)
   | TP_pair of { left : pat; right : pat }
-  | TP_annot of { pat : pat; annot : type_ }
+  (* (p : T) *)
+  | TP_annot of { pat : pat; annot : term }
+  | TP_loc of { pat : pat; loc : Location.t [@opaque] }
 
-and annot = TAnnot of { loc : Location.t; [@opaque] pat : pat; annot : type_ }
+and annot = TAnnot of { loc : Location.t; [@opaque] pat : pat; annot : term }
 
 and bind = TBind of { loc : Location.t; [@opaque] pat : pat; value : term }
 [@@deriving show { with_path = false }]
-
-(* term *)
-let tterm loc type_ desc = TTerm { loc; desc; type_ }
-let ttype loc desc = TType { loc; desc }
-let tt_var loc type_ ~offset = tterm loc type_ (TT_var { offset })
-let tt_forall loc ~param ~return = ttype loc (TT_forall { param; return })
-
-let tt_lambda loc type_ ~param ~return =
-  tterm loc type_ (TT_lambda { param; return })
-
-let tt_apply loc type_ ~lambda ~arg = tterm loc type_ (TT_apply { lambda; arg })
-let tt_exists loc ~left ~right = ttype loc (TT_exists { left; right })
-let tt_pair loc type_ ~left ~right = tterm loc type_ (TT_pair { left; right })
-let tt_let loc type_ ~bound ~return = tterm loc type_ (TT_let { bound; return })
-let tt_annot loc ~value ~annot = tterm loc annot (TT_annot { value; annot })
-
-(* pattern *)
-let tpat loc type_ desc = TPat { loc; desc; type_ }
-let tp_var loc type_ ~var = tpat loc type_ (TP_var { var })
-let tp_pair loc type_ ~left ~right = tpat loc type_ (TP_pair { left; right })
-let tp_annot loc ~pat ~annot = tpat loc annot (TP_annot { pat; annot })
-
-(* annot *)
-let tannot loc ~pat ~annot = TAnnot { loc; pat; annot }
-
-(* bind *)
-let tbind loc ~pat ~value = TBind { loc; pat; value }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,15 +1,10 @@
-(* TODO: to avoid normalizing many times,
-    makes normalization cached, with unification this
-    means that this cache will probably be dependent on holes *)
-(* TODO: make this private again *)
-type term = TTerm of { loc : Location.t; desc : term_desc; type_ : type_ }
-and type_ = TType of { loc : Location.t; desc : term_desc }
+(* TODO: make this private again? *)
 
-and term_desc =
+type term =
   (* x *)
   | TT_var of { offset : Offset.t }
   (* (x : A) -> B *)
-  | TT_forall of { param : pat; return : type_ }
+  | TT_forall of { param : pat; return : term }
   (* (x : A) => e *)
   | TT_lambda of { param : pat; return : term }
   (* l a *)
@@ -21,42 +16,20 @@ and term_desc =
   (* x = v; r *)
   | TT_let of { bound : bind; return : term }
   (* (v : T) *)
-  | TT_annot of { value : term; annot : type_ }
-  (* e+-n *)
-  | TT_offset of { desc : term_desc; offset : Offset.t }
+  | TT_annot of { term : term; annot : term }
+  | TT_loc of { term : term; loc : Location.t }
+  | TT_offset of { term : term; offset : Offset.t }
 
-and pat = TPat of { loc : Location.t; desc : pat_desc; type_ : type_ }
-
-and pat_desc =
+and pat =
   (* x *)
   | TP_var of { var : Name.t }
   (* (p1, p2) *)
   | TP_pair of { left : pat; right : pat }
   (* (p : T) *)
-  | TP_annot of { pat : pat; annot : type_ }
+  | TP_annot of { pat : pat; annot : term }
+  | TP_loc of { pat : pat; loc : Location.t }
 
-and annot = private TAnnot of { loc : Location.t; pat : pat; annot : type_ }
+and annot = TAnnot of { loc : Location.t; pat : pat; annot : term }
 
-and bind = private TBind of { loc : Location.t; pat : pat; value : term }
+and bind = TBind of { loc : Location.t; pat : pat; value : term }
 [@@deriving show]
-
-(* term & type_*)
-val tt_var : Location.t -> type_ -> offset:Offset.t -> term
-val tt_forall : Location.t -> param:pat -> return:type_ -> type_
-val tt_lambda : Location.t -> type_ -> param:pat -> return:term -> term
-val tt_apply : Location.t -> type_ -> lambda:term -> arg:term -> term
-val tt_exists : Location.t -> left:annot -> right:annot -> type_
-val tt_pair : Location.t -> type_ -> left:bind -> right:bind -> term
-val tt_let : Location.t -> type_ -> bound:bind -> return:term -> term
-val tt_annot : Location.t -> value:term -> annot:type_ -> term
-
-(* pattern *)
-val tp_var : Location.t -> type_ -> var:Name.t -> pat
-val tp_pair : Location.t -> type_ -> left:pat -> right:pat -> pat
-val tp_annot : Location.t -> pat:pat -> annot:type_ -> pat
-
-(* annot *)
-val tannot : Location.t -> pat:pat -> annot:type_ -> annot
-
-(* bind *)
-val tbind : Location.t -> pat:pat -> value:term -> bind

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -3,181 +3,167 @@ open Ttree
 module Typer_context = Context.Typer_context (Normalize) (Unify)
 open Typer_context
 
-let extract_type term =
-  let (TTerm { loc = _; desc = _; type_ }) = term in
-  type_
+let rec typeof_term term =
+  match term with
+  | TT_var { offset = var } -> error_term_var_not_annotated ~var
+  | TT_forall { param = _; return = _ } -> tt_type ()
+  | TT_lambda { param; return } ->
+      let* return = typeof_term return in
+      tt_forall ~param ~return
+  | TT_apply { lambda; arg } ->
+      let* forall = typeof_term lambda in
+      let+ param, return = split_forall forall in
+      let lambda = TT_lambda { param; return } in
+      TT_apply { lambda; arg }
+  | TT_exists { left = _; right = _ } -> tt_type ()
+  | TT_pair { left; right } ->
+      let* left = typeof_bind left in
+      let* right = typeof_bind right in
+      tt_exists ~left ~right
+  | TT_let { bound; return } ->
+      let* return = typeof_term return in
+      tt_let ~bound ~return
+  | TT_annot { term = _; annot } -> return annot
+  | TT_loc { term; loc = _ } -> typeof_term term
+  | TT_offset { term; offset } ->
+      let* term = typeof_term term in
+      return @@ TT_offset { term; offset }
 
-let annot_of_bind bind =
+and typeof_bind bind =
   let (TBind { loc; pat; value }) = bind in
-  with_loc ~loc @@ fun () ->
-  let annot = extract_type value in
-  tannot ~pat ~annot
+  let+ annot = typeof_term value in
+  TAnnot { loc; pat; annot }
 
-(* TODO: this is a hack *)
-let rec with_pat pat f =
-  let (TPat { loc = _; desc; type_ }) = pat in
-  match desc with
-  | TP_var { var } -> with_binder ~var ~type_ f
-  | TP_pair { left; right } -> with_pat left @@ fun () -> with_pat right f
-  | TP_annot { pat; annot = _ } -> with_pat pat f
-
-(* TODO: this function is clearly not ideal *)
-let apply ~lambda ~arg =
-  let lambda_type = extract_type lambda in
-  let arg_type = extract_type arg in
-  let* param, return = split_forall lambda_type in
-  let (TPat { loc = _; desc = _; type_ = param_type }) = param in
-  let* () = unify_type ~expected:param_type ~received:arg_type in
-  let* type_ =
-    let* type_ = tt_type () in
-    let* lambda =
-      with_pat param @@ fun () ->
-      let* type_ =
-        let* return = tt_type () in
-        tt_forall ~param ~return
+and typeof_pat pat =
+  match pat with
+  | TP_var { var } -> error_pat_var_not_annotated ~var
+  | TP_pair { left; right } ->
+      (* TODO: proper locs *)
+      let loc = Location.none in
+      let* left =
+        let* annot = typeof_pat left in
+        tannot ~loc ~pat:left ~annot
       in
-      let* return = term_of_type return in
-      tt_lambda type_ ~param ~return
-    in
-    tt_apply type_ ~lambda ~arg
-  in
-  let* type_ = type_of_term type_ in
-  tt_apply type_ ~lambda ~arg
-
-let let_ ~bound ~return =
-  let* type_ =
-    let* type_ = tt_type () in
-    let return_type = extract_type return in
-    let* return = term_of_type return_type in
-    let* let_ = tt_let type_ ~bound ~return in
-    type_of_term let_
-  in
-  tt_let type_ ~bound ~return
+      let* right =
+        let* annot = typeof_pat right in
+        tannot ~loc ~pat:right ~annot
+      in
+      tt_exists ~left ~right
+  | TP_annot { pat = _; annot } -> return @@ annot
+  | TP_loc { pat; loc = _ } -> typeof_pat pat
 
 let rec infer_term term =
   match term with
   | LT_var { var } ->
-      let* offset, type_ = instance ~var in
-      tt_var type_ ~offset
+      let* offset, annot = instance ~var in
+      tt_var ~annot ~offset
   | LT_forall { param; return } ->
-      let* forall =
-        infer_pat param @@ fun param ->
-        let* return = infer_term return in
-        let* return = type_of_term return in
-        tt_forall ~param ~return
+      infer_pat param @@ fun param ->
+      let* return =
+        let* expected = tt_type () in
+        check_term return ~expected
       in
-      term_of_type forall
+      tt_forall ~param ~return
   | LT_lambda { param; return } ->
       infer_pat param @@ fun param ->
       let* return = infer_term return in
-      let* type_ =
-        let return = extract_type return in
-        tt_forall ~param ~return
-      in
-      tt_lambda type_ ~param ~return
+      tt_lambda ~param ~return
   | LT_apply { lambda; arg } ->
       let* lambda = infer_term lambda in
-      let* expected_arg_type =
-        let forall = extract_type lambda in
-        let+ TPat { loc = _; desc = _; type_ = param_type }, _return =
-          split_forall forall
+      let* arg =
+        let* expected =
+          let* forall = typeof_term lambda in
+          let* param, _return = split_forall forall in
+          typeof_pat param
         in
-        param_type
+        check_term arg ~expected
       in
-      let* arg = check_term arg ~expected:expected_arg_type in
-      apply ~lambda ~arg
+      tt_apply ~lambda ~arg
   | LT_exists { left; right } ->
-      let* exists =
-        infer_annot left @@ fun left ->
-        infer_annot right @@ fun right -> tt_exists ~left ~right
-      in
-      term_of_type exists
+      infer_annot left @@ fun left ->
+      infer_annot right @@ fun right -> tt_exists ~left ~right
   | LT_pair { left; right } ->
       infer_bind left @@ fun left ->
-      infer_bind right @@ fun right ->
-      let* type_ =
-        let* left = annot_of_bind left in
-        let* right = annot_of_bind right in
-        tt_exists ~left ~right
-      in
-      tt_pair type_ ~left ~right
+      infer_bind right @@ fun right -> tt_pair ~left ~right
   | LT_let { bound; return } ->
       infer_bind bound @@ fun bound ->
       let* return = infer_term return in
-      let_ ~bound ~return
+      tt_let ~bound ~return
   | LT_annot { term; annot } ->
-      let* annot = infer_term annot in
-      let* annot = type_of_term annot in
+      let* annot =
+        let* expected = tt_type () in
+        check_term annot ~expected
+      in
       let* term = check_term term ~expected:annot in
-      tt_annot ~value:term ~annot
-  | LT_loc { term; loc } -> with_loc ~loc @@ fun () -> infer_term term
+      tt_annot ~term ~annot
+  | LT_loc { term; loc } -> with_tt_loc ~loc @@ fun () -> infer_term term
 
 and infer_annot : type a. _ -> (_ -> a typer_context) -> a typer_context =
  fun annot f ->
   let (LAnnot { loc; pat; annot }) = annot in
-  with_loc ~loc @@ fun () ->
-  let* annot = infer_term annot in
-  let* annot = type_of_term annot in
+  let* annot =
+    let* expected = tt_type () in
+    check_term annot ~expected
+  in
   check_pat pat ~expected:annot @@ fun pat ->
-  let* annot = tannot ~pat ~annot in
+  let* annot = tannot ~loc ~pat ~annot in
   f annot
 
 and infer_bind : type a. _ -> (_ -> a typer_context) -> a typer_context =
  fun bind f ->
   let (LBind { loc; pat; value }) = bind in
-  with_loc ~loc @@ fun () ->
   let* value = infer_term value in
-  let annot = extract_type value in
+  let* annot = typeof_term value in
   check_pat pat ~expected:annot @@ fun pat ->
-  let* bind = tbind ~pat ~value in
+  let* bind = tbind ~loc ~pat ~value in
   f bind
 
 and check_term term ~expected =
-  let (TType { loc = _; desc = expected_desc }) = expected in
   (* TODO: repr function for term, maybe with_term? *)
-  match (term, expected_desc) with
+  match (term, expected) with
   | ( LT_lambda { param; return },
       TT_forall { param = expected_param; return = expected_return } ) ->
-      let (TPat { loc = _; desc = _; type_ = expected_param }) =
-        expected_param
-      in
-      check_pat param ~expected:expected_param @@ fun param ->
+      let* expected_param_type = typeof_pat expected_param in
+      check_pat param ~expected:expected_param_type @@ fun param ->
       let* return = check_term return ~expected:expected_return in
-      let* type_ =
-        let return = extract_type return in
-        tt_forall ~param ~return
-      in
-      tt_lambda type_ ~param ~return
-  | LT_loc { term; loc }, _expected_desc ->
-      with_loc ~loc @@ fun () -> check_term term ~expected
+      tt_lambda ~param ~return
+  | LT_loc { term; loc }, expected ->
+      with_tt_loc ~loc @@ fun () -> check_term term ~expected
+      (* TODO: what about this loc? *)
+  | term, TT_loc { term = expected; loc = _ } -> check_term term ~expected
   (* TODO: maybe LT_annot? *)
   | ( ( LT_var _ | LT_forall _ | LT_lambda _ | LT_apply _ | LT_exists _
       | LT_pair _ | LT_let _ | LT_annot _ ),
-      _expected_desc ) ->
+      expected ) ->
       let* term = infer_term term in
-      let received = extract_type term in
-      let+ () = unify_type ~expected ~received in
+      let+ () =
+        let* received = typeof_term term in
+        unify_term ~expected ~received
+      in
       term
 
 and infer_pat : type a. _ -> (_ -> a typer_context) -> a typer_context =
  fun pat f ->
   match pat with
   | LP_annot { pat; annot } ->
-      let* annot = infer_term annot in
-      let* annot = type_of_term annot in
+      let* annot =
+        let* expected = tt_type () in
+        check_term annot ~expected
+      in
       check_pat pat ~expected:annot f
-  | LP_loc { pat; loc } -> with_loc ~loc @@ fun () -> infer_pat pat f
+  | LP_loc { pat; loc } ->
+      with_tp_loc ~loc @@ fun k ->
+      infer_pat pat @@ fun pat -> k pat f
   | LP_var _ | LP_pair _ -> error_pat_not_annotated ~pat
 
 and check_pat :
     type a. _ -> expected:_ -> (_ -> a typer_context) -> a typer_context =
  fun pat ~expected f ->
   (* TODO: expected should be a pattern, to achieve strictness *)
-  let (TType { loc = _; desc = expected_desc }) = expected in
-  match (pat, expected_desc) with
-  | LP_var { var }, _expected_desc ->
+  match (pat, expected) with
+  | LP_var { var }, expected ->
       with_binder ~var ~type_:expected @@ fun () ->
-      let* pat = tp_var expected ~var in
+      let* pat = tp_var ~annot:expected ~var in
       f pat
   | ( LP_pair { left; right },
       TT_exists { left = left_expected; right = right_expected } ) ->
@@ -186,13 +172,16 @@ and check_pat :
       let (TAnnot { loc = _; pat = _; annot = right_type }) = right_expected in
       check_pat left ~expected:left_type @@ fun left ->
       check_pat right ~expected:right_type @@ fun right ->
-      let* pat = tp_pair expected ~left ~right in
+      let* pat = tp_pair ~left ~right in
       f pat
-  | LP_pair _, _expected_desc -> error_typer_pat_not_pair ~pat ~expected
+  | LP_pair _, expected -> error_pat_not_pair ~pat ~expected
   | LP_annot { pat; annot }, _expected_desc ->
-      let* annot = infer_term annot in
-      let* annot = type_of_term annot in
-      let* () = unify_type ~expected ~received:annot in
+      let* annot =
+        let* expected = tt_type () in
+        check_term annot ~expected
+      in
+      let* () = unify_term ~expected ~received:annot in
       check_pat pat ~expected:annot f
   | LP_loc { pat; loc }, _expected_desc ->
-      with_loc ~loc @@ fun () -> check_pat pat ~expected f
+      with_tp_loc ~loc @@ fun k ->
+      check_pat pat ~expected @@ fun pat -> k pat f

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -18,68 +18,8 @@ open Unify_context
     constructors that have max_level < hole_level *)
 
 (* TODO: optimization, just check, when type is closed *)
+
 let rec unify_term ~expected ~received =
-  (* TODO: use those locations for something? *)
-  let (TTerm { loc = _; desc = expected_desc; type_ = expected_type }) =
-    expected
-  in
-  let (TTerm { loc = _; desc = received_desc; type_ = received_type }) =
-    received
-  in
-  (* TODO: why is this needed? *)
-  let* () = unify_type ~expected:expected_type ~received:received_type in
-  unify_desc ~expected:expected_desc ~received:received_desc
-
-and unify_type ~expected ~received =
-  (* TODO: use those locations for something? *)
-  let (TType { loc = _; desc = expected }) = expected in
-  let (TType { loc = _; desc = received }) = received in
-  unify_desc ~expected ~received
-
-and unify_pat ~expected ~received =
-  let (TPat { loc = _; desc = expected; type_ = expected_type }) = expected in
-  let (TPat { loc = _; desc = received; type_ = received_type }) = received in
-  (* TODO: why unify this? *)
-  let* () = unify_type ~expected:expected_type ~received:received_type in
-  unify_pat_desc ~expected ~received
-
-and unify_pat_desc ~expected ~received =
-  match (expected, received) with
-  | TP_var { var = _ }, TP_var { var = _ } -> return ()
-  | ( TP_pair { left = expected_left; right = expected_right },
-      TP_pair { left = received_left; right = received_right } ) ->
-      let* () = unify_pat ~expected:expected_left ~received:received_left in
-      unify_pat ~expected:expected_right ~received:received_right
-  | TP_annot { pat = expected; annot = _ }, received ->
-      let (TPat { loc = _; desc = expected; type_ = _ }) = expected in
-      unify_pat_desc ~expected ~received
-  | expected, TP_annot { pat = received; annot = _ } ->
-      let (TPat { loc = _; desc = received; type_ = _ }) = received in
-      unify_pat_desc ~expected ~received
-  | (TP_var _ | TP_pair _), (TP_var _ | TP_pair _) ->
-      error_pat_clash ~expected ~received
-
-and unify_annot ~expected ~received =
-  let (TAnnot { loc = _; pat = expected_pat; annot = expected_annot }) =
-    expected
-  in
-  let (TAnnot { loc = _; pat = received_pat; annot = received_annot }) =
-    received
-  in
-  let* () = unify_type ~expected:expected_annot ~received:received_annot in
-  unify_pat ~expected:expected_pat ~received:received_pat
-
-and unify_bind ~expected ~received =
-  let (TBind { loc = _; pat = expected_pat; value = expected_value }) =
-    expected
-  in
-  let (TBind { loc = _; pat = received_pat; value = received_value }) =
-    received
-  in
-  let* () = unify_term ~expected:expected_value ~received:received_value in
-  unify_pat ~expected:expected_pat ~received:received_pat
-
-and unify_desc ~expected ~received =
   match (expected, received) with
   | TT_var { offset = expected }, TT_var { offset = received } -> (
       let* expected = repr_expected_var ~var:expected in
@@ -92,7 +32,7 @@ and unify_desc ~expected ~received =
       TT_forall { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
       let* () = unify_pat ~expected:expected_param ~received:received_param in
-      unify_type ~expected:expected_return ~received:received_return
+      unify_term ~expected:expected_return ~received:received_return
   | ( TT_lambda { param = expected_param; return = expected_return },
       TT_lambda { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
@@ -116,28 +56,65 @@ and unify_desc ~expected ~received =
       TT_let { bound = received_bound; return = received_return } ) ->
       let* () = unify_bind ~expected:expected_bound ~received:received_bound in
       unify_term ~expected:expected_return ~received:received_return
-  (* TODO: why matching patterns? *)
-  | ( TT_annot { value = expected_value; annot = expected_annot },
-      TT_annot { value = received_value; annot = received_annot } ) ->
-      let* () = unify_type ~expected:expected_annot ~received:received_annot in
-      unify_term ~expected:expected_value ~received:received_value
-  | TT_offset { desc = expected; offset }, received ->
-      with_expected_offset ~offset @@ fun () -> unify_desc ~expected ~received
-  | expected, TT_offset { desc = received; offset } ->
-      with_received_offset ~offset @@ fun () -> unify_desc ~expected ~received
+  | TT_annot { term = expected; annot = _ }, received ->
+      unify_term ~expected ~received
+  | expected, TT_annot { term = received; annot = _ } ->
+      unify_term ~expected ~received
+  | TT_loc { term = expected; loc = _ }, received ->
+      unify_term ~expected ~received
+  | expected, TT_loc { term = received; loc = _ } ->
+      unify_term ~expected ~received
+      (* TODO: use those locations for something? *)
+  | TT_offset { term = expected; offset }, received ->
+      with_expected_offset ~offset @@ fun () -> unify_term ~expected ~received
+  | expected, TT_offset { term = received; offset } ->
+      with_received_offset ~offset @@ fun () -> unify_term ~expected ~received
   | ( ( TT_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_exists _
-      | TT_pair _ | TT_let _ | TT_annot _ ),
+      | TT_pair _ | TT_let _ ),
       ( TT_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_exists _
-      | TT_pair _ | TT_let _ | TT_annot _ ) ) ->
+      | TT_pair _ | TT_let _ ) ) ->
       error_type_clash ~expected ~received
+
+and unify_pat ~expected ~received =
+  match (expected, received) with
+  | TP_var { var = _ }, TP_var { var = _ } -> return ()
+  | ( TP_pair { left = expected_left; right = expected_right },
+      TP_pair { left = received_left; right = received_right } ) ->
+      let* () = unify_pat ~expected:expected_left ~received:received_left in
+      unify_pat ~expected:expected_right ~received:received_right
+  | ( TP_annot { pat = expected; annot = expected_annot },
+      TP_annot { pat = received; annot = received_annot } ) ->
+      let* () = unify_term ~expected:expected_annot ~received:received_annot in
+      unify_pat ~expected ~received
+  | TP_loc { pat = expected; loc = _ }, received ->
+      unify_pat ~expected ~received
+  | expected, TP_loc { pat = received; loc = _ } ->
+      unify_pat ~expected ~received
+  | (TP_var _ | TP_pair _ | TP_annot _), (TP_var _ | TP_pair _ | TP_annot _) ->
+      error_pat_clash ~expected ~received
+
+and unify_annot ~expected ~received =
+  let (TAnnot { loc = _; pat = expected_pat; annot = expected_annot }) =
+    expected
+  in
+  let (TAnnot { loc = _; pat = received_pat; annot = received_annot }) =
+    received
+  in
+  let* () = unify_term ~expected:expected_annot ~received:received_annot in
+  unify_pat ~expected:expected_pat ~received:received_pat
+
+and unify_bind ~expected ~received =
+  let (TBind { loc = _; pat = expected_pat; value = expected_value }) =
+    expected
+  in
+  let (TBind { loc = _; pat = received_pat; value = received_value }) =
+    received
+  in
+  let* () = unify_term ~expected:expected_value ~received:received_value in
+  unify_pat ~expected:expected_pat ~received:received_pat
 
 let unify_term ~expected ~received =
   (* TODO: does it make sense to always normalize? *)
   let* expected = normalize_term expected in
   let* received = normalize_term received in
   unify_term ~expected ~received
-
-let unify_type ~expected ~received =
-  let* expected = normalize_type expected in
-  let* received = normalize_type received in
-  unify_type ~expected ~received

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -3,6 +3,3 @@ open Context
 
 val unify_term :
   expected:term -> received:term -> unit Unify_context(Normalize).t
-
-val unify_type :
-  expected:type_ -> received:type_ -> unit Unify_context(Normalize).t


### PR DESCRIPTION
## Goals

Experiment with different tree representations for the typer.

## Context

Current typed tree representation is kind of painful to manipulate, this tries to apply the same pattern from #87 but on the typed tree.