### PR TITLE
teika: remove unification

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -3,17 +3,11 @@ open Ttree
 type error = CError of { loc : Location.t; [@opaque] desc : error_desc }
 
 and error_desc =
-  (* normalize *)
-  | CError_normalize_unknown_hole_repr of { id : Uid.t }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
   | CError_unify_type_clash of { expected : term; received : term }
   | CError_unify_pat_clash of { expected : pat; received : pat }
   | CError_unify_var_escape_scope of { var : Offset.t }
-  (* invariant *)
-  | CError_unify_unknown_hole of { id : Uid.t }
-  | CError_unify_linked_hole of { id : Uid.t }
-  | CError_unify_lower_to_higher of { id : Uid.t }
   (* typer *)
   | CError_typer_unknown_var of { var : Name.t }
   | Cerror_typer_not_a_forall of { type_ : term }
@@ -22,37 +16,8 @@ and error_desc =
   | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : term }
   (* invariant *)
   | CError_typer_term_var_not_annotated of { var : Offset.t }
-  | CError_typer_term_hole_not_annotated of { hole : Uid.t }
   | CError_typer_pat_var_not_annotated of { var : Name.t }
 [@@deriving show { with_path = false }]
-
-let[@inline always] repr_hole ~holes ~next_hole_id ~ok ~unknown ~id =
-  let index = Uid.repr id in
-  let next_hole_index = Uid.repr next_hole_id in
-  match index < next_hole_index with
-  (* TODO: try unsafe? *)
-  | true -> ok (Array.get holes index)
-  | false -> unknown ~id
-
-(* TODO: double is a lot *)
-let[@inline always] double ~holes =
-  let length = Array.length holes in
-  let new_holes =
-    let length = max (Array.length holes * 2) 1 in
-    Array.make length H_open
-  in
-  Array.blit holes 0 new_holes 0 length;
-  new_holes
-
-let[@inline always] create_hole ~holes ~next_hole_id ~ok =
-  let hole = next_hole_id in
-  let holes =
-    match Uid.repr hole >= Array.length holes with
-    | true -> double ~holes
-    | false -> holes
-  in
-  let next_hole_id = Uid.next next_hole_id in
-  ok ~holes ~next_hole_id hole
 
 module Normalize_context = struct
   type var_info = Subst of { to_ : term } | Bound of { base : Offset.t }
@@ -62,8 +27,6 @@ module Normalize_context = struct
     context :
       'k.
       vars:var_info list ->
