### PR TITLE
teika: eager shifting

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -18,7 +18,7 @@ type error = private
   | CError_typer_pat_var_not_annotated of { name : Name.t }
 [@@deriving show]
 
-type var_info = Bound of { base : Offset.t }
+type var_info = Bound
 
 module Normalize_context : sig
   type 'a normalize_context
@@ -26,10 +26,7 @@ module Normalize_context : sig
 
   (* monad *)
   val test :
-    vars:var_info list ->
-    offset:Offset.t ->
-    (unit -> 'a normalize_context) ->
-    ('a, error) result
+    vars:var_info list -> (unit -> 'a normalize_context) -> ('a, error) result
 
   val return : 'a -> 'a normalize_context
 
@@ -42,12 +39,8 @@ module Normalize_context : sig
   val ( let+ ) : 'a normalize_context -> ('a -> 'b) -> 'b normalize_context
 
   (* vars *)
-  val repr_var : var:Offset.t -> ex_term normalize_context
-  val with_var : (unit -> 'a normalize_context) -> 'a normalize_context
 
-  (* offset *)
-  val with_offset :
-    offset:Offset.t -> (unit -> 'a normalize_context) -> 'a normalize_context
+  val with_var : (unit -> 'a normalize_context) -> 'a normalize_context
 end
 
 (* TODO: this is bad *)
@@ -58,9 +51,7 @@ module Unify_context : sig
   (* monad *)
   val test :
     expected_vars:var_info list ->
-    expected_offset:Offset.t ->
     received_vars:var_info list ->
-    received_offset:Offset.t ->
     (unit -> 'a unify_context) ->
     ('a, error) result
 
@@ -86,16 +77,6 @@ module Unify_context : sig
 
   val with_received_normalize_context :
     (unit -> 'a Normalize_context.t) -> 'a unify_context
-
-  (* offset *)
-  val expected_offset : unit -> Offset.t unify_context
-  val received_offset : unit -> Offset.t unify_context
-
-  val with_expected_offset :
-    offset:Offset.t -> (unit -> 'a unify_context) -> 'a unify_context
-
-  val with_received_offset :
-    offset:Offset.t -> (unit -> 'a unify_context) -> 'a unify_context
 end
 
 module Typer_context : sig

--- a/teika/normalize.ml
+++ b/teika/normalize.ml
@@ -9,9 +9,7 @@ let rec normalize_term : type a. a term -> _ =
   (* TODO: is removing those ok / ideal? *)
   | TT_annot { term; annot = _ } -> normalize_term term
   | TT_loc { term; loc = _ } -> normalize_term term
-  | TT_offset { term; offset } ->
-      with_offset ~offset @@ fun () -> normalize_term term
-  | TT_var { offset } -> repr_var ~var:offset
+  | TT_var { offset } -> return @@ Ex_term (TT_var { offset })
   | TT_forall { param; return } ->
       normalize_pat param @@ fun param ->
       let+ (Ex_term return) = normalize_term return in

--- a/teika/shift.ml
+++ b/teika/shift.ml
@@ -1,0 +1,55 @@
+open Ttree
+
+let rec shift_term : type a. by:_ -> depth:_ -> a term -> a term =
+ fun ~by ~depth term ->
+  let shift_term ~depth term = shift_term ~by ~depth term in
+  let shift_pat ~depth pat f = shift_pat ~by ~depth pat f in
+  match term with
+  | TT_loc { term; loc } ->
+      let term = shift_term ~depth term in
+      TT_loc { term; loc }
+  | TT_var { offset = var } ->
+      let var =
+        match Offset.(var < depth) with
+        | true -> var
+        | false -> Offset.(var + by)
+      in
+      TT_var { offset = var }
+  | TT_forall { param; return } ->
+      shift_pat ~depth param @@ fun ~depth param ->
+      let return = shift_term ~depth return in
+      TT_forall { param; return }
+  | TT_lambda { param; return } ->
+      shift_pat ~depth param @@ fun ~depth param ->
+      let return = shift_term ~depth return in
+      TT_lambda { param; return }
+  | TT_apply { lambda; arg } ->
+      let lambda = shift_term ~depth lambda in
+      let arg = shift_term ~depth arg in
+      TT_apply { lambda; arg }
+  | TT_annot { term; annot } ->
+      let term = shift_term ~depth term in
+      let annot = shift_term ~depth annot in
+      TT_annot { term; annot }
+
+and shift_pat :
+    type a k. by:_ -> depth:_ -> a pat -> (depth:_ -> a pat -> k) -> k =
+ fun ~by ~depth pat f ->
+  let shift_term ~depth term = shift_term ~by ~depth term in
+  let shift_pat ~depth pat f = shift_pat ~by ~depth pat f in
+  match pat with
+  | TP_loc { pat; loc } ->
+      shift_pat ~depth pat @@ fun ~depth pat -> f ~depth (TP_loc { pat; loc })
+  | TP_var { var } ->
+      let depth = Offset.(depth + one) in
+      f ~depth (TP_var { var })
+  | TP_annot { pat; annot } ->
+      let annot = shift_term ~depth annot in
+      shift_pat ~depth pat @@ fun ~depth pat ->
+      f ~depth (TP_annot { pat; annot })
+
+let shift_term ~offset term =
+  let by = offset in
+  let depth = Offset.zero in
+  let term = shift_term ~by ~depth term in
+  term

--- a/teika/shift.mli
+++ b/teika/shift.mli
@@ -1,0 +1,3 @@
+open Ttree
+
+val shift_term : offset:Offset.t -> 'a term -> 'a term

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -1,59 +1,5 @@
 open Ttree
-
-let rec shift_term : type a. by:_ -> depth:_ -> a term -> a term =
- fun ~by ~depth term ->
-  let shift_term ~depth term = shift_term ~by ~depth term in
-  let shift_pat ~depth pat f = shift_pat ~by ~depth pat f in
-  match term with
-  | TT_loc { term; loc } ->
-      let term = shift_term ~depth term in
-      TT_loc { term; loc }
-  | TT_offset { term; offset } ->
-      let term = shift_term ~depth term in
-      TT_offset { term; offset }
-  | TT_var { offset = var } ->
-      let var =
-        match Offset.(var < depth) with
-        | true -> var
-        | false -> Offset.(var + by)
-      in
-      TT_var { offset = var }
-  | TT_forall { param; return } ->
-      shift_pat ~depth param @@ fun ~depth param ->
-      let return = shift_term ~depth return in
-      TT_forall { param; return }
-  | TT_lambda { param; return } ->
-      shift_pat ~depth param @@ fun ~depth param ->
-      let return = shift_term ~depth return in
-      TT_lambda { param; return }
-  | TT_apply { lambda; arg } ->
-      let lambda = shift_term ~depth lambda in
-      let arg = shift_term ~depth arg in
-      TT_apply { lambda; arg }
-  | TT_annot { term; annot } ->
-      let term = shift_term ~depth term in
-      let annot = shift_term ~depth annot in
-      TT_annot { term; annot }
-
-and shift_pat :
-    type a k. by:_ -> depth:_ -> a pat -> (depth:_ -> a pat -> k) -> k =
- fun ~by ~depth pat f ->
-  let shift_term ~depth term = shift_term ~by ~depth term in
-  let shift_pat ~depth pat f = shift_pat ~by ~depth pat f in
-  match pat with
-  | TP_loc { pat; loc } ->
-      shift_pat ~depth pat @@ fun ~depth pat -> f ~depth (TP_loc { pat; loc })
-  | TP_var { var } ->
-      let depth = Offset.(depth + one) in
-      f ~depth (TP_var { var })
-  | TP_annot { pat; annot } ->
-      let annot = shift_term ~depth annot in
-      shift_pat ~depth pat @@ fun ~depth pat ->
-      f ~depth (TP_annot { pat; annot })
-
-let shift_term ~from term =
-  let depth = Offset.zero in
-  shift_term ~by:from ~depth term
+open Shift
 
 let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
  fun ~from ~to_ term ->
@@ -64,12 +10,9 @@ let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
   | TT_loc { term; loc } ->
       let (Ex_term term) = subst_term ~from term in
       Ex_term (TT_loc { term; loc })
-  | TT_offset { term; offset } ->
-      let (Ex_term term) = subst_term ~from term in
-      Ex_term (TT_offset { term; offset })
   | TT_var { offset = var } -> (
       match Offset.equal var from with
-      | true -> Ex_term (shift_term ~from to_)
+      | true -> Ex_term (shift_term ~offset:from to_)
       | false ->
           let var =
             match Offset.(var < from) with

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -252,7 +252,7 @@ module Ttree_utils = struct
     run @@ fun () -> Typer.infer_term term
 
   (* let normalize_term term =
-       Context.Normalize_context.test ~vars:[] ~offset:Offset.zero @@ fun () ->
+       Context.Normalize_context.test ~vars:[] @@ fun () ->
        Normalize.normalize_term term
 
      let dump code =

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -14,7 +14,6 @@ type core = Core
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
-  | TT_offset : { term : _ term; offset : Offset.t } -> offset term
   | TT_var : { offset : Offset.t } -> core term
   | TT_forall : { param : annot pat; return : _ term } -> core term
   | TT_lambda : { param : annot pat; return : _ term } -> core term

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -5,7 +5,6 @@ type core = Core
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
-  | TT_offset : { term : _ term; offset : Offset.t } -> offset term
   (* x *)
   | TT_var : { offset : Offset.t } -> core term
   (* (x : A) -> B *)

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -15,7 +15,7 @@ let split_forall (type a) (type_ : a term) =
   let* (Ex_term type_) = normalize_received_term type_ in
   match type_ with
   | TT_forall { param; return } -> Typer_context.return (param, Ex_term return)
-  | TT_var _ | TT_lambda _ | TT_apply _ | TT_annot _ | TT_loc _ | TT_offset _ ->
+  | TT_var _ | TT_lambda _ | TT_apply _ | TT_annot _ | TT_loc _ ->
       error_not_a_forall ~type_
 
 let typeof_term term =

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -33,16 +33,7 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       unify_term ~expected ~received
   | expected, TT_loc { term = received; loc = _ } ->
       unify_term ~expected ~received
-      (* TODO: use those locations for something? *)
-  | TT_offset { term = expected; offset }, received ->
-      with_expected_offset ~offset @@ fun () -> unify_term ~expected ~received
-  | expected, TT_offset { term = received; offset } ->
-      with_received_offset ~offset @@ fun () -> unify_term ~expected ~received
   | TT_var { offset = expected }, TT_var { offset = received } -> (
-      let* expected_offset = expected_offset () in
-      let* received_offset = received_offset () in
-      let expected = Offset.(expected + expected_offset) in
-      let received = Offset.(received + received_offset) in
       match Offset.equal expected received with
       | true -> return ()
       | false -> error_var_clash ~expected ~received)


### PR DESCRIPTION
## Goals

Make typed tree and context simpler.

## Context

Currently we do shifting through TT_offset, which is a lazy shifting, this means that the context needs to track the current offset, additionally this mechanism doesn't seems to handle free variables well.

To simplify and allow me to progress on the language, I will be doing eager shifting instead.