### PR TITLE
teika: remove support to pairs

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -11,9 +11,8 @@ and error_desc = private
   (* typer *)
   | CError_typer_unknown_var of { var : Name.t }
   | Cerror_typer_not_a_forall of { type_ : term }
-  | Cerror_typer_not_an_exists of { type_ : term }
   | CError_typer_pat_not_annotated of { pat : Ltree.pat }
-  | CError_typer_pat_not_pair of { pat : Ltree.pat; expected : term }
+  | CError_typer_pairs_not_implemented
   (* invariant *)
   | CError_typer_term_var_not_annotated of { var : Offset.t }
   | CError_typer_pat_var_not_annotated of { var : Name.t }
@@ -129,9 +128,9 @@ end) : sig
 
   (* errors *)
   val error_pat_not_annotated : pat:Ltree.pat -> 'a typer_context
-  val error_pat_not_pair : pat:Ltree.pat -> expected:term -> 'a typer_context
   val error_term_var_not_annotated : var:Offset.t -> 'a typer_context
   val error_pat_var_not_annotated : var:Name.t -> 'a typer_context
+  val error_pairs_not_implemented : unit -> 'a typer_context
 
   (* vars *)
   val instance : var:Name.t -> (Offset.t * term) typer_context
@@ -157,17 +156,10 @@ end) : sig
   val tt_forall : param:pat -> return:term -> term typer_context
   val tt_lambda : param:pat -> return:term -> term typer_context
   val tt_apply : lambda:term -> arg:term -> term typer_context
-  val tt_exists : left:annot -> right:annot -> term typer_context
-  val tt_pair : left:bind -> right:bind -> term typer_context
-  val tt_let : bound:bind -> return:term -> term typer_context
   val tt_annot : term:term -> annot:term -> term typer_context
   val tp_var : annot:term -> var:Name.t -> pat typer_context
-  val tp_pair : left:pat -> right:pat -> pat typer_context
   val tp_annot : pat:pat -> annot:term -> pat typer_context
-  val tannot : loc:Location.t -> pat:pat -> annot:term -> annot typer_context
-  val tbind : loc:Location.t -> pat:pat -> value:term -> bind typer_context
 
   (* utils *)
   val split_forall : term -> (pat * term) typer_context
-  val split_exists : term -> (annot * annot) typer_context
 end

--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -27,17 +27,6 @@ let rec normalize_term term =
           (* TODO: match every case below *)
           elim_apply ~pat:param ~return ~arg @@ fun () -> normalize_term return
       | _ -> return @@ TT_apply { lambda; arg })
-  | TT_exists { left; right } ->
-      normalize_annot left @@ fun left ->
-      normalize_annot right @@ fun right -> return @@ TT_exists { left; right }
-  | TT_pair { left; right } ->
-      normalize_bind left @@ fun left ->
-      normalize_bind right @@ fun right -> return @@ TT_pair { left; right }
-  | TT_let { bound; return } ->
-      normalize_bind bound @@ fun bound ->
-      let (TBind { loc = _lambda_loc; pat = param; value = arg }) = bound in
-      let lambda = TT_lambda { param; return } in
-      normalize_term (TT_apply { lambda; arg })
 
 (* TODO: weird *)
 and elim_apply ~pat ~return ~arg f =
@@ -46,38 +35,13 @@ and elim_apply ~pat ~return ~arg f =
   | TP_loc { pat; loc = _ }, arg -> elim_apply ~pat ~return ~arg f
   | TP_var { var = _ }, arg ->
       with_offset ~offset:Offset.(zero - one) @@ fun () -> elim_var ~to_:arg f
-  | ( TP_pair { left = left_pat; right = right_pat },
-      TT_pair { left = left_arg; right = right_arg } ) ->
-      (* TODO: what if bind pat is not just var? This is wrong *)
-      let (TBind { loc = _; pat = _; value = left_arg }) = left_arg in
-      let (TBind { loc = _; pat = _; value = right_arg }) = right_arg in
-      elim_apply ~pat:left_pat ~return ~arg:left_arg @@ fun () ->
-      elim_apply ~pat:right_pat ~return ~arg:right_arg f
-  | (TP_pair _ as param), arg ->
-      let lambda = TT_lambda { param; return } in
-      let apply = TT_apply { lambda; arg } in
-      Context.Normalize_context.return apply
 
 and normalize_pat pat f =
   match pat with
   | TP_var { var } ->
       (* TODO: ensure all pat variables are wrapped with annotation *)
       with_var @@ fun () -> f (TP_var { var })
