### PR TITLE
teika: enhance context abstractions

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -25,43 +25,31 @@ type error =
   | CError_typer_pat_var_not_annotated of { var : Name.t }
 [@@deriving show { with_path = false }]
 
+type ('a, 'b) result = { match_ : 'k. ok:('a -> 'k) -> error:('b -> 'k) -> 'k }
+[@@ocaml.unboxed]
+
+let[@inline always] ok value = { match_ = (fun ~ok ~error:_ -> ok value) }
+let[@inline always] error desc = { match_ = (fun ~ok:_ ~error -> error desc) }
+
 module Normalize_context = struct
   type var_info = Subst of { to_ : term } | Bound of { base : Offset.t }
 
-  type 'a normalize_context = {
-    (* TODO: accumulate locations during normalization *)
-    context :
-      'k.
-      vars:var_info list ->
-      offset:Offset.t ->
-      ok:('a -> 'k) ->
-      error:(error -> 'k) ->
-      'k;
-  }
-  [@@ocaml.unboxed]
+  type 'a normalize_context =
+    vars:var_info list -> offset:Offset.t -> ('a, error) result
 
   type 'a t = 'a normalize_context
 
   let[@inline always] test ~vars ~offset f =
-    let { context } = f () in
-    let ok value = Ok value in
-    let error error = Error error in
-    context ~vars ~offset ~ok ~error
+    (f () ~vars ~offset).match_
+      ~ok:(fun value -> Ok value)
+      ~error:(fun desc -> Error desc)
 
-  let[@inline always] return value =
-    let context ~vars:_ ~offset:_ ~ok ~error:_ = ok value in
-    { context }
+  let[@inline always] return value ~vars:_ ~offset:_ = ok value
 
-  let[@inline always] bind context f =
-    let { context } = context in
-    let context ~vars ~offset ~ok ~error =
-      let ok data =
-        let { context } = f data in
-        context ~vars ~offset ~ok ~error
-      in
-      context ~vars ~offset ~ok ~error
-    in
-    { context }
+  let[@inline always] bind context f ~vars ~offset =
+    (context ~vars ~offset).match_
+      ~ok:(fun value -> f value ~vars ~offset)
+      ~error
 
   let ( let* ) = bind
 
@@ -69,89 +57,57 @@ module Normalize_context = struct
     let* value = context in
     return @@ f value
 
-  let[@inline always] repr_var ~var =
-    let context ~vars ~offset ~ok ~error:_ =
-      match
-        (* TODO: should this be var + offset? *)
-        let index = Offset.(repr (var - one)) in
-        List.nth_opt vars index
-      with
-      | Some (Subst { to_ }) ->
-          let offset = Offset.(var + offset) in
-          ok (TT_offset { term = to_; offset })
-      | Some (Bound { base }) ->
-          let offset = Offset.(var + offset - base) in
-          ok (TT_var { offset })
-      | None | (exception Invalid_argument _) ->
-          (* free var *)
-          let offset = Offset.(var + offset) in
-          ok (TT_var { offset })
-    in
-    { context }
+  let[@inline always] repr_var ~var ~vars ~offset =
+    match
+      (* TODO: should this be var + offset? *)
+      let index = Offset.(repr (var - one)) in
+      List.nth_opt vars index
+    with
+    | Some (Subst { to_ }) ->
+        let offset = Offset.(var + offset) in
+        ok @@ TT_offset { term = to_; offset }
+    | Some (Bound { base }) ->
+        let offset = Offset.(var + offset - base) in
+        ok @@ TT_var { offset }
+    | None | (exception Invalid_argument _) ->
+        (* free var *)
+        let offset = Offset.(var + offset) in
+        ok @@ TT_var { offset }
 
-  let[@inline always] with_var f =
-    let context ~vars ~offset ~ok ~error =
-      let vars = Bound { base = offset } :: vars in
-      let { context } = f () in
-      context ~vars ~offset ~ok ~error
-    in
-    { context }
+  let[@inline always] with_var f ~vars ~offset =
+    let vars = Bound { base = offset } :: vars in
+    f () ~vars ~offset
 
-  let[@inline always] elim_var ~to_ f =
-    let context ~vars ~offset ~ok ~error =
-      let vars = Subst { to_ } :: vars in
-      let { context } = f () in
-      context ~vars ~offset ~ok ~error
-    in
-    { context }
+  let[@inline always] elim_var ~to_ f ~vars ~offset =
+    let vars = Subst { to_ } :: vars in
+    f () ~vars ~offset
 
-  let[@inline always] with_offset ~offset f =
-    let context ~vars ~offset:current_offset ~ok ~error =
-      let offset = Offset.(current_offset + offset) in
-      let { context } = f () in
-      context ~vars ~offset ~ok ~error
-    in
-    { context }
+  let[@inline always] with_offset ~offset f ~vars ~offset:current_offset =
+    let offset = Offset.(current_offset + offset) in
+    f () ~vars ~offset
 end
 
 module Unify_context (Normalize : sig
   val normalize_term : term -> term Normalize_context.t
 end) =
 struct
-  type 'a unify_context = {
-    (* TODO: accumulate locations during unification *)
-    context :
-      'k.
-      expected_offset:Offset.t ->
-      received_offset:Offset.t ->
-      ok:('a -> 'k) ->
-      error:(error -> 'k) ->
-      'k;
-  }
-  [@@ocaml.unboxed]
+  type 'a unify_context =
+    expected_offset:Offset.t -> received_offset:Offset.t -> ('a, error) result
 
   type 'a t = 'a unify_context
 
   let[@inline always] test ~expected_offset ~received_offset f =
-    let { context } = f () in
-    let ok value = Ok value in
-    let error error = Error error in
-    context ~expected_offset ~received_offset ~ok ~error
+    (f () ~expected_offset ~received_offset).match_
+      ~ok:(fun value -> Ok value)
+      ~error:(fun desc -> Error desc)
 
-  let[@inline always] return value =
-    let context ~expected_offset:_ ~received_offset:_ ~ok ~error:_ = ok value in
-    { context }
+  let[@inline always] return value ~expected_offset:_ ~received_offset:_ =
+    ok value
 
-  let[@inline always] bind context f =
-    let { context } = context in
-    let context ~expected_offset ~received_offset ~ok ~error =
-      let ok data =
-        let { context } = f data in
-        context ~expected_offset ~received_offset ~ok ~error
-      in
-      context ~expected_offset ~received_offset ~ok ~error
-    in
-    { context }
+  let[@inline always] bind context f ~expected_offset ~received_offset =
+    (context ~expected_offset ~received_offset).match_
+      ~ok:(fun value -> f value ~expected_offset ~received_offset)
+      ~error
 
   let ( let* ) = bind
 
@@ -159,70 +115,44 @@ struct
     let* value = context in
     return @@ f value
 
-  let[@inline always] error_var_clash ~expected ~received =
-    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
-      error (CError_unify_var_clash { expected; received })
-    in
-    { context }
+  let[@inline always] error_var_clash ~expected ~received ~expected_offset:_
+      ~received_offset:_ =
+    error @@ CError_unify_var_clash { expected; received }
 
-  let[@inline always] error_type_clash ~expected ~received =
-    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
-      error (CError_unify_type_clash { expected; received })
-    in
-    { context }
+  let[@inline always] error_type_clash ~expected ~received ~expected_offset:_
+      ~received_offset:_ =
+    error @@ CError_unify_type_clash { expected; received }
 
-  let[@inline always] error_pat_clash ~expected ~received =
-    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
-      error (CError_unify_pat_clash { expected; received })
-    in
-    { context }
+  let[@inline always] error_pat_clash ~expected ~received ~expected_offset:_
+      ~received_offset:_ =
+    error @@ CError_unify_pat_clash { expected; received }
 
-  let[@inline always] error_var_escape_scope ~var =
-    let context ~expected_offset:_ ~received_offset:_ ~ok:_ ~error =
-      error (CError_unify_var_escape_scope { var })
-    in
-    { context }
+  let[@inline always] error_var_escape_scope ~var ~expected_offset:_
+      ~received_offset:_ =
+    error @@ CError_unify_var_escape_scope { var }
 
-  let[@inline always] with_normalize_context f =
-    let context ~expected_offset:_ ~received_offset:_ ~ok ~error =
-      let Normalize_context.{ context } = f () in
-      let offset = Offset.zero in
-      let ok value = ok value in
-      let error desc = error desc in
-      context ~vars:[] ~offset ~ok ~error
-    in
-    { context }
+  let[@inline always] with_normalize_context f ~expected_offset:_
+      ~received_offset:_ =
+    f () ~vars:[] ~offset:Offset.zero
 
   let[@inline always] normalize_term term =
     with_normalize_context @@ fun () -> Normalize.normalize_term term
 
-  let[@inline always] expected_offset () =
-    let context ~expected_offset ~received_offset:_ ~ok ~error:_ =
-      ok expected_offset
-    in
-    { context }
+  let[@inline always] expected_offset () ~expected_offset ~received_offset:_ =
+    ok expected_offset
 
-  let[@inline always] received_offset () =
-    let context ~expected_offset:_ ~received_offset ~ok ~error:_ =
-      ok received_offset
-    in
-    { context }
+  let[@inline always] received_offset () ~expected_offset:_ ~received_offset =
+    ok received_offset
 
-  let[@inline always] with_expected_offset ~offset f =
-    let context ~expected_offset ~received_offset ~ok ~error =
-      let expected_offset = Offset.(expected_offset + offset) in
-      let { context } = f () in
-      context ~expected_offset ~received_offset ~ok ~error
-    in
-    { context }
+  let[@inline always] with_expected_offset ~offset f ~expected_offset
+      ~received_offset =
+    let expected_offset = Offset.(expected_offset + offset) in
+    f () ~expected_offset ~received_offset
 
-  let[@inline always] with_received_offset ~offset f =
-    let context ~expected_offset ~received_offset ~ok ~error =
-      let received_offset = Offset.(received_offset + offset) in
-      let { context } = f () in
-      context ~expected_offset ~received_offset ~ok ~error
-    in
-    { context }
+  let[@inline always] with_received_offset ~offset f ~expected_offset
+      ~received_offset =
+    let received_offset = Offset.(received_offset + offset) in
+    f () ~expected_offset ~received_offset
 end
 
 module Typer_context (Normalize : sig
@@ -232,23 +162,15 @@ end) (Unify : sig
     expected:term -> received:term -> unit Unify_context(Normalize).t
 end) =
 struct
-  type 'a typer_context = {
-    (* TODO: accumulate locations during instantiation *)
-    context :
-      'k.
-      type_of_types:Level.t ->
-      level:Level.t ->
-      names:(Level.t * term) Name.Tbl.t ->
-      ok:('a -> 'k) ->
-      error:(error -> 'k) ->
-      'k;
-  }
-  [@@ocaml.unboxed]
+  type 'a typer_context =
+    type_of_types:Level.t ->
+    level:Level.t ->
+    names:(Level.t * term) Name.Tbl.t ->
+    ('a, error) result
 
   type 'a t = 'a typer_context
 
   let[@inline always] run f =
-    let { context } = f () in
     let type_of_types = Level.zero in
     let level = Level.next type_of_types in
     (* TODO: meaningful size?
@@ -260,30 +182,21 @@ struct
      let type_ = TT_annot { term = type_; annot = type_ } in
      (* TODO: better place for constants *)
      Name.Tbl.add names type_name (type_of_types, type_));
-    let ok value = Ok value in
-    let error error = Error error in
-    context ~type_of_types ~level ~names ~ok ~error
+    (f () ~type_of_types ~level ~names).match_
+      ~ok:(fun value -> Ok value)
+      ~error:(fun desc -> Error desc)
 
   let[@inline always] test ~type_of_types ~level ~names f =
-    let { context } = f () in
-    let ok value = Ok value in
-    let error error = Error error in
-    context ~type_of_types ~level ~names ~ok ~error
+    (f () ~type_of_types ~level ~names).match_
+      ~ok:(fun value -> Ok value)
+      ~error:(fun desc -> Error desc)
 
-  let[@inline always] return value =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ = ok value in
-    { context }
+  let[@inline always] return value ~type_of_types:_ ~level:_ ~names:_ = ok value
 
-  let[@inline always] bind context f =
-    let { context } = context in
-    let context ~type_of_types ~level ~names ~ok ~error =
-      let ok data =
-        let { context } = f data in
-        context ~type_of_types ~level ~names ~ok ~error
-      in
-      context ~type_of_types ~level ~names ~ok ~error
-    in
-    { context }
+  let[@inline always] bind context f ~type_of_types ~level ~names =
+    (context ~type_of_types ~level ~names).match_
+      ~ok:(fun value -> f value ~type_of_types ~level ~names)
+      ~error
 
   let ( let* ) = bind
 
@@ -291,83 +204,55 @@ struct
     let* value = context in
     return @@ f value
 
-  let[@inline always] error_pat_not_annotated ~pat =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
-      error (CError_typer_pat_not_annotated { pat })
-    in
-    { context }
+  let[@inline always] error_pat_not_annotated ~pat ~type_of_types:_ ~level:_
+      ~names:_ =
+    error @@ CError_typer_pat_not_annotated { pat }
 
-  let[@inline always] error_term_var_not_annotated ~var =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
-      error (CError_typer_term_var_not_annotated { var })
-    in
-    { context }
+  let[@inline always] error_term_var_not_annotated ~var ~type_of_types:_
+      ~level:_ ~names:_ =
+    error @@ CError_typer_term_var_not_annotated { var }
 
-  let[@inline always] error_pat_var_not_annotated ~var =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
-      error (CError_typer_pat_var_not_annotated { var })
-    in
-    { context }
+  let[@inline always] error_pat_var_not_annotated ~var ~type_of_types:_ ~level:_
+      ~names:_ =
+    error @@ CError_typer_pat_var_not_annotated { var }
 
-  let[@inline always] error_pairs_not_implemented () =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok:_ ~error =
-      error CError_typer_pairs_not_implemented
-    in
-    { context }
+  let[@inline always] error_pairs_not_implemented () ~type_of_types:_ ~level:_
+      ~names:_ =
+    error @@ CError_typer_pairs_not_implemented
 
-  let[@inline always] instance ~var =
-    let context ~type_of_types:_ ~level ~names ~ok ~error =
-      match Name.Tbl.find_opt names var with
-      | Some (var_level, type_) ->
-          let offset = Level.offset ~from:var_level ~to_:level in
-          let type_ = TT_offset { term = type_; offset } in
-          ok (offset, type_)
-      | None -> error (CError_typer_unknown_var { var })
-    in
-    { context }
+  let[@inline always] instance ~var ~type_of_types:_ ~level ~names =
+    match Name.Tbl.find_opt names var with
+    | Some (var_level, type_) ->
+        let offset = Level.offset ~from:var_level ~to_:level in
+        let type_ = TT_offset { term = type_; offset } in
+        ok @@ (offset, type_)
+    | None -> error @@ CError_typer_unknown_var { var }
 
-  let[@inline always] with_binder ~var ~type_ f =
-    let context ~type_of_types ~level ~names ~ok ~error =
-      Name.Tbl.add names var (level, type_);
-      let level = Level.next level in
-      let { context } = f () in
-      let ok value =
+  let[@inline always] with_binder ~var ~type_ f ~type_of_types ~level ~names =
+    Name.Tbl.add names var (level, type_);
+    let level = Level.next level in
+    (f () ~type_of_types ~level ~names).match_
+      ~ok:(fun value ->
         Name.Tbl.remove names var;
-        ok value
-      in
-      context ~type_of_types ~level ~names ~ok ~error
-    in
-    { context }
+        ok value)
+      ~error
 
-  module Unify_context = Unify_context (Normalize)
+  let[@inline always] unify_term ~expected ~received ~type_of_types:_ ~level:_
+      ~names:_ =
+    Unify.unify_term ~expected ~received ~expected_offset:Offset.zero
+      ~received_offset:Offset.zero
 
-  let[@inline always] unify_term ~expected ~received =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
-      let Unify_context.{ context } = Unify.unify_term ~expected ~received in
-      context ~expected_offset:Offset.zero ~received_offset:Offset.zero ~ok
-        ~error
-    in
-    { context }
+  let[@inline always] with_tt_loc ~loc f ~type_of_types ~level ~names =
+    (f () ~type_of_types ~level ~names).match_
+      ~ok:(fun term -> ok @@ TT_loc { term; loc })
+      ~error:(fun desc -> error @@ CError_loc { error = desc; loc })
 
-  let[@inline always] with_tt_loc ~loc f =
-    let context ~type_of_types ~level ~names ~ok ~error =
-      let { context } = f () in
-      let ok term = ok @@ TT_loc { term; loc } in
-      let error desc = error @@ CError_loc { error = desc; loc } in
-      context ~type_of_types ~level ~names ~ok ~error
-    in
-    { context }
-
-  let[@inline always] with_tp_loc ~loc f =
-    let context ~type_of_types ~level ~names ~ok ~error =
-      let { context } =
-        f (fun pat k ->
-            let pat = TP_loc { pat; loc } in
-            k pat)
-      in
-      context ~type_of_types ~level ~names ~ok ~error
-    in
-    { context }
+  let[@inline always] with_tp_loc ~loc f ~type_of_types ~level ~names =
+    f
+      (fun pat k ->
+        let pat = TP_loc { pat; loc } in
+        k pat)
+      ~type_of_types ~level ~names
 
   open Ttree
 
@@ -375,14 +260,9 @@ struct
     let offset = Level.offset ~from:type_of_types ~to_:level in
     TT_var { offset }
 
-  let[@inline always] with_normalize_context f =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
-      let Normalize_context.{ context } = f () in
-      let ok value = ok value in
-      let error desc = error desc in
-      context ~vars:[] ~offset:Offset.zero ~ok ~error
-    in
-    { context }
+  let[@inline always] with_normalize_context f ~type_of_types:_ ~level:_
+      ~names:_ =
+    f () ~vars:[] ~offset:Offset.zero
 
   let[@inline always] normalize_term type_ =
     with_normalize_context @@ fun () -> Normalize.normalize_term type_
@@ -392,64 +272,40 @@ struct
     (* TODO: two normalize guarantees no TT_offset? *)
     (* TODO: it doesn't *)
     let* type_ = normalize_term type_ in
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error =
+    fun ~type_of_types:_ ~level:_ ~names:_ ->
       match type_ with
-      | TT_forall { param; return } -> ok (param, return)
+      | TT_forall { param; return } -> ok @@ (param, return)
       | TT_var _ | TT_lambda _ | TT_apply _ | TT_annot _ | TT_loc _
       | TT_offset _ ->
-          error (Cerror_typer_not_a_forall { type_ })
-    in
-    { context }
+          error @@ Cerror_typer_not_a_forall { type_ }
 
   let[@inline always] tt_annot ~annot term = TT_annot { term; annot }
 
-  let[@inline always] tt_type () =
-    let context ~type_of_types ~level ~names:_ ~ok ~error:_ =
-      ok @@ tt_type ~type_of_types ~level
-    in
-    { context }
+  let[@inline always] tt_type () ~type_of_types ~level ~names:_ =
+    ok @@ tt_type ~type_of_types ~level
 
-  let[@inline always] tt_var ~annot ~offset =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_annot ~annot @@ TT_var { offset }
-    in
-    { context }
+  let[@inline always] tt_var ~annot ~offset ~type_of_types:_ ~level:_ ~names:_ =
+    ok @@ tt_annot ~annot @@ TT_var { offset }
 
-  let[@inline always] tt_forall ~param ~return =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ TT_forall { param; return }
-    in
-    { context }
+  let[@inline always] tt_forall ~param ~return ~type_of_types:_ ~level:_
+      ~names:_ =
+    ok @@ TT_forall { param; return }
 
-  let[@inline always] tt_lambda ~param ~return =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ TT_lambda { param; return }
-    in
-    { context }
+  let[@inline always] tt_lambda ~param ~return ~type_of_types:_ ~level:_
+      ~names:_ =
+    ok @@ TT_lambda { param; return }
 
-  let[@inline always] tt_apply ~lambda ~arg =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ TT_apply { lambda; arg }
-    in
-    { context }
+  let[@inline always] tt_apply ~lambda ~arg ~type_of_types:_ ~level:_ ~names:_ =
+    ok @@ TT_apply { lambda; arg }
 
-  let[@inline always] tt_annot ~term ~annot =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tt_annot ~annot term
-    in
-    { context }
+  let[@inline always] tt_annot ~term ~annot ~type_of_types:_ ~level:_ ~names:_ =
+    ok @@ tt_annot ~annot term
 
   let[@inline always] tp_annot ~annot pat = TP_annot { pat; annot }
 
-  let[@inline always] tp_var ~annot ~var =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ tp_annot ~annot @@ TP_var { var }
-    in
-    { context }
+  let[@inline always] tp_var ~annot ~var ~type_of_types:_ ~level:_ ~names:_ =
+    ok @@ tp_annot ~annot @@ TP_var { var }
 
-  let[@inline always] tp_annot ~pat ~annot =
-    let context ~type_of_types:_ ~level:_ ~names:_ ~ok ~error:_ =
-      ok @@ TP_annot { pat; annot }
-    in
-    { context }
+  let[@inline always] tp_annot ~pat ~annot ~type_of_types:_ ~level:_ ~names:_ =
+    ok @@ TP_annot { pat; annot }
 end

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -1,8 +1,8 @@
 open Ttree
 
-type error = private CError of { loc : Location.t; desc : error_desc }
-
-and error_desc = private
+type error = private
+  (* metadata *)
+  | CError_loc of { error : error; loc : Location.t [@opaque] }
   (* unify *)
   | CError_unify_var_clash of { expected : Offset.t; received : Offset.t }
   | CError_unify_type_clash of { expected : term; received : term }
@@ -25,7 +25,6 @@ module Normalize_context : sig
 
   (* monad *)
   val test :
-    loc:Warnings.loc ->
     vars:var_info list ->
     offset:Offset.t ->
     (unit -> 'a normalize_context) ->
@@ -62,7 +61,6 @@ end) : sig
 
   (* monad *)
   val test :
-    loc:Warnings.loc ->
     expected_offset:Offset.t ->
     received_offset:Offset.t ->
     (unit -> 'a unify_context) ->
@@ -108,10 +106,9 @@ end) : sig
   type 'a t = 'a typer_context
 
   (* monad *)
-  val run : loc:Location.t -> (unit -> 'a typer_context) -> ('a, error) result
+  val run : (unit -> 'a typer_context) -> ('a, error) result
 
   val test :
-    loc:Warnings.loc ->
     type_of_types:Level.t ->
     level:Level.t ->
     names:(Level.t * term) Name.Tbl.t ->

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -249,8 +249,7 @@ module Ttree_utils = struct
 
   let infer_term term =
     let open Typer_context in
-    let loc = Location.none in
-    run ~loc @@ fun () -> Typer.infer_term term
+    run @@ fun () -> Typer.infer_term term
 
   (* let normalize_term term =
        Context.Normalize_context.test ~loc:Location.none ~vars:[]
@@ -262,11 +261,10 @@ module Ttree_utils = struct
        let ltree = Lparser.from_stree stree in
        let ttree = infer_term ltree |> Result.get_ok in
        let ttree = normalize_term ttree |> Result.get_ok in
-       let ttree = normalize_term ttree |> Result.get_ok in
-       Format.eprintf "%a\n%!" pp_term ttree
+       Format.eprintf "%a\n%!" Tprinter.pp_term ttree;
+       assert false
 
-     let () =
-       dump "((id : (A : Type) -> (x : A) -> A) => id) (A => x => x) Type Type" *)
+     let () = dump "((id : (A : Type) -> (x : A) -> A) => id) (A => x => x)" *)
 end
 
 module Typer = struct


### PR DESCRIPTION
## Goals

Make the typing context easier to manage.

## Context

To avoid allocating intermediate states I'm currently using CPS for the entire context, yes, this is a bad reason.

Currently the code redefines result everywhere, which lead to some terrible code wrapping due to OCaml not having good support to rank-2. Here I just use a shared definition of result.