### PR TITLE
teika: refactor context and remove functors

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -16,13 +16,13 @@ type error =
     }
   | CError_unify_var_escape_scope of { var : Offset.t }
   (* typer *)
-  | CError_typer_unknown_var of { var : Name.t }
+  | CError_typer_unknown_var of { name : Name.t }
   | Cerror_typer_not_a_forall of { type_ : term [@printer Tprinter.pp_term] }
   | CError_typer_pat_not_annotated of { pat : Ltree.pat }
   | CError_typer_pairs_not_implemented
   (* invariant *)
   | CError_typer_term_var_not_annotated of { var : Offset.t }
-  | CError_typer_pat_var_not_annotated of { var : Name.t }
+  | CError_typer_pat_var_not_annotated of { name : Name.t }
 [@@deriving show { with_path = false }]
 
 type ('a, 'b) result = { match_ : 'k. ok:('a -> 'k) -> error:('b -> 'k) -> 'k }
@@ -31,9 +31,9 @@ type ('a, 'b) result = { match_ : 'k. ok:('a -> 'k) -> error:('b -> 'k) -> 'k }
 let[@inline always] ok value = { match_ = (fun ~ok ~error:_ -> ok value) }
 let[@inline always] error desc = { match_ = (fun ~ok:_ ~error -> error desc) }
 
-module Normalize_context = struct
-  type var_info = Subst of { to_ : term } | Bound of { base : Offset.t }
+type var_info = Subst of { to_ : term } | Bound of { base : Offset.t }
 