-      holes:hole array ->
-      next_hole_id:Uid.t ->
       offset:Offset.t ->
       ok:('a -> 'k) ->
       error:(error_desc -> 'k) ->
@@ -73,26 +36,24 @@ module Normalize_context = struct
 
   type 'a t = 'a normalize_context
 
-  let[@inline always] test ~loc ~vars ~holes ~next_hole_id ~offset f =
+  let[@inline always] test ~loc ~vars ~offset f =
     let { context } = f () in
     let ok value = Ok value in
     let error desc = Error (CError { loc; desc }) in
-    context ~vars ~holes ~next_hole_id ~offset ~ok ~error
+    context ~vars ~offset ~ok ~error
 
   let[@inline always] return value =
-    let context ~vars:_ ~holes:_ ~next_hole_id:_ ~offset:_ ~ok ~error:_ =
-      ok value
-    in
+    let context ~vars:_ ~offset:_ ~ok ~error:_ = ok value in
     { context }
 
   let[@inline always] bind context f =
     let { context } = context in
-    let context ~vars ~holes ~next_hole_id ~offset ~ok ~error =
+    let context ~vars ~offset ~ok ~error =
       let ok data =
         let { context } = f data in
-        context ~vars ~holes ~next_hole_id ~offset ~ok ~error
+        context ~vars ~offset ~ok ~error
       in
-      context ~vars ~holes ~next_hole_id ~offset ~ok ~error
+      context ~vars ~offset ~ok ~error
     in
     { context }
 
@@ -103,7 +64,7 @@ module Normalize_context = struct
     return @@ f value
 
   let[@inline always] repr_var ~var =
-    let context ~vars ~holes:_ ~next_hole_id:_ ~offset ~ok ~error:_ =
+    let context ~vars ~offset ~ok ~error:_ =
       match
         (* TODO: should this be var + offset? *)
         let index = Offset.(repr (var - one)) in
@@ -123,40 +84,26 @@ module Normalize_context = struct
     { context }
 
   let[@inline always] with_var f =
-    let context ~vars ~holes ~next_hole_id ~offset ~ok ~error =
+    let context ~vars ~offset ~ok ~error =
       let vars = Bound { base = offset } :: vars in
       let { context } = f () in
-      context ~vars ~holes ~next_hole_id ~offset ~ok ~error
+      context ~vars ~offset ~ok ~error
     in
     { context }
 
   let[@inline always] elim_var ~to_ f =
-    let context ~vars ~holes ~next_hole_id ~offset ~ok ~error =
+    let context ~vars ~offset ~ok ~error =
       let vars = Subst { to_ } :: vars in
       let { context } = f () in
-      context ~vars ~holes ~next_hole_id ~offset ~ok ~error
+      context ~vars ~offset ~ok ~error
     in
     { context }
 
   let[@inline always] with_offset ~offset f =
-    let context ~vars ~holes ~next_hole_id ~offset:current_offset ~ok ~error =
+    let context ~vars ~offset:current_offset ~ok ~error =
       let offset = Offset.(current_offset + offset) in
       let { context } = f () in
-      context ~vars ~holes ~next_hole_id ~offset ~ok ~error
-    in
-    { context }
-
-  let[@inline always] repr_hole ~id =
-    let context ~vars:_ ~holes ~next_hole_id ~offset ~ok ~error =
-      let unknown ~id = error (CError_normalize_unknown_hole_repr { id }) in
-      let ok hole =
-        let term =
-          match hole with H_open -> TT_hole { id } | H_link { term } -> term
-        in
-
-        ok @@ TT_offset { term; offset }
-      in
-      repr_hole ~holes ~next_hole_id ~ok ~unknown ~id
+      context ~vars ~offset ~ok ~error
     in
     { context }
 end
@@ -169,42 +116,34 @@ struct
     (* TODO: accumulate locations during unification *)
     context :
       'k.
-      holes:hole array ->
-      next_hole_id:Uid.t ->
       expected_offset:Offset.t ->
       received_offset:Offset.t ->
-      ok:(holes:hole array -> next_hole_id:Uid.t -> 'a -> 'k) ->
-      error:(holes:hole array -> next_hole_id:Uid.t -> error_desc -> 'k) ->
+      ok:('a -> 'k) ->
+      error:(error_desc -> 'k) ->
       'k;
   }
   [@@ocaml.unboxed]
 
   type 'a t = 'a unify_context
 
-  let[@inline always] test ~loc ~holes ~next_hole_id ~expected_offset
-      ~received_offset f =
+  let[@inline always] test ~loc ~expected_offset ~received_offset f =
     let { context } = f () in
-    let ok ~holes:_ ~next_hole_id:_ value = Ok value in
-    let error ~holes:_ ~next_hole_id:_ desc = Error (CError { loc; desc }) in
-    context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok ~error
+    let ok value = Ok value in
+    let error desc = Error (CError { loc; desc }) in
+    context ~expected_offset ~received_offset ~ok ~error
 
   let[@inline always] return value =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id value
-    in
+    let context ~expected_offset:_ ~received_offset:_ ~ok ~error:_ = ok value in
     { context }
 
   let[@inline always] bind context f =
     let { context } = context in
-    let context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok
-        ~error =
-      let ok ~holes ~next_hole_id data =
+    let context ~expected_offset ~received_offset ~ok ~error =
+      let ok data =
         let { context } = f data in
-        context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok
-          ~error
+        context ~expected_offset ~received_offset ~ok ~error
       in
-      context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok ~error
+      context ~expected_offset ~received_offset ~ok ~error
     in
     { context }
 
@@ -215,42 +154,36 @@ struct
     return @@ f value
 
   let[@inline always] error_var_clash ~expected ~received =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_unify_var_clash { expected; received })
+    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
+      error (CError_unify_var_clash { expected; received })
     in
     { context }
 
   let[@inline always] error_type_clash ~expected ~received =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id
-        (CError_unify_type_clash { expected; received })
+    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
+      error (CError_unify_type_clash { expected; received })
     in
     { context }
 
   let[@inline always] error_pat_clash ~expected ~received =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_unify_pat_clash { expected; received })
+    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
+      error (CError_unify_pat_clash { expected; received })
     in
     { context }
 
   let[@inline always] error_var_escape_scope ~var =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_unify_var_escape_scope { var })
+    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
+      error (CError_unify_var_escape_scope { var })
     in
     { context }
 
   let[@inline always] with_normalize_context f =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok
-        ~error =
+    let context ~expected_offset:_ ~received_offset:_ ~ok ~error =
       let Normalize_context.{ context } = f () in
       let offset = Offset.zero in