-  | TP_pair { left; right } ->
-      normalize_pat left @@ fun left ->
-      normalize_pat right @@ fun right -> f (TP_pair { left; right })
   | TP_annot { pat; annot } ->
       let* annot = normalize_term annot in
       normalize_pat pat @@ fun pat -> f (TP_annot { pat; annot })
   | TP_loc { pat; loc = _ } -> normalize_pat pat f
-
-and normalize_annot annot f =
-  let (TAnnot { loc; pat; annot }) = annot in
-  let* annot = normalize_term annot in
-  normalize_pat pat @@ fun pat -> f (TAnnot { loc; pat; annot })
-
-and normalize_bind bind f =
-  let (TBind { loc; pat; value }) = bind in
-  let* value = normalize_term value in
-  normalize_pat pat @@ fun pat ->
-  elim_var ~to_:value @@ fun () -> f (TBind { loc; pat; value })

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -324,10 +324,10 @@ module Typer = struct
       {|(((A : Type) => (x : A) => (y : A) => y)
         : (A : Type) -> (x : A) -> (y : A) -> A)|}
 
-  let pair =
-    check "pair" ~wrapper:false
-      {|(((A : Type) => (B : Type) => (x : A) => (y : B) => (x = x, y = y))
-        : (A : Type) -> (B : Type) -> (x : A) -> (y : B) -> (x  : A, y : B))|}
+  (* let pair =
+     check "pair" ~wrapper:false
+       {|(((A : Type) => (B : Type) => (x : A) => (y : B) => (x = x, y = y))
+         : (A : Type) -> (B : Type) -> (x : A) -> (y : B) -> (x  : A, y : B))|} *)
 
   (* let left_unpair =
        check "left_unpair" ~wrapper:false
@@ -362,9 +362,10 @@ module Typer = struct
       bool;
       true_;
       false_;
-      pair;
-      (* left_unpair;
-         right_unpair; *)
+      (*
+          pair;
+          left_unpair;
+          right_unpair; *)
     ]
 
   (* alcotest *)

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -12,23 +12,12 @@ type term =
   | TT_forall of { param : pat; return : term }
   | TT_lambda of { param : pat; return : term }
   | TT_apply of { lambda : term; arg : term }
-  | TT_exists of { left : annot; right : annot }
-  | TT_pair of { left : bind; right : bind }
-  | TT_let of { bound : bind; return : term }
   | TT_annot of { term : term; annot : term }
   | TT_offset of { term : term; offset : Offset.t }
   | TT_loc of { term : term; loc : Location.t [@opaque] }
 
 and pat =
-  (* x *)
   | TP_var of { var : Name.t }
-  (* (p1, p2) *)
-  | TP_pair of { left : pat; right : pat }
-  (* (p : T) *)
   | TP_annot of { pat : pat; annot : term }
   | TP_loc of { pat : pat; loc : Location.t [@opaque] }
-
-and annot = TAnnot of { loc : Location.t; [@opaque] pat : pat; annot : term }
-
-and bind = TBind of { loc : Location.t; [@opaque] pat : pat; value : term }
 [@@deriving show { with_path = false }]

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -9,12 +9,6 @@ type term =
   | TT_lambda of { param : pat; return : term }
   (* l a *)
   | TT_apply of { lambda : term; arg : term }
-  (* (x : A, y : B) *)
-  | TT_exists of { left : annot; right : annot }
-  (* (x = 0, y = 0) *)
-  | TT_pair of { left : bind; right : bind }
-  (* x = v; r *)
-  | TT_let of { bound : bind; return : term }
   (* (v : T) *)
   | TT_annot of { term : term; annot : term }
   | TT_offset of { term : term; offset : Offset.t }
@@ -23,13 +17,7 @@ type term =
 and pat =
   (* x *)
   | TP_var of { var : Name.t }
-  (* (p1, p2) *)
-  | TP_pair of { left : pat; right : pat }
   (* (p : T) *)
   | TP_annot of { pat : pat; annot : term }
   | TP_loc of { pat : pat; loc : Location.t }
-
-and annot = TAnnot of { loc : Location.t; pat : pat; annot : term }
-
-and bind = TBind of { loc : Location.t; pat : pat; value : term }
 [@@deriving show]


### PR DESCRIPTION
## Goals

Have progress on a working core with inference and induction.

## Context

I've been stuck a couple days on the normalization of dependent pairs in the context of a linear calculus, while it seems like it is feasible through permutation of typing rules I don't have the right knowledge to do that right now. Additionally I also don't know if it matters as this normalization only happens to check terms on the type level.

But instead of being stuck fighting it, I will just drop it for now to get a good core. Will revisit this in a couple weeks.