### PR TITLE
teika: add simple printer for ttree

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -5,12 +5,18 @@ type error = CError of { loc : Location.t; [@opaque] desc : error_desc }
 and error_desc =
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
-  | CError_unify_type_clash of { expected : term; received : term }
-  | CError_unify_pat_clash of { expected : pat; received : pat }
+  | CError_unify_type_clash of {
+      expected : term; [@printer Tprinter.pp_term]
+      received : term; [@printer Tprinter.pp_term]
+    }
+  | CError_unify_pat_clash of {
+      expected : pat; [@printer Tprinter.pp_pat]
+      received : pat; [@printer Tprinter.pp_pat]
+    }
   | CError_unify_var_escape_scope of { var : Offset.t }
   (* typer *)
   | CError_typer_unknown_var of { var : Name.t }
-  | Cerror_typer_not_a_forall of { type_ : term }
+  | Cerror_typer_not_a_forall of { type_ : term [@printer Tprinter.pp_term] }
   | CError_typer_pat_not_annotated of { pat : Ltree.pat }
   | CError_typer_pairs_not_implemented
   (* invariant *)

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -1,0 +1,163 @@
+[@@@ocaml.warning "-unused-constructor"]
+
+open Ttree
+
+module Ptree = struct
+  open Format
+
+  type term =
+    | PT_loc of { term : term; loc : Location.t }
+    | PT_offset of { term : term; offset : Offset.t }
+    | PT_var_index of { index : Offset.t }
+    | PT_var_name of { name : Name.t }
+    | PT_forall of { param : term; return : term }
+    | PT_lambda of { param : term; return : term }
+    | PT_apply of { lambda : term; arg : term }
+    | PT_annot of { term : term; annot : term }
+
+  let pp_loc fmt loc =
+    let pp_pos fmt pos =
+      let Lexing.{ pos_fname; pos_lnum; pos_bol; pos_cnum = _ } = pos in
+      (* TODO: print only file by default? *)
+      fprintf fmt "%s:%d:%d" pos_fname pos_lnum pos_bol
+    in
+    let Location.{ loc_start; loc_end; loc_ghost = _ } = loc in
+    match Location.is_none loc with
+    | true -> fprintf fmt "[%a .. %a]" pp_pos loc_start pp_pos loc_end
+    | false -> fprintf fmt "[__NONE__]"
+
+  let pp_offset fmt offset =
+    match Offset.(offset < zero) with
+    | true -> fprintf fmt "%d" (Offset.repr offset)
+    | false -> fprintf fmt "+%d" (Offset.repr offset)
+
+  let pp_term_syntax ~pp_wrapped ~pp_funct ~pp_apply ~pp_atom fmt term =
+    match term with
+    | PT_loc { term; loc } -> fprintf fmt "%a#%a" pp_atom term pp_loc loc
+    | PT_offset { term; offset } ->
+        fprintf fmt "%a#%a" pp_atom term pp_offset offset
+    | PT_var_index { index } -> fprintf fmt "\\%d" (Offset.repr index)
+    | PT_var_name { name } -> fprintf fmt "%s" (Name.repr name)
+    | PT_forall { param; return } ->
+        fprintf fmt "%a -> %a" pp_atom param pp_funct return
+    | PT_lambda { param; return } ->
+        fprintf fmt "%a => %a" pp_atom param pp_funct return
+    | PT_apply { lambda; arg } ->
+        fprintf fmt "%a %a" pp_apply lambda pp_atom arg
+    | PT_annot { term; annot } ->
+        fprintf fmt "%a : %a" pp_funct term pp_wrapped annot
+
+  type prec = Wrapped | Funct | Apply | Atom
+
+  let rec pp_term prec fmt term =
+    let pp_wrapped fmt term = pp_term Wrapped fmt term in
+    let pp_funct fmt term = pp_term Funct fmt term in
+    let pp_apply fmt term = pp_term Apply fmt term in
+    let pp_atom fmt term = pp_term Atom fmt term in
+    match (term, prec) with
+    | ( (PT_loc _ | PT_offset _ | PT_var_index _ | PT_var_name _),
+        (Wrapped | Funct | Apply | Atom) )
+    | PT_apply _, (Wrapped | Funct | Apply)
+    | (PT_forall _ | PT_lambda _), (Wrapped | Funct)
+    | PT_annot _, Wrapped ->
+        pp_term_syntax ~pp_wrapped ~pp_funct ~pp_apply ~pp_atom fmt term
+    | PT_apply _, Atom
+    | (PT_forall _ | PT_lambda _), (Apply | Atom)
+    | PT_annot _, (Funct | Apply | Atom) ->
+        fprintf fmt "(%a)" pp_wrapped term
+
+  let pp_term fmt term = pp_term Wrapped fmt term
+end
+(* TODO: probably make printer tree *)
+
+type loc_mode = Loc_default | Loc_meaningful | Loc_force
+type var_mode = Var_name | Var_index | Var_both
+type offset_mode = Offset_default | Offset_meaningful | Offset_force
+
+open Ptree
+
+let should_print_loc ~loc_mode ~loc =
+  match loc_mode with
+  | Loc_default -> false
+  | Loc_force -> true
+  | Loc_meaningful -> not (Location.is_none loc)
+
+let should_print_offset ~offset_mode ~offset =
+  match offset_mode with
+  | Offset_default -> false
+  | Offset_force -> true
+  | Offset_meaningful -> not Offset.(equal offset zero)
+
+let rec ptree_of_term ~loc_mode ~offset_mode ~var_mode offset term =
+  let ptree_of_term offset term =
+    ptree_of_term ~loc_mode ~offset_mode ~var_mode offset term
+  in
+  let ptree_of_pat offset pat =
+    ptree_of_pat ~loc_mode ~offset_mode ~var_mode offset pat
+  in
+  match term with
+  | TT_loc { term; loc } -> (
+      let term = ptree_of_term offset term in
+      match should_print_loc ~loc_mode ~loc with
+      | true -> PT_loc { term; loc }
+      | false -> term)
+  | TT_offset { term; offset = additional_offset } -> (
+      (* accumulates only if not printed *)
+      match should_print_offset ~offset_mode ~offset with
+      | true ->
+          let term = ptree_of_term offset term in
+          PT_offset { term; offset = additional_offset }
+      | false ->
+          let offset = Offset.(offset + additional_offset) in
+          ptree_of_term offset term)
+  | TT_var { offset = index } ->
+      let index = Offset.(offset + index) in
+      PT_var_index { index }
+  | TT_forall { param; return } ->
+      let param = ptree_of_pat offset param in
+      let return = ptree_of_term offset return in
+      PT_forall { param; return }
+  | TT_lambda { param; return } ->
+      let param = ptree_of_pat offset param in
+      let return = ptree_of_term offset return in
+      PT_lambda { param; return }
+  | TT_apply { lambda; arg } ->
+      let lambda = ptree_of_term offset lambda in
+      let arg = ptree_of_term offset arg in
+      PT_apply { lambda; arg }
+  | TT_annot { term; annot } ->
+      let term = ptree_of_term offset term in
+      let annot = ptree_of_term offset annot in
+      PT_annot { term; annot }
+
+and ptree_of_pat ~loc_mode ~offset_mode ~var_mode offset pat =
+  let ptree_of_term term =
+    ptree_of_term ~loc_mode ~offset_mode ~var_mode offset term
+  in
+  let ptree_of_pat pat =
+    ptree_of_pat ~loc_mode ~offset_mode ~var_mode offset pat
+  in
+  match pat with
+  | TP_loc { pat; loc } -> (
+      let pat = ptree_of_pat pat in
+      match should_print_loc ~loc_mode ~loc with
+      (* TODO: calling this term is weird *)
+      | true -> PT_loc { term = pat; loc }
+      | false -> pat)
+  | TP_var { var = name } -> PT_var_name { name }
+  | TP_annot { pat; annot } ->
+      let pat = ptree_of_pat pat in
+      let annot = ptree_of_term annot in
+      PT_annot { term = pat; annot }
+
+let loc_mode = Loc_default
+let offset_mode = Offset_default
+let var_mode = Var_index
+
+let pp_term fmt term =
+  let pterm = ptree_of_term ~loc_mode ~offset_mode ~var_mode Offset.zero term in
+  Ptree.pp_term fmt pterm
+
+let pp_pat fmt pat =
+  let pterm = ptree_of_pat ~loc_mode ~offset_mode ~var_mode Offset.zero pat in
+  Ptree.pp_term fmt pterm

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,0 +1,4 @@
+open Ttree
+
+val pp_term : Format.formatter -> term -> unit
+val pp_pat : Format.formatter -> pat -> unit

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -8,16 +8,15 @@
    means that this cache will probably be dependent on holes *)
 
 type term =