-      let ok value = ok ~holes ~next_hole_id value in
-      let error desc = error ~holes ~next_hole_id desc in
-      context ~vars:[] ~holes ~next_hole_id ~offset ~ok ~error
+      let ok value = ok value in
+      let error desc = error desc in
+      context ~vars:[] ~offset ~ok ~error
     in
     { context }
 
@@ -258,91 +191,30 @@ struct
     with_normalize_context @@ fun () -> Normalize.normalize_term term
 
   let[@inline always] expected_offset () =
-    let context ~holes ~next_hole_id ~expected_offset ~received_offset:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id expected_offset
+    let context ~expected_offset ~received_offset:_ ~ok ~error:_ =
+      ok expected_offset
     in
     { context }
 
   let[@inline always] received_offset () =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id received_offset
+    let context ~expected_offset:_ ~received_offset ~ok ~error:_ =
+      ok received_offset
     in
     { context }
 
   let[@inline always] with_expected_offset ~offset f =
-    let context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok
-        ~error =
+    let context ~expected_offset ~received_offset ~ok ~error =
       let expected_offset = Offset.(expected_offset + offset) in
       let { context } = f () in
-      context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok ~error
+      context ~expected_offset ~received_offset ~ok ~error
     in
     { context }
 
   let[@inline always] with_received_offset ~offset f =
-    let context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok
-        ~error =
+    let context ~expected_offset ~received_offset ~ok ~error =
       let received_offset = Offset.(received_offset + offset) in
       let { context } = f () in
-      context ~holes ~next_hole_id ~expected_offset ~received_offset ~ok ~error
-    in
-    { context }
-
-  let[@inline always] repr_hole ~id =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok
-        ~error =
-      let unknown ~id =
-        error ~holes ~next_hole_id (CError_unify_unknown_hole { id })
-      in
-      let ok repr = ok ~holes ~next_hole_id repr in
-      repr_hole ~holes ~next_hole_id ~ok ~unknown ~id
-    in
-    { context }
-
-  let[@inline always] link_hole ~id ~to_ ~offset =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok
-        ~error =
-      let index = Uid.repr id in
-      let next_hole_index = Uid.repr next_hole_id in
-      match index < next_hole_index with
-      | true -> (
-          match Array.get holes index with
-          | H_open ->
-              let term = TT_offset { term = to_; offset } in
-              Array.set holes index (H_link { term });
-              ok ~holes ~next_hole_id ()
-          | H_link { term = _ } ->
-              error ~holes ~next_hole_id (CError_unify_linked_hole { id }))
-      | false -> error ~holes ~next_hole_id (CError_unify_unknown_hole { id })
-    in
-    { context }
-
-  (* TODO: diff is a bad name *)
-  let[@inline always] lower_hole ~id ~diff =
-    let context ~holes ~next_hole_id ~expected_offset:_ ~received_offset:_ ~ok
-        ~error =
-      let index = Uid.repr id in
-      let next_hole_index = Uid.repr next_hole_id in
-      match index < next_hole_index with
-      | true -> (
-          match Array.get holes index with
-          | H_open -> (
-              match Offset.(diff < zero) with
-              | true ->
-                  error ~holes ~next_hole_id
-                    (CError_unify_lower_to_higher { id })
-              | false ->
-                  let ok ~holes ~next_hole_id new_hole =
-                    let new_hole = TT_hole { id = new_hole } in
-                    let term = TT_offset { term = new_hole; offset = diff } in
-                    Array.set holes index (H_link { term });
-                    ok ~holes ~next_hole_id ()
-                  in
-                  create_hole ~holes ~next_hole_id ~ok)
-          | H_link { term = _ } ->
-              error ~holes ~next_hole_id (CError_unify_linked_hole { id }))
-      | false -> error ~holes ~next_hole_id (CError_unify_unknown_hole { id })
+      context ~expected_offset ~received_offset ~ok ~error
     in
     { context }
 end
@@ -358,13 +230,11 @@ struct
     (* TODO: accumulate locations during instantiation *)
     context :
       'k.
-      holes:hole array ->
-      next_hole_id:Uid.t ->
       type_of_types:Level.t ->
       level:Level.t ->
       names:(Level.t * term) Name.Tbl.t ->
