### PR TITLE
teika: add eager substitution again

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -33,7 +33,7 @@ type ('a, 'b) result = { match_ : 'k. ok:('a -> 'k) -> error:('b -> 'k) -> 'k }
 let[@inline always] ok value = { match_ = (fun ~ok ~error:_ -> ok value) }
 let[@inline always] error desc = { match_ = (fun ~ok:_ ~error -> error desc) }
 
-type var_info = Subst of { to_ : ex_term } | Bound of { base : Offset.t }
+type var_info = Bound of { base : Offset.t }
 
 module Normalize_context = struct
   type 'a normalize_context =
@@ -65,9 +65,6 @@ module Normalize_context = struct
       let index = Offset.(repr (var - one)) in
       List.nth_opt vars index
     with
-    | Some (Subst { to_ = Ex_term to_ }) ->
-        let offset = Offset.(var + offset) in
-        ok @@ Ex_term (TT_offset { term = to_; offset })
     | Some (Bound { base }) ->
         let offset = Offset.(var + offset - base) in
         ok @@ Ex_term (TT_var { offset })
@@ -78,10 +75,6 @@ module Normalize_context = struct
 
   let[@inline always] with_var f ~vars ~offset =
     let vars = Bound { base = offset } :: vars in
-    f () ~vars ~offset
-
-  let[@inline always] elim_var ~to_ f ~vars ~offset =
-    let vars = Subst { to_ } :: vars in
     f () ~vars ~offset
 
   let[@inline always] with_offset ~offset f ~vars ~offset:current_offset =

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -18,7 +18,7 @@ type error = private
   | CError_typer_pat_var_not_annotated of { name : Name.t }
 [@@deriving show]
 
-type var_info = Subst of { to_ : ex_term } | Bound of { base : Offset.t }
+type var_info = Bound of { base : Offset.t }
 
 module Normalize_context : sig
   type 'a normalize_context
