### PR TITLE
teika: use GADTs to enforce some typing invariants

### DIFF
--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -3,9 +3,10 @@ open Context.Normalize_context
 
 (* TODO: with subtyping, should normalize be able to recover information? *)
 
-let rec normalize_term term =
+let rec normalize_term : type a. a term -> _ =
+ fun term ->
   match term with
-  (* TODO: is removing those ok / idea? *)
+  (* TODO: is removing those ok / ideal? *)
   | TT_annot { term; annot = _ } -> normalize_term term
   | TT_loc { term; loc = _ } -> normalize_term term
   | TT_offset { term; offset } ->
@@ -13,35 +14,39 @@ let rec normalize_term term =
   | TT_var { offset } -> repr_var ~var:offset
   | TT_forall { param; return } ->
       normalize_pat param @@ fun param ->
-      let+ return = normalize_term return in
-      TT_forall { param; return }
+      let+ (Ex_term return) = normalize_term return in
+      Ex_term (TT_forall { param; return })
   | TT_lambda { param; return } ->
       normalize_pat param @@ fun param ->
-      let+ return = normalize_term return in
-      TT_lambda { param; return }
+      let+ (Ex_term return) = normalize_term return in
+      Ex_term (TT_lambda { param; return })
   | TT_apply { lambda; arg } -> (
-      let* lambda = normalize_term lambda in
-      let* arg = normalize_term arg in
+      let* (Ex_term lambda) = normalize_term lambda in
+      let* (Ex_term arg) = normalize_term arg in
       match lambda with
       | TT_lambda { param; return } ->
           (* TODO: match every case below *)
           elim_apply ~pat:param ~return ~arg @@ fun () -> normalize_term return
-      | _ -> return @@ TT_apply { lambda; arg })
+      | _ -> return @@ Ex_term (TT_apply { lambda; arg }))
 
 (* TODO: weird *)
-and elim_apply ~pat ~return ~arg f =
+and elim_apply : type p r a. pat:p pat -> return:r term -> arg:a term -> _ =
+ fun ~pat ~return ~arg f ->
   match (pat, arg) with
   | TP_annot { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg f
   | TP_loc { pat; loc = _ }, arg -> elim_apply ~pat ~return ~arg f
   | TP_var { var = _ }, arg ->
-      with_offset ~offset:Offset.(zero - one) @@ fun () -> elim_var ~to_:arg f
+      with_offset ~offset:Offset.(zero - one) @@ fun () ->
+      elim_var ~to_:(Ex_term arg) f
 
-and normalize_pat pat f =
+and normalize_pat : type a. a pat -> (a pat -> _) -> _ =
+ fun pat f ->
   match pat with
   | TP_var { var = name } ->
       (* TODO: ensure all pat variables are wrapped with annotation *)
       with_var @@ fun () -> f (TP_var { var = name })
   | TP_annot { pat; annot } ->
-      let* annot = normalize_term annot in
+      let* (Ex_term annot) = normalize_term annot in
       normalize_pat pat @@ fun pat -> f (TP_annot { pat; annot })
-  | TP_loc { pat; loc = _ } -> normalize_pat pat f
+  | TP_loc { pat; loc } ->
+      normalize_pat pat @@ fun pat -> f (TP_loc { pat; loc })

--- a/teika/normalize.mli
+++ b/teika/normalize.mli
@@ -1,4 +1,4 @@
 open Ttree
 open Context
 
-val normalize_term : term -> term Normalize_context.t
+val normalize_term : 'a term -> ex_term Normalize_context.t

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -74,8 +74,6 @@ type loc_mode = Loc_default | Loc_meaningful | Loc_force
 type var_mode = Var_name | Var_index | Var_both
 type offset_mode = Offset_default | Offset_meaningful | Offset_force
 
-open Ptree
-
 let should_print_loc ~loc_mode ~loc =
   match loc_mode with
   | Loc_default -> false
@@ -88,7 +86,10 @@ let should_print_offset ~offset_mode ~offset =
   | Offset_force -> true
   | Offset_meaningful -> not Offset.(equal offset zero)
 
-let rec ptree_of_term ~loc_mode ~offset_mode ~var_mode offset term =
+let rec ptree_of_term :
+    type a. loc_mode:_ -> offset_mode:_ -> var_mode:_ -> _ -> a term -> _ =
+ fun ~loc_mode ~offset_mode ~var_mode offset (term : a term) ->
+  let open Ptree in
   let ptree_of_term offset term =
     ptree_of_term ~loc_mode ~offset_mode ~var_mode offset term
   in
@@ -130,7 +131,10 @@ let rec ptree_of_term ~loc_mode ~offset_mode ~var_mode offset term =
       let annot = ptree_of_term offset annot in
       PT_annot { term; annot }
 
-and ptree_of_pat ~loc_mode ~offset_mode ~var_mode offset pat =
+and ptree_of_pat :
+    type a. loc_mode:_ -> offset_mode:_ -> var_mode:_ -> _ -> a pat -> _ =
+ fun ~loc_mode ~offset_mode ~var_mode offset pat ->
+  let open Ptree in
   let ptree_of_term term =
     ptree_of_term ~loc_mode ~offset_mode ~var_mode offset term
   in
@@ -161,3 +165,6 @@ let pp_term fmt term =
 let pp_pat fmt pat =
   let pterm = ptree_of_pat ~loc_mode ~offset_mode ~var_mode Offset.zero pat in
   Ptree.pp_term fmt pterm
+
+let pp_ex_term fmt (Ex_term term) = pp_term fmt term
+let pp_ex_pat fmt (Ex_pat pat) = pp_pat fmt pat

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,4 +1,6 @@
 open Ttree
 
-val pp_term : Format.formatter -> term -> unit
-val pp_pat : Format.formatter -> pat -> unit
+val pp_term : Format.formatter -> _ term -> unit
+val pp_pat : Format.formatter -> _ pat -> unit
+val pp_ex_term : Format.formatter -> ex_term -> unit
+val pp_ex_pat : Format.formatter -> ex_pat -> unit

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -7,16 +7,24 @@
    makes normalization cached, with unification this
    means that this cache will probably be dependent on holes *)
 