-      ok:(holes:hole array -> next_hole_id:Uid.t -> 'a -> 'k) ->
-      error:(holes:hole array -> next_hole_id:Uid.t -> error_desc -> 'k) ->
+      ok:('a -> 'k) ->
+      error:(error_desc -> 'k) ->
       'k;
   }
   [@@ocaml.unboxed]
@@ -373,9 +243,6 @@ struct
 
   let[@inline always] run ~loc f =
     let { context } = f () in
-    (* TODO: meaningful size? *)
-    let holes = Array.make 1024 H_open in
-    let next_hole_id = Uid.initial in
     let type_of_types = Level.zero in
     let level = Level.next type_of_types in
     (* TODO: meaningful size?
@@ -387,32 +254,28 @@ struct
      let type_ = TT_annot { term = type_; annot = type_ } in
      (* TODO: better place for constants *)
      Name.Tbl.add names type_name (type_of_types, type_));
-    let ok ~holes:_ ~next_hole_id:_ value = Ok value in
-    let error ~holes:_ ~next_hole_id:_ desc = Error (CError { loc; desc }) in
-    context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error
+    let ok value = Ok value in
+    let error desc = Error (CError { loc; desc }) in
+    context ~type_of_types ~level ~names ~ok ~error
 
-  let[@inline always] test ~loc ~holes ~next_hole_id ~type_of_types ~level
-      ~names f =
+  let[@inline always] test ~loc ~type_of_types ~level ~names f =
     let { context } = f () in
-    let ok ~holes:_ ~next_hole_id:_ value = Ok value in
-    let error ~holes:_ ~next_hole_id:_ desc = Error (CError { loc; desc }) in
-    context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error
+    let ok value = Ok value in
+    let error desc = Error (CError { loc; desc }) in
+    context ~type_of_types ~level ~names ~ok ~error
 
   let[@inline always] return value =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id value
-    in
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ = ok value in
     { context }
 
   let[@inline always] bind context f =
     let { context } = context in
-    let context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error =
-      let ok ~holes ~next_hole_id data =
+    let context ~type_of_types ~level ~names ~ok ~error =
+      let ok data =
         let { context } = f data in
-        context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error
+        context ~type_of_types ~level ~names ~ok ~error
       in
-      context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error
+      context ~type_of_types ~level ~names ~ok ~error
     in
     { context }
 
@@ -423,93 +286,79 @@ struct
     return @@ f value
 
   let[@inline always] error_pat_not_annotated ~pat =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_typer_pat_not_annotated { pat })
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+      error (CError_typer_pat_not_annotated { pat })
     in
     { context }
 
   let[@inline always] error_pat_not_pair ~pat ~expected =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_typer_pat_not_pair { pat; expected })
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+      error (CError_typer_pat_not_pair { pat; expected })
     in
     { context }
 
   let[@inline always] error_term_var_not_annotated ~var =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_typer_term_var_not_annotated { var })
-    in
-    { context }
-
-  let[@inline always] error_term_hole_not_annotated ~hole =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_typer_term_hole_not_annotated { hole })
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+      error (CError_typer_term_var_not_annotated { var })
     in
     { context }
 
   let[@inline always] error_pat_var_not_annotated ~var =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok:_
-        ~error =
-      error ~holes ~next_hole_id (CError_typer_pat_var_not_annotated { var })
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
+      error (CError_typer_pat_var_not_annotated { var })
     in
     { context }
 
   let[@inline always] instance ~var =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level ~names ~ok ~error =
+    let context ~type_of_types:_ ~level ~names ~ok ~error =
       match Name.Tbl.find_opt names var with
       | Some (var_level, type_) ->
           let offset = Level.offset ~from:var_level ~to_:level in
           let type_ = TT_offset { term = type_; offset } in
-          ok ~holes ~next_hole_id (offset, type_)
-      | None -> error ~holes ~next_hole_id (CError_typer_unknown_var { var })
+          ok (offset, type_)
+      | None -> error (CError_typer_unknown_var { var })
     in
     { context }
 
   let[@inline always] with_binder ~var ~type_ f =
-    let context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error =
+    let context ~type_of_types ~level ~names ~ok ~error =
       Name.Tbl.add names var (level, type_);
       let level = Level.next level in
       let { context } = f () in
-      let ok ~holes ~next_hole_id value =
+      let ok value =
         Name.Tbl.remove names var;
-        ok ~holes ~next_hole_id value
+        ok value
       in
-      context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error
+      context ~type_of_types ~level ~names ~ok ~error
     in
     { context }
 
   module Unify_context = Unify_context (Normalize)
 
   let[@inline always] unify_term ~expected ~received =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
       let Unify_context.{ context } = Unify.unify_term ~expected ~received in
-      context ~holes ~next_hole_id ~expected_offset:Offset.zero
-        ~received_offset:Offset.zero ~ok ~error
+      context ~expected_offset:Offset.zero ~received_offset:Offset.zero ~ok
+        ~error
     in
     { context }
 
   let[@inline always] with_tt_loc ~loc f =
-    let context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error =
+    let context ~type_of_types ~level ~names ~ok ~error =
       let { context } = f () in