+module Normalize_context = struct
   type 'a normalize_context =
     vars:var_info list -> offset:Offset.t -> ('a, error) result
 
@@ -87,26 +87,36 @@ module Normalize_context = struct
     f () ~vars ~offset
 end
 
-module Unify_context (Normalize : sig
-  val normalize_term : term -> term Normalize_context.t
-end) =
-struct
+module Unify_context = struct
   type 'a unify_context =
-    expected_offset:Offset.t -> received_offset:Offset.t -> ('a, error) result
+    expected_vars:var_info list ->
+    expected_offset:Offset.t ->
+    received_vars:var_info list ->
+    received_offset:Offset.t ->
+    ('a, error) result
 
   type 'a t = 'a unify_context
 
-  let[@inline always] test ~expected_offset ~received_offset f =
-    (f () ~expected_offset ~received_offset).match_
+  let[@inline always] test ~expected_vars ~expected_offset ~received_vars
+      ~received_offset f =
+    (f () ~expected_vars ~expected_offset ~received_vars ~received_offset)
+      .match_
       ~ok:(fun value -> Ok value)
       ~error:(fun desc -> Error desc)
 
-  let[@inline always] return value ~expected_offset:_ ~received_offset:_ =
-    ok value
+  let[@inline always] return_raw value ~expected_vars:_ ~expected_offset:_
+      ~received_vars:_ ~received_offset:_ =
+    value
 
-  let[@inline always] bind context f ~expected_offset ~received_offset =
-    (context ~expected_offset ~received_offset).match_
-      ~ok:(fun value -> f value ~expected_offset ~received_offset)
+  let[@inline always] return value = return_raw @@ ok value
+  let[@inline always] fail desc = return_raw @@ error desc
+
+  let[@inline always] bind context f ~expected_vars ~expected_offset
+      ~received_vars ~received_offset =
+    (context ~expected_vars ~expected_offset ~received_vars ~received_offset)
+      .match_
+      ~ok:(fun value ->
+        f value ~expected_vars ~expected_offset ~received_vars ~received_offset)
       ~error
 
   let ( let* ) = bind
@@ -115,57 +125,52 @@ struct
     let* value = context in
     return @@ f value
 
-  let[@inline always] error_var_clash ~expected ~received ~expected_offset:_
-      ~received_offset:_ =
-    error @@ CError_unify_var_clash { expected; received }
+  let[@inline always] error_var_clash ~expected ~received =
+    fail @@ CError_unify_var_clash { expected; received }
 
-  let[@inline always] error_type_clash ~expected ~received ~expected_offset:_
-      ~received_offset:_ =
-    error @@ CError_unify_type_clash { expected; received }
+  let[@inline always] error_type_clash ~expected ~received =
+    fail @@ CError_unify_type_clash { expected; received }
 
-  let[@inline always] error_pat_clash ~expected ~received ~expected_offset:_
-      ~received_offset:_ =
-    error @@ CError_unify_pat_clash { expected; received }
+  let[@inline always] error_pat_clash ~expected ~received =
+    fail @@ CError_unify_pat_clash { expected; received }
 
-  let[@inline always] error_var_escape_scope ~var ~expected_offset:_
-      ~received_offset:_ =
-    error @@ CError_unify_var_escape_scope { var }
+  let[@inline always] error_var_escape_scope ~var =
+    fail @@ CError_unify_var_escape_scope { var }
 
-  let[@inline always] with_normalize_context f ~expected_offset:_
-      ~received_offset:_ =
-    f () ~vars:[] ~offset:Offset.zero
+  let[@inline always] with_expected_normalize_context f ~expected_vars
+      ~expected_offset ~received_vars:_ ~received_offset:_ =
+    f () ~vars:expected_vars ~offset:expected_offset
 
-  let[@inline always] normalize_term term =
-    with_normalize_context @@ fun () -> Normalize.normalize_term term
+  let[@inline always] with_received_normalize_context f ~expected_vars:_
+      ~expected_offset:_ ~received_vars ~received_offset =
+    f () ~vars:received_vars ~offset:received_offset
 
-  let[@inline always] expected_offset () ~expected_offset ~received_offset:_ =
+  let[@inline always] expected_offset () ~expected_vars:_ ~expected_offset
+      ~received_vars:_ ~received_offset:_ =
     ok expected_offset
 
-  let[@inline always] received_offset () ~expected_offset:_ ~received_offset =
+  let[@inline always] received_offset () ~expected_vars:_ ~expected_offset:_
+      ~received_vars:_ ~received_offset =
     ok received_offset
 
-  let[@inline always] with_expected_offset ~offset f ~expected_offset
-      ~received_offset =
+  let[@inline always] with_expected_offset ~offset f ~expected_vars
+      ~expected_offset ~received_vars ~received_offset =
     let expected_offset = Offset.(expected_offset + offset) in
-    f () ~expected_offset ~received_offset
+    f () ~expected_vars ~expected_offset ~received_vars ~received_offset
 
-  let[@inline always] with_received_offset ~offset f ~expected_offset
-      ~received_offset =
+  let[@inline always] with_received_offset ~offset f ~expected_vars
+      ~expected_offset ~received_vars ~received_offset =
     let received_offset = Offset.(received_offset + offset) in
-    f () ~expected_offset ~received_offset
+    f () ~expected_vars ~expected_offset ~received_vars ~received_offset
 end
 
-module Typer_context (Normalize : sig
-  val normalize_term : term -> term Normalize_context.t
-end) (Unify : sig
-  val unify_term :
-    expected:term -> received:term -> unit Unify_context(Normalize).t
-end) =
-struct
+module Typer_context = struct
   type 'a typer_context =
     type_of_types:Level.t ->
     level:Level.t ->
-    names:(Level.t * term) Name.Tbl.t ->
+    (* TODO: Hashtbl *)
+    names:(Level.t * term) Name.Map.t ->
+    received_vars:var_info list ->
     ('a, error) result
 
   type 'a t = 'a typer_context
@@ -173,29 +178,36 @@ struct
   let[@inline always] run f =
     let type_of_types = Level.zero in
     let level = Level.next type_of_types in
-    (* TODO: meaningful size?
-        - parser counts binders
-        - estimate based on the file size *)
-    let names = Name.Tbl.create 1024 in
-    (let type_name = Name.make "Type" in
-     let type_ = TT_var { offset = Offset.zero } in
-     let type_ = TT_annot { term = type_; annot = type_ } in
-     (* TODO: better place for constants *)
-     Name.Tbl.add names type_name (type_of_types, type_));
-    (f () ~type_of_types ~level ~names).match_
+    let names = Name.Map.empty in
+    let type_name = Name.make "Type" in
+    let names =
+      let type_ = TT_var { offset = Offset.zero } in
+      let type_ = TT_annot { term = type_; annot = type_ } in
+      (* TODO: better place for constants *)
+      Name.Map.add type_name (type_of_types, type_) names
+    in
+    let received_vars = [ Bound { base = Offset.zero } ] in
+    (* TODO: should Type be here? *)
+    (f () ~type_of_types ~level ~names ~received_vars).match_
       ~ok:(fun value -> Ok value)
       ~error:(fun desc -> Error desc)
 
-  let[@inline always] test ~type_of_types ~level ~names f =
-    (f () ~type_of_types ~level ~names).match_
+  let[@inline always] test ~type_of_types ~level ~names ~received_vars f =
+    (f () ~type_of_types ~level ~names ~received_vars).match_
       ~ok:(fun value -> Ok value)
       ~error:(fun desc -> Error desc)
 
-  let[@inline always] return value ~type_of_types:_ ~level:_ ~names:_ = ok value
+  let[@inline always] return_raw value ~type_of_types:_ ~level:_ ~names:_
+      ~received_vars:_ =
+    value
 
-  let[@inline always] bind context f ~type_of_types ~level ~names =
-    (context ~type_of_types ~level ~names).match_
-      ~ok:(fun value -> f value ~type_of_types ~level ~names)
+  let[@inline always] return value = return_raw @@ ok value
+  let[@inline always] fail desc = return_raw @@ error desc
+
+  let[@inline always] bind context f ~type_of_types ~level ~names ~received_vars
+      =
+    (context ~type_of_types ~level ~names ~received_vars).match_
+      ~ok:(fun value -> f value ~type_of_types ~level ~names ~received_vars)
       ~error
 
   let ( let* ) = bind
@@ -204,55 +216,60 @@ struct
     let* value = context in
     return @@ f value
 
-  let[@inline always] error_pat_not_annotated ~pat ~type_of_types:_ ~level:_
-      ~names:_ =
-    error @@ CError_typer_pat_not_annotated { pat }
+  let[@inline always] error_pat_not_annotated ~pat =
+    fail @@ CError_typer_pat_not_annotated { pat }
 
-  let[@inline always] error_term_var_not_annotated ~var ~type_of_types:_
-      ~level:_ ~names:_ =
-    error @@ CError_typer_term_var_not_annotated { var }
+  let[@inline always] error_term_var_not_annotated ~var =
+    fail @@ CError_typer_term_var_not_annotated { var }
 
-  let[@inline always] error_pat_var_not_annotated ~var ~type_of_types:_ ~level:_
-      ~names:_ =
-    error @@ CError_typer_pat_var_not_annotated { var }
+  let[@inline always] error_pat_var_not_annotated ~name =
+    fail @@ CError_typer_pat_var_not_annotated { name }
 
-  let[@inline always] error_pairs_not_implemented () ~type_of_types:_ ~level:_
-      ~names:_ =
-    error @@ CError_typer_pairs_not_implemented
+  let[@inline always] error_pairs_not_implemented () =
+    fail @@ CError_typer_pairs_not_implemented
 
-  let[@inline always] instance ~var ~type_of_types:_ ~level ~names =
-    match Name.Tbl.find_opt names var with
+  let[@inline always] error_not_a_forall ~type_ =
+    fail @@ Cerror_typer_not_a_forall { type_ }
+
+  let[@inline always] instance ~name ~type_of_types:_ ~level ~names
+      ~received_vars:_ =
+    match Name.Map.find_opt name names with
     | Some (var_level, type_) ->
         let offset = Level.offset ~from:var_level ~to_:level in
         let type_ = TT_offset { term = type_; offset } in
         ok @@ (offset, type_)
-    | None -> error @@ CError_typer_unknown_var { var }
+    | None -> error @@ CError_typer_unknown_var { name }
 
-  let[@inline always] with_binder ~var ~type_ f ~type_of_types ~level ~names =
-    Name.Tbl.add names var (level, type_);
+  let[@inline always] with_binder ~name ~type_ f ~type_of_types ~level ~names
+      ~received_vars =
+    let names = Name.Map.add name (level, type_) names in
+    let received_vars = Bound { base = Offset.zero } :: received_vars in
+    (* TODO: weird, level increases first? *)
     let level = Level.next level in
-    (f () ~type_of_types ~level ~names).match_
-      ~ok:(fun value ->
-        Name.Tbl.remove names var;
-        ok value)
-      ~error
+    f () ~type_of_types ~level ~names ~received_vars
 
-  let[@inline always] unify_term ~expected ~received ~type_of_types:_ ~level:_
-      ~names:_ =
-    Unify.unify_term ~expected ~received ~expected_offset:Offset.zero
+  let[@inline always] with_unify_context f ~type_of_types:_ ~level:_ ~names:_
+      ~received_vars:_ =
+    f () ~expected_vars:[] ~expected_offset:Offset.zero ~received_vars:[]
       ~received_offset:Offset.zero
 
-  let[@inline always] with_tt_loc ~loc f ~type_of_types ~level ~names =
-    (f () ~type_of_types ~level ~names).match_
+  let[@inline always] with_received_normalize_context f ~type_of_types:_
+      ~level:_ ~names:_ ~received_vars:_ =
+    f () ~vars:[] ~offset:Offset.zero
+
+  let[@inline always] with_tt_loc ~loc f ~type_of_types ~level ~names
+      ~received_vars =
+    (f () ~type_of_types ~level ~names ~received_vars).match_
       ~ok:(fun term -> ok @@ TT_loc { term; loc })
       ~error:(fun desc -> error @@ CError_loc { error = desc; loc })
 
-  let[@inline always] with_tp_loc ~loc f ~type_of_types ~level ~names =
+  let[@inline always] with_tp_loc ~loc f ~type_of_types ~level ~names
+      ~received_vars =
     f
       (fun pat k ->
         let pat = TP_loc { pat; loc } in
         k pat)
-      ~type_of_types ~level ~names
+      ~type_of_types ~level ~names ~received_vars
 
   open Ttree
 
@@ -260,52 +277,27 @@ struct
     let offset = Level.offset ~from:type_of_types ~to_:level in
     TT_var { offset }
 
-  let[@inline always] with_normalize_context f ~type_of_types:_ ~level:_
-      ~names:_ =
-    f () ~vars:[] ~offset:Offset.zero
-
-  let[@inline always] normalize_term type_ =
-    with_normalize_context @@ fun () -> Normalize.normalize_term type_
-
-  let[@inline always] split_forall type_ =
-    let* type_ = normalize_term type_ in
-    (* TODO: two normalize guarantees no TT_offset? *)
-    (* TODO: it doesn't *)
-    let* type_ = normalize_term type_ in
-    fun ~type_of_types:_ ~level:_ ~names:_ ->
-      match type_ with
-      | TT_forall { param; return } -> ok @@ (param, return)
-      | TT_var _ | TT_lambda _ | TT_apply _ | TT_annot _ | TT_loc _
-      | TT_offset _ ->
-          error @@ Cerror_typer_not_a_forall { type_ }
-
   let[@inline always] tt_annot ~annot term = TT_annot { term; annot }
 
-  let[@inline always] tt_type () ~type_of_types ~level ~names:_ =
+  let[@inline always] tt_type () ~type_of_types ~level ~names:_ ~received_vars:_
+      =
     ok @@ tt_type ~type_of_types ~level
 
-  let[@inline always] tt_var ~annot ~offset ~type_of_types:_ ~level:_ ~names:_ =
-    ok @@ tt_annot ~annot @@ TT_var { offset }
+  let[@inline always] tt_var ~annot ~offset =
+    return @@ tt_annot ~annot @@ TT_var { offset }
 
-  let[@inline always] tt_forall ~param ~return ~type_of_types:_ ~level:_
-      ~names:_ =
-    ok @@ TT_forall { param; return }
+  let[@inline always] tt_forall ~param ~return =
+    return_raw @@ ok @@ TT_forall { param; return }
 
-  let[@inline always] tt_lambda ~param ~return ~type_of_types:_ ~level:_
-      ~names:_ =
-    ok @@ TT_lambda { param; return }
+  let[@inline always] tt_lambda ~param ~return =
+    return_raw @@ ok @@ TT_lambda { param; return }
 
-  let[@inline always] tt_apply ~lambda ~arg ~type_of_types:_ ~level:_ ~names:_ =
-    ok @@ TT_apply { lambda; arg }
-
-  let[@inline always] tt_annot ~term ~annot ~type_of_types:_ ~level:_ ~names:_ =
-    ok @@ tt_annot ~annot term
-
+  let[@inline always] tt_apply ~lambda ~arg = return @@ TT_apply { lambda; arg }
+  let[@inline always] tt_annot ~term ~annot = return @@ tt_annot ~annot term
   let[@inline always] tp_annot ~annot pat = TP_annot { pat; annot }
 
-  let[@inline always] tp_var ~annot ~var ~type_of_types:_ ~level:_ ~names:_ =
-    ok @@ tp_annot ~annot @@ TP_var { var }
+  let[@inline always] tp_var ~annot ~var =
+    return @@ tp_annot ~annot @@ TP_var { var }
 
-  let[@inline always] tp_annot ~pat ~annot ~type_of_types:_ ~level:_ ~names:_ =
-    ok @@ TP_annot { pat; annot }
+  let[@inline always] tp_annot ~pat ~annot = return @@ TP_annot { pat; annot }
 end

--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -38,9 +38,9 @@ and elim_apply ~pat ~return ~arg f =
 
 and normalize_pat pat f =
   match pat with
-  | TP_var { var } ->
+  | TP_var { var = name } ->
       (* TODO: ensure all pat variables are wrapped with annotation *)
-      with_var @@ fun () -> f (TP_var { var })
+      with_var @@ fun () -> f (TP_var { var = name })
   | TP_annot { pat; annot } ->
       let* annot = normalize_term annot in
       normalize_pat pat @@ fun pat -> f (TP_annot { pat; annot })

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -245,16 +245,15 @@ end
 
 module Ttree_utils = struct
   open Teika
-  module Typer_context = Context.Typer_context (Normalize) (Unify)
+  open Context
 
   let infer_term term =
     let open Typer_context in
     run @@ fun () -> Typer.infer_term term
 
   (* let normalize_term term =
-       Context.Normalize_context.test ~loc:Location.none ~vars:[]
-         ~offset:Offset.zero
-       @@ fun () -> Normalize.normalize_term term
+       Context.Normalize_context.test ~vars:[] ~offset:Offset.zero @@ fun () ->
+       Normalize.normalize_term term
 
      let dump code =
        let stree = Slexer.from_string Sparser.term_opt code |> Option.get in

--- a/teika/typer.mli
+++ b/teika/typer.mli
@@ -1,3 +1,3 @@
 open Context
 
-val infer_term : Ltree.term -> Ttree.term Typer_context(Normalize)(Unify).t
+val infer_term : Ltree.term -> Ttree.term Typer_context.t

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -1,5 +1,4 @@
 open Ttree
 open Context
 
-val unify_term :
-  expected:term -> received:term -> unit Unify_context(Normalize).t
+val unify_term : expected:term -> received:term -> unit Unify_context.t


### PR DESCRIPTION
## Goals

Prepare the context for lazy normalization and unification.

## Context

This is another context PR improvement, here the code start tracking all variables defined by the typer and additionally remove all functors.