-type term =
-  | TT_loc of { term : term; loc : Location.t [@opaque] }
-  | TT_offset of { term : term; offset : Offset.t }
-  | TT_var of { offset : Offset.t }
-  | TT_forall of { param : pat; return : term }
-  | TT_lambda of { param : pat; return : term }
-  | TT_apply of { lambda : term; arg : term }
-  | TT_annot of { term : term; annot : term }
+type loc = Loc
+type offset = Offset
+type annot = Annot
+type core = Core
 
-and pat =
-  | TP_loc of { pat : pat; loc : Location.t [@opaque] }
-  | TP_var of { var : Name.t }
-  | TP_annot of { pat : pat; annot : term }
+type _ term =
+  | TT_loc : { term : _ term; loc : Location.t } -> loc term
+  | TT_offset : { term : _ term; offset : Offset.t } -> offset term
+  | TT_var : { offset : Offset.t } -> core term
+  | TT_forall : { param : annot pat; return : _ term } -> core term
+  | TT_lambda : { param : annot pat; return : _ term } -> core term
+  | TT_apply : { lambda : _ term; arg : _ term } -> core term
+  | TT_annot : { term : _ term; annot : _ term } -> annot term
+
+and _ pat =
+  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
+  | TP_var : { var : Name.t } -> core pat
+  | TP_annot : { pat : _ pat; annot : _ term } -> annot pat
+
+type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,22 +1,28 @@
-(* TODO: make this private again? *)
+type loc = Loc
+type offset = Offset
+type annot = Annot
+type core = Core
 
-type term =
-  | TT_loc of { term : term; loc : Location.t }
-  | TT_offset of { term : term; offset : Offset.t }
+type _ term =
+  | TT_loc : { term : _ term; loc : Location.t } -> loc term
+  | TT_offset : { term : _ term; offset : Offset.t } -> offset term
   (* x *)
-  | TT_var of { offset : Offset.t }
+  | TT_var : { offset : Offset.t } -> core term
   (* (x : A) -> B *)
-  | TT_forall of { param : pat; return : term }
+  | TT_forall : { param : annot pat; return : _ term } -> core term
   (* (x : A) => e *)
-  | TT_lambda of { param : pat; return : term }
+  | TT_lambda : { param : annot pat; return : _ term } -> core term
   (* l a *)
-  | TT_apply of { lambda : term; arg : term }
+  | TT_apply : { lambda : _ term; arg : _ term } -> core term
   (* (v : T) *)
-  | TT_annot of { term : term; annot : term }
+  | TT_annot : { term : _ term; annot : _ term } -> annot term
 
-and pat =
-  | TP_loc of { pat : pat; loc : Location.t }
+and _ pat =
+  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
   (* x *)
-  | TP_var of { var : Name.t }
+  | TP_var : { var : Name.t } -> core pat
   (* (p : T) *)
-  | TP_annot of { pat : pat; annot : term }
+  | TP_annot : { pat : _ pat; annot : _ term } -> annot pat
+
+type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/teika/typer.mli
+++ b/teika/typer.mli
@@ -1,3 +1,4 @@
 open Context
+open Ttree
 
-val infer_term : Ltree.term -> Ttree.term Typer_context.t
+val infer_term : Ltree.term -> annot term Typer_context.t

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -22,7 +22,8 @@ open Unify_context
 (* TODO: occurs should probably be on it's own context *)
 
 (* TODO: diff is a bad name *)
-let rec unify_term ~expected ~received =
+let rec unify_term : type e r. expected:e term -> received:r term -> _ =
+ fun ~expected ~received ->
   match (expected, received) with
   | TT_annot { term = expected; annot = _ }, received ->
       unify_term ~expected ~received
@@ -66,7 +67,8 @@ let rec unify_term ~expected ~received =
       (TT_var _ | TT_forall _ | TT_lambda _ | TT_apply _) ) ->
       error_type_clash ~expected ~received
 
-and unify_pat ~expected ~received =
+and unify_pat : type e r. expected:e pat -> received:r pat -> _ =
+ fun ~expected ~received ->
   match (expected, received) with
   | TP_var { var = _ }, TP_var { var = _ } -> return ()
   | ( TP_annot { pat = expected; annot = expected_annot },
@@ -82,11 +84,11 @@ and unify_pat ~expected ~received =
 
 let unify_term ~expected ~received =
   (* TODO: does it make sense to always normalize? *)
-  let* expected =
+  let* (Ex_term expected) =
     with_expected_normalize_context @@ fun () ->
     Normalize.normalize_term expected
   in
-  let* received =
+  let* (Ex_term received) =
     with_received_normalize_context @@ fun () ->
     Normalize.normalize_term received
   in

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -1,4 +1,4 @@
 open Ttree
 open Context
 
-val unify_term : expected:term -> received:term -> unit Unify_context.t
+val unify_term : expected:_ term -> received:_ term -> unit Unify_context.t


### PR DESCRIPTION
## Goals

Try to improve the reliability of the type checker.

## Context

The current typed tree doesn't enforce basic properties such as patterns of lambdas always being annotated and the return of the typing function always being an annotated term. This leads to some cases that will never occur but must be handled.

Here I try to improve the situation a bit by tracking at least what is annotated and what is not through GADTs.