-      let ok ~holes ~next_hole_id term =
-        ok ~holes ~next_hole_id @@ TT_loc { term; loc }
-      in
-      context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error
+      let ok term = ok @@ TT_loc { term; loc } in
+      context ~type_of_types ~level ~names ~ok ~error
     in
     { context }
 
   let[@inline always] with_tp_loc ~loc f =
-    let context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error =
+    let context ~type_of_types ~level ~names ~ok ~error =
       let { context } =
         f (fun pat k ->
             let pat = TP_loc { pat; loc } in
             k pat)
       in
-      context ~holes ~next_hole_id ~type_of_types ~level ~names ~ok ~error
+      context ~type_of_types ~level ~names ~ok ~error
     in
     { context }
 
@@ -520,12 +369,11 @@ struct
     TT_var { offset }
 
   let[@inline always] with_normalize_context f =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
       let Normalize_context.{ context } = f () in
-      let ok value = ok ~holes ~next_hole_id value in
-      let error desc = error ~holes ~next_hole_id desc in
-      context ~vars:[] ~holes ~next_hole_id ~offset:Offset.zero ~ok ~error
+      let ok value = ok value in
+      let error desc = error desc in
+      context ~vars:[] ~offset:Offset.zero ~ok ~error
     in
     { context }
 
@@ -537,13 +385,12 @@ struct
     (* TODO: two normalize guarantees no TT_offset? *)
     (* TODO: it doesn't *)
     let* type_ = normalize_term type_ in
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
       match type_ with
-      | TT_forall { param; return } -> ok ~holes ~next_hole_id (param, return)
-      | TT_var _ | TT_hole _ | TT_lambda _ | TT_apply _ | TT_exists _
-      | TT_pair _ | TT_let _ | TT_annot _ | TT_loc _ | TT_offset _ ->
-          error ~holes ~next_hole_id (Cerror_typer_not_a_forall { type_ })
+      | TT_forall { param; return } -> ok (param, return)
+      | TT_var _ | TT_lambda _ | TT_apply _ | TT_exists _ | TT_pair _ | TT_let _
+      | TT_annot _ | TT_loc _ | TT_offset _ ->
+          error (Cerror_typer_not_a_forall { type_ })
     in
     { context }
 
@@ -551,115 +398,100 @@ struct
     let* type_ = normalize_term type_ in
     (* TODO: two normalize guarantees no TT_offset? *)
     let* type_ = normalize_term type_ in
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error =
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
       match type_ with
-      | TT_exists { left; right } -> ok ~holes ~next_hole_id (left, right)
-      | TT_var _ | TT_hole _ | TT_forall _ | TT_lambda _ | TT_apply _
-      | TT_pair _ | TT_let _ | TT_annot _ | TT_loc _ | TT_offset _ ->
-          error ~holes ~next_hole_id (Cerror_typer_not_an_exists { type_ })
+      | TT_exists { left; right } -> ok (left, right)
+      | TT_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_pair _ | TT_let _
+      | TT_annot _ | TT_loc _ | TT_offset _ ->
+          error (Cerror_typer_not_an_exists { type_ })
     in
     { context }
 
   let[@inline always] tt_annot ~annot term = TT_annot { term; annot }
 
   let[@inline always] tt_type () =
-    let context ~holes ~next_hole_id ~type_of_types ~level ~names:_ ~ok ~error:_
-        =
-      ok ~holes ~next_hole_id @@ tt_type ~type_of_types ~level
+    let context ~type_of_types ~level ~names:_ ~ok ~error:_ =
+      ok @@ tt_type ~type_of_types ~level
     in
     { context }
 
   let[@inline always] tt_var ~annot ~offset =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ tt_annot ~annot @@ TT_var { offset }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ tt_annot ~annot @@ TT_var { offset }
     in
     { context }
 
   let[@inline always] tt_forall ~param ~return =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TT_forall { param; return }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_forall { param; return }
     in
     { context }
 
   let[@inline always] tt_lambda ~param ~return =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TT_lambda { param; return }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_lambda { param; return }
     in
     { context }
 
   let[@inline always] tt_apply ~lambda ~arg =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TT_apply { lambda; arg }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_apply { lambda; arg }
     in
     { context }
 
   let[@inline always] tt_exists ~left ~right =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TT_exists { left; right }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_exists { left; right }
     in
     { context }
 
   let[@inline always] tt_pair ~left ~right =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TT_pair { left; right }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_pair { left; right }
     in
     { context }
 
   let[@inline always] tt_let ~bound ~return =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TT_let { bound; return }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TT_let { bound; return }
     in
     { context }
 
   let[@inline always] tt_annot ~term ~annot =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ tt_annot ~annot term
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ tt_annot ~annot term
     in
     { context }
 
   let[@inline always] tp_annot ~annot pat = TP_annot { pat; annot }
 
   let[@inline always] tp_var ~annot ~var =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ tp_annot ~annot @@ TP_var { var }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ tp_annot ~annot @@ TP_var { var }
     in
     { context }
 
   let[@inline always] tp_pair ~left ~right =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TP_pair { left; right }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TP_pair { left; right }
     in
     { context }
 
   let[@inline always] tp_annot ~pat ~annot =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TP_annot { pat; annot }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TP_annot { pat; annot }
     in
     { context }
 
   let[@inline always] tannot ~loc ~pat ~annot =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TAnnot { loc; pat; annot }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TAnnot { loc; pat; annot }
     in
     { context }
 
   let[@inline always] tbind ~loc ~pat ~value =
-    let context ~holes ~next_hole_id ~type_of_types:_ ~level:_ ~names:_ ~ok
-        ~error:_ =
-      ok ~holes ~next_hole_id @@ TBind { loc; pat; value }
+    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
+      ok @@ TBind { loc; pat; value }
     in
     { context }
 end

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -3,17 +3,11 @@ open Ttree
 type error = private CError of { loc : Location.t; desc : error_desc }
 
 and error_desc = private
-  (* normalize *)
-  | CError_normalize_unknown_hole_repr of { id : Uid.t }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
   | CError_unify_type_clash of { expected : term; received : term }
   | CError_unify_pat_clash of { expected : pat; received : pat }
   | CError_unify_var_escape_scope of { var : Offset.t }
-  (* invariant *)
-  | CError_unify_unknown_hole of { id : Uid.t }
-  | CError_unify_linked_hole of { id : Uid.t }
-  | CError_unify_lower_to_higher of { id : Uid.t }
   (* typer *)
   | CError_typer_unknown_var of { var : Name.t }
   | Cerror_typer_not_a_forall of { type_ : term }
@@ -22,7 +16,6 @@ and error_desc = private
   | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : term }
   (* invariant *)
   | CError_typer_term_var_not_annotated of { var : Offset.t }