@@ -44,9 +44,6 @@ module Normalize_context : sig
   (* vars *)
   val repr_var : var:Offset.t -> ex_term normalize_context
   val with_var : (unit -> 'a normalize_context) -> 'a normalize_context
-
-  val elim_var :
-    to_:ex_term -> (unit -> 'a normalize_context) -> 'a normalize_context
 
   (* offset *)
   val with_offset :

--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -26,18 +26,20 @@ let rec normalize_term : type a. a term -> _ =
       match lambda with
       | TT_lambda { param; return } ->
           (* TODO: match every case below *)
-          elim_apply ~pat:param ~return ~arg @@ fun () -> normalize_term return
+          elim_apply ~pat:param ~return ~arg
       | _ -> return @@ Ex_term (TT_apply { lambda; arg }))
 
 (* TODO: weird *)
 and elim_apply : type p r a. pat:p pat -> return:r term -> arg:a term -> _ =
- fun ~pat ~return ~arg f ->
+ fun ~pat ~return ~arg ->
   match (pat, arg) with
-  | TP_annot { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg f
-  | TP_loc { pat; loc = _ }, arg -> elim_apply ~pat ~return ~arg f
+  | TP_annot { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg
+  | TP_loc { pat; loc = _ }, arg -> elim_apply ~pat ~return ~arg
   | TP_var { var = _ }, arg ->
-      with_offset ~offset:Offset.(zero - one) @@ fun () ->
-      elim_var ~to_:(Ex_term arg) f
+      let from = Offset.one in
+      let (Ex_term return) = Subst.subst_term ~from ~to_:arg return in
+      (* TODO: is this normalize needed? *)
+      normalize_term return
 
 and normalize_pat : type a. a pat -> (a pat -> _) -> _ =
  fun pat f ->

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -1,0 +1,111 @@
+open Ttree
+
+let rec shift_term : type a. by:_ -> depth:_ -> a term -> a term =
+ fun ~by ~depth term ->
+  let shift_term ~depth term = shift_term ~by ~depth term in
+  let shift_pat ~depth pat f = shift_pat ~by ~depth pat f in
+  match term with
+  | TT_loc { term; loc } ->
+      let term = shift_term ~depth term in
+      TT_loc { term; loc }
+  | TT_offset { term; offset } ->
+      let term = shift_term ~depth term in
+      TT_offset { term; offset }
+  | TT_var { offset = var } ->
+      let var =
+        match Offset.(var < depth) with
+        | true -> var
+        | false -> Offset.(var + by)
+      in
+      TT_var { offset = var }
+  | TT_forall { param; return } ->
+      shift_pat ~depth param @@ fun ~depth param ->
+      let return = shift_term ~depth return in
+      TT_forall { param; return }
+  | TT_lambda { param; return } ->
+      shift_pat ~depth param @@ fun ~depth param ->
+      let return = shift_term ~depth return in
+      TT_lambda { param; return }
+  | TT_apply { lambda; arg } ->
+      let lambda = shift_term ~depth lambda in
+      let arg = shift_term ~depth arg in
+      TT_apply { lambda; arg }
+  | TT_annot { term; annot } ->
+      let term = shift_term ~depth term in
+      let annot = shift_term ~depth annot in
+      TT_annot { term; annot }
+
+and shift_pat :
+    type a k. by:_ -> depth:_ -> a pat -> (depth:_ -> a pat -> k) -> k =
+ fun ~by ~depth pat f ->
+  let shift_term ~depth term = shift_term ~by ~depth term in
+  let shift_pat ~depth pat f = shift_pat ~by ~depth pat f in
+  match pat with
+  | TP_loc { pat; loc } ->
+      shift_pat ~depth pat @@ fun ~depth pat -> f ~depth (TP_loc { pat; loc })
+  | TP_var { var } ->
+      let depth = Offset.(depth + one) in
+      f ~depth (TP_var { var })
+  | TP_annot { pat; annot } ->
+      let annot = shift_term ~depth annot in
+      shift_pat ~depth pat @@ fun ~depth pat ->
+      f ~depth (TP_annot { pat; annot })
+
+let shift_term ~from term =
+  let by = Offset.(from - one) in
+  let depth = Offset.one in
+  shift_term ~by ~depth term
+
+let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
+ fun ~from ~to_ term ->
+  let subst_term ~from term = subst_term ~from ~to_ term in
+  let subst_pat ~from pat f = subst_pat ~from ~to_ pat f in
+
+  match term with
+  | TT_loc { term; loc } ->
+      let (Ex_term term) = subst_term ~from term in
+      Ex_term (TT_loc { term; loc })
+  | TT_offset { term; offset } ->
+      let (Ex_term term) = subst_term ~from term in
+      Ex_term (TT_offset { term; offset })
+  | TT_var { offset = var } -> (
+      match Offset.equal var from with
+      | true -> Ex_term (shift_term ~from to_)
+      | false ->
+          let var =
+            match Offset.(var < from) with
+            | true -> var
+            | false -> Offset.(var - one)
+          in
+          Ex_term (TT_var { offset = var }))
+  | TT_forall { param; return } ->
+      subst_pat ~from param @@ fun ~from param ->
+      let (Ex_term return) = subst_term ~from return in
+      Ex_term (TT_forall { param; return })
+  | TT_lambda { param; return } ->
+      subst_pat ~from param @@ fun ~from param ->
+      let (Ex_term return) = subst_term ~from return in
+      Ex_term (TT_lambda { param; return })
+  | TT_apply { lambda; arg } ->
+      let (Ex_term lambda) = subst_term ~from lambda in
+      let (Ex_term arg) = subst_term ~from arg in
+      Ex_term (TT_apply { lambda; arg })
+  | TT_annot { term; annot } ->
+      let (Ex_term annot) = subst_term ~from annot in
+      let (Ex_term term) = subst_term ~from term in
+      Ex_term (TT_annot { term; annot })
+
+and subst_pat :
+    type a k. from:_ -> to_:_ -> a pat -> (from:_ -> a pat -> k) -> k =
+ fun ~from ~to_ pat f ->
+  let subst_term ~from term = subst_term ~from ~to_ term in
+  let subst_pat pat f = subst_pat ~from ~to_ pat f in
+  match pat with
+  | TP_loc { pat; loc } ->
+      subst_pat pat @@ fun ~from pat -> f ~from (TP_loc { pat; loc })
+  | TP_var { var } ->
+      let from = Offset.(from + one) in
+      f ~from (TP_var { var })
+  | TP_annot { pat; annot } ->
+      let (Ex_term annot) = subst_term ~from annot in
+      subst_pat pat @@ fun ~from pat -> f ~from (TP_annot { pat; annot })

--- a/teika/subst.mli
+++ b/teika/subst.mli
@@ -1,0 +1,3 @@
+open Ttree
+
+val subst_term : from:Offset.t -> to_:_ term -> _ term -> ex_term


### PR DESCRIPTION
## Goals

Reduce normalization complexity. And prepare to extend the langauge.

## Context

I learned recently that what I was doing is essentially explicit substitutions. But while that can work it is way more subtle than I imagined. So to keep having progress I will be moving back to eager substitutions, but those will still be under the de-bruijin index framework.