### PR TITLE
teika: de-bruijin indexing by zero

### DIFF
--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -36,7 +36,7 @@ and elim_apply : type p r a. pat:p pat -> return:r term -> arg:a term -> _ =
   | TP_annot { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg
   | TP_loc { pat; loc = _ }, arg -> elim_apply ~pat ~return ~arg
   | TP_var { var = _ }, arg ->
-      let from = Offset.one in
+      let from = Offset.zero in
       let (Ex_term return) = Subst.subst_term ~from ~to_:arg return in
       (* TODO: is this normalize needed? *)
       normalize_term return

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -52,9 +52,8 @@ and shift_pat :
       f ~depth (TP_annot { pat; annot })
 
 let shift_term ~from term =
-  let by = Offset.(from - one) in
-  let depth = Offset.one in
-  shift_term ~by ~depth term
+  let depth = Offset.zero in
+  shift_term ~by:from ~depth term
 
 let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
  fun ~from ~to_ term ->

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -258,12 +258,18 @@ module Ttree_utils = struct
      let dump code =
        let stree = Slexer.from_string Sparser.term_opt code |> Option.get in
        let ltree = Lparser.from_stree stree in
-       let ttree = infer_term ltree |> Result.get_ok in
-       let ttree = normalize_term ttree |> Result.get_ok in
+       let (TT_annot { term = _; annot = ttree }) =
+         match infer_term ltree with
+         | Ok ttree -> ttree
+         | Error error ->
+             Format.eprintf "%a\n%!" Context.pp_error error;
+             failwith "infer"
+       in
+       let (Ex_term ttree) = normalize_term ttree |> Result.get_ok in
        Format.eprintf "%a\n%!" Tprinter.pp_term ttree;
        assert false
 
-     let () = dump "((id : (A : Type) -> (x : A) -> A) => id) (A => x => x)" *)
+     let () = dump "((A : Type) => (x : A) => x) Type" *)
 end
 
 module Typer = struct


### PR DESCRIPTION
## Goals

Simplify substitutions so that it matches better some models.

## Context

A couple interesting explicit substitutions papers use de-bruijin indexed by zero, which is also more intuitive to me.