-  | CError_typer_term_hole_not_annotated of { hole : Uid.t }
   | CError_typer_pat_var_not_annotated of { var : Name.t }
 [@@deriving show]
 
@@ -35,8 +28,6 @@ module Normalize_context : sig
   val test :
     loc:Warnings.loc ->
     vars:var_info list ->
-    holes:hole array ->
-    next_hole_id:Uid.t ->
     offset:Offset.t ->
     (unit -> 'a normalize_context) ->
     ('a, error) result
@@ -58,9 +49,6 @@ module Normalize_context : sig
   val elim_var :
     to_:term -> (unit -> 'a normalize_context) -> 'a normalize_context
 
-  (* holes *)
-  val repr_hole : id:Uid.t -> term normalize_context
-
   (* offset *)
   val with_offset :
     offset:Offset.t -> (unit -> 'a normalize_context) -> 'a normalize_context
@@ -76,8 +64,6 @@ end) : sig
   (* monad *)
   val test :
     loc:Warnings.loc ->
-    holes:hole array ->
-    next_hole_id:Uid.t ->
     expected_offset:Offset.t ->
     received_offset:Offset.t ->
     (unit -> 'a unify_context) ->
@@ -111,11 +97,6 @@ end) : sig
 
   val with_received_offset :
     offset:Offset.t -> (unit -> 'a unify_context) -> 'a unify_context
-
-  (* holes *)
-  val repr_hole : id:Uid.t -> hole unify_context
-  val link_hole : id:Uid.t -> to_:term -> offset:Offset.t -> unit unify_context
-  val lower_hole : id:Uid.t -> diff:Offset.t -> unit unify_context
 end
 
 module Typer_context (Normalize : sig
@@ -132,8 +113,6 @@ end) : sig
 
   val test :
     loc:Warnings.loc ->
-    holes:hole array ->
-    next_hole_id:Uid.t ->
     type_of_types:Level.t ->
     level:Level.t ->
     names:(Level.t * term) Name.Tbl.t ->
@@ -152,7 +131,6 @@ end) : sig
   val error_pat_not_annotated : pat:Ltree.pat -> 'a typer_context
   val error_pat_not_pair : pat:Ltree.pat -> expected:term -> 'a typer_context
   val error_term_var_not_annotated : var:Offset.t -> 'a typer_context
-  val error_term_hole_not_annotated : hole:Uid.t -> 'a typer_context
   val error_pat_var_not_annotated : var:Name.t -> 'a typer_context
 
   (* vars *)

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -9,7 +9,6 @@
 
 type term =
   | TT_var of { offset : Offset.t }
-  | TT_hole of { id : Uid.t }
   | TT_forall of { param : pat; return : term }
   | TT_lambda of { param : pat; return : term }
   | TT_apply of { lambda : term; arg : term }
@@ -30,7 +29,6 @@ and pat =
   | TP_loc of { pat : pat; loc : Location.t [@opaque] }
 
 and annot = TAnnot of { loc : Location.t; [@opaque] pat : pat; annot : term }
-and bind = TBind of { loc : Location.t; [@opaque] pat : pat; value : term }
 
-and hole = H_open | H_link of { term : term }
+and bind = TBind of { loc : Location.t; [@opaque] pat : pat; value : term }
 [@@deriving show { with_path = false }]

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -3,8 +3,6 @@
 type term =
   (* x *)
   | TT_var of { offset : Offset.t }
-  (* _A *)
-  | TT_hole of { id : Uid.t }
   (* (x : A) -> B *)
   | TT_forall of { param : pat; return : term }
   (* (x : A) => e *)
@@ -32,5 +30,6 @@ and pat =
   | TP_loc of { pat : pat; loc : Location.t }
 
 and annot = TAnnot of { loc : Location.t; pat : pat; annot : term }
+
 and bind = TBind of { loc : Location.t; pat : pat; value : term }
-and hole = H_open | H_link of { term : term } [@@deriving show]
+[@@deriving show]

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -6,7 +6,6 @@ open Typer_context
 let rec typeof_term term =
   match term with
   | TT_var { offset = var } -> error_term_var_not_annotated ~var
-  | TT_hole { id = hole } -> error_term_hole_not_annotated ~hole
   | TT_forall { param = _; return = _ } -> tt_type ()
   | TT_lambda { param; return } ->
       let* return = typeof_term return in

--- a/teika/uid.ml
+++ b/teika/uid.ml
@@ -1,5 +1,0 @@
-type t = int [@@deriving show, eq, ord]
-
-let initial = 0
-let next n = n + 1
-let repr n = n

--- a/teika/uid.mli
+++ b/teika/uid.mli
@@ -1,5 +1,0 @@
-type t [@@deriving show, eq, ord]
-
-val initial : t
-val next : t -> t
-val repr : t -> int

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -19,90 +19,9 @@ open Unify_context
 
 (* TODO: optimization, just check, when type is closed *)
 
-(* TODO: should probably be on it's own context *)
-let rec occurs_and_escape_check_term ~hole_offset ~to_offset ~to_ =
-  let occurs_and_escape_check_term ~to_offset ~to_ =
-    occurs_and_escape_check_term ~hole_offset ~to_offset ~to_
-  in
-  let occurs_and_escape_check_pat ~to_offset ~to_ =
-    occurs_and_escape_check_pat ~hole_offset ~to_offset ~to_
-  in
-  let occurs_and_escape_check_annot ~to_offset ~to_ =
-    occurs_and_escape_check_annot ~hole_offset ~to_offset ~to_
-  in
-  let occurs_and_escape_check_bind ~to_offset ~to_ =
-    occurs_and_escape_check_bind ~hole_offset ~to_offset ~to_
-  in
-  match to_ with
-  | TT_var { offset } -> (
-      let offset = Offset.(to_offset + offset) in
-      match Offset.(offset < hole_offset) with
-      | true -> error_var_escape_scope ~var:offset
-      | false -> return ())
-  | TT_hole { id } -> (
-      let* in_repr = repr_hole ~id in
-      match in_repr with
-      | H_open -> (
-          let diff = Offset.(hole_offset - to_offset) in
-          match Offset.(zero < diff) with
-          | true -> lower_hole ~id ~diff
-          | false -> return ())
-      | H_link { term = to_ } -> occurs_and_escape_check_term ~to_offset ~to_)
-  | TT_forall { param; return } ->
-      let* () = occurs_and_escape_check_pat ~to_offset ~to_:param in
-      occurs_and_escape_check_term ~to_offset ~to_:return
-  | TT_lambda { param; return } ->
-      let* () = occurs_and_escape_check_pat ~to_offset ~to_:param in
-      occurs_and_escape_check_term ~to_offset ~to_:return
-  | TT_apply { lambda; arg } ->
-      let* () = occurs_and_escape_check_term ~to_offset ~to_:lambda in
-      occurs_and_escape_check_term ~to_offset ~to_:arg
-  | TT_exists { left; right } ->
-      let* () = occurs_and_escape_check_annot ~to_offset ~to_:left in
-      occurs_and_escape_check_annot ~to_offset ~to_:right
-  | TT_pair { left; right } ->
-      let* () = occurs_and_escape_check_bind ~to_offset ~to_:left in
-      occurs_and_escape_check_bind ~to_offset ~to_:right
-  | TT_let { bound; return } ->
-      let* () = occurs_and_escape_check_bind ~to_offset ~to_:bound in
-      occurs_and_escape_check_term ~to_offset ~to_:return
-  | TT_annot { term; annot } ->
-      (* TODO: check annot? *)
-      let* () = occurs_and_escape_check_term ~to_offset ~to_:annot in
-      occurs_and_escape_check_term ~to_offset ~to_:term
-  | TT_offset { term; offset } ->
-      let to_offset = Offset.(to_offset + offset) in
-      occurs_and_escape_check_term ~to_offset ~to_:term
-  | TT_loc { term; loc = _ } ->
-      occurs_and_escape_check_term ~to_offset ~to_:term
+(* TODO: occurs should probably be on it's own context *)
 
-and occurs_and_escape_check_pat ~hole_offset ~to_offset ~to_ =
-  let occurs_and_escape_check_term ~to_ =
-    occurs_and_escape_check_term ~hole_offset ~to_offset ~to_
-  in
-  let occurs_and_escape_check_pat ~to_ =
-    occurs_and_escape_check_pat ~hole_offset ~to_offset ~to_
-  in
-  match to_ with
-  | TP_var { var = _ } -> return ()
-  | TP_pair { left; right } ->
-      let* () = occurs_and_escape_check_pat ~to_:left in
-      occurs_and_escape_check_pat ~to_:right
-  | TP_annot { pat; annot } ->
-      let* () = occurs_and_escape_check_term ~to_:annot in
-      occurs_and_escape_check_pat ~to_:pat
-  | TP_loc { pat; loc = _ } -> occurs_and_escape_check_pat ~to_:pat
-
-and occurs_and_escape_check_annot ~hole_offset ~to_offset ~to_ =
-  let (TAnnot { loc = _; pat; annot }) = to_ in
-  let* () = occurs_and_escape_check_term ~hole_offset ~to_offset ~to_:annot in
-  occurs_and_escape_check_pat ~hole_offset ~to_offset ~to_:pat
-
-and occurs_and_escape_check_bind ~hole_offset ~to_offset ~to_ =
-  let (TBind { loc = _; pat; value }) = to_ in
-  let* () = occurs_and_escape_check_term ~hole_offset ~to_offset ~to_:value in
-  occurs_and_escape_check_pat ~hole_offset ~to_offset ~to_:pat
-
+(* TODO: diff is a bad name *)
 let rec unify_term ~expected ~received =
   match (expected, received) with
   | TT_var { offset = expected }, TT_var { offset = received } -> (
@@ -113,22 +32,6 @@ let rec unify_term ~expected ~received =
       match Offset.equal expected received with
       | true -> return ()
       | false -> error_var_clash ~expected ~received)
-  | TT_hole { id = hole }, received -> (
-      let* expected = repr_hole ~id:hole in
-      match expected with
-      | H_open ->
-          let* hole_offset = expected_offset () in
-          let* to_offset = received_offset () in
-          unify_hole ~hole ~hole_offset ~to_:received ~to_offset
-      | H_link { term = expected } -> unify_term ~expected ~received)
-  | expected, TT_hole { id = hole } -> (
-      let* received = repr_hole ~id:hole in
-      match received with
-      | H_open ->
-          let* hole_offset = received_offset () in
-          let* to_offset = expected_offset () in
-          unify_hole ~hole ~hole_offset ~to_:expected ~to_offset
-      | H_link { term = received } -> unify_term ~expected ~received)
   (* TODO: track whenever it is unified and locations, visualizing inference *)
   | ( TT_forall { param = expected_param; return = expected_return },
       TT_forall { param = received_param; return = received_return } ) ->
@@ -214,11 +117,6 @@ and unify_bind ~expected ~received =
   in
   let* () = unify_term ~expected:expected_value ~received:received_value in
   unify_pat ~expected:expected_pat ~received:received_pat
-
-and unify_hole ~hole ~hole_offset ~to_ ~to_offset =
-  let* () = occurs_and_escape_check_term ~hole_offset ~to_offset ~to_ in
-  let offset = Offset.(to_offset - hole_offset) in
-  link_hole ~id:hole ~to_ ~offset
 
 let unify_term ~expected ~received =
   (* TODO: does it make sense to always normalize? *)


### PR DESCRIPTION
## Goals

Reduce the complexity to extend Teika

## Context

At #89 I did introduce unification back, but after many hours playing with it, it doesn't seems to be the right decision, especially in the presence of subtyping.