+  | TT_loc of { term : term; loc : Location.t [@opaque] }
+  | TT_offset of { term : term; offset : Offset.t }
   | TT_var of { offset : Offset.t }
   | TT_forall of { param : pat; return : term }
   | TT_lambda of { param : pat; return : term }
   | TT_apply of { lambda : term; arg : term }
   | TT_annot of { term : term; annot : term }
-  | TT_offset of { term : term; offset : Offset.t }
-  | TT_loc of { term : term; loc : Location.t [@opaque] }
 
 and pat =
+  | TP_loc of { pat : pat; loc : Location.t [@opaque] }
   | TP_var of { var : Name.t }
   | TP_annot of { pat : pat; annot : term }
-  | TP_loc of { pat : pat; loc : Location.t [@opaque] }
-[@@deriving show { with_path = false }]

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,6 +1,8 @@
 (* TODO: make this private again? *)
 
 type term =
+  | TT_loc of { term : term; loc : Location.t }
+  | TT_offset of { term : term; offset : Offset.t }
   (* x *)
   | TT_var of { offset : Offset.t }
   (* (x : A) -> B *)
@@ -11,13 +13,10 @@ type term =
   | TT_apply of { lambda : term; arg : term }
   (* (v : T) *)
   | TT_annot of { term : term; annot : term }
-  | TT_offset of { term : term; offset : Offset.t }
-  | TT_loc of { term : term; loc : Location.t }
 
 and pat =
+  | TP_loc of { pat : pat; loc : Location.t }
   (* x *)
   | TP_var of { var : Name.t }
   (* (p : T) *)
   | TP_annot of { pat : pat; annot : term }
-  | TP_loc of { pat : pat; loc : Location.t }
-[@@deriving show]


### PR DESCRIPTION
## Goals

Make my own life(@EduardoRFS) a bit less painful.

## Context

Currently the only printing available for ttree is the super noisy one generated by ppx_deriving, but a proper generated may actually have a lot of additional nodes. So here I add a printer for ttree that prints it in a way intended for humans to read, but also added a couple additional flags so that a raw ttree can also be dumped.