### PR TITLE
teika: track all variables during typing

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -90,6 +90,7 @@ module Typer_context : sig
     type_of_types:Level.t ->
     level:Level.t ->
     names:(Level.t * ex_term) Name.Map.t ->
+    expected_vars:var_info list ->
     received_vars:var_info list ->
     (unit -> 'a typer_context) ->
     ('a, error) result
@@ -111,8 +112,9 @@ module Typer_context : sig
 
   (* vars *)
   val instance : name:Name.t -> (Offset.t * ex_term) typer_context
+  val with_expected_var : (unit -> 'a typer_context) -> 'a typer_context
 
-  val with_binder :
+  val with_received_var :
     name:Name.t ->
     type_:_ term ->
     (unit -> 'a typer_context) ->

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -251,25 +251,31 @@ module Ttree_utils = struct
     let open Typer_context in
     run @@ fun () -> Typer.infer_term term
 
-  (* let normalize_term term =
-       Context.Normalize_context.test ~vars:[] @@ fun () ->
-       Normalize.normalize_term term
-
-     let dump code =
+  (* let dump code =
        let stree = Slexer.from_string Sparser.term_opt code |> Option.get in
        let ltree = Lparser.from_stree stree in
-       let (TT_annot { term = _; annot = ttree }) =
+       let ttree =
          match infer_term ltree with
          | Ok ttree -> ttree
          | Error error ->
              Format.eprintf "%a\n%!" Context.pp_error error;
              failwith "infer"
        in
-       let (Ex_term ttree) = normalize_term ttree |> Result.get_ok in
+       let (TT_annot { term = _ttree; annot = ttree }) = ttree in
+       let (Ex_term ttree) =
+         match
+           Context.Normalize_context.test ~vars:[ Bound ] @@ fun () ->
+           Normalize.normalize_term ttree
+         with
+         | Ok ttree -> ttree
+         | Error error ->
+             Format.eprintf "%a\n%!" Context.pp_error error;
+             failwith "normal"
+       in
        Format.eprintf "%a\n%!" Tprinter.pp_term ttree;
        assert false
 
-     let () = dump "((A : Type) => (x : A) => x) Type" *)
+     let () = dump {|((((id : (A : Type) -> (x : A) -> A) => id)) )|} *)
 end
 
 module Typer = struct

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -7,6 +7,7 @@
    makes normalization cached, with unification this
    means that this cache will probably be dependent on holes *)
 
+(* TODO: try parametric hoas *)
 type loc = Loc
 type offset = Offset
 type annot = Annot

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -3,20 +3,23 @@ open Ttree
 open Context
 open Typer_context
 
-let normalize_received_term term =
-  with_received_normalize_context @@ fun () -> Normalize.normalize_term term
-
 let unify_term ~expected ~received =
   with_unify_context @@ fun () -> Unify.unify_term ~expected ~received
 
+let normalize_received_term term =
+  with_received_normalize_context @@ fun () -> Normalize.normalize_term term
+
 let split_forall (type a) (type_ : a term) =
-  (* TODO: two normalize guarantees no TT_offset? *)
-  (* TODO: it doesn't *)
   let* (Ex_term type_) = normalize_received_term type_ in
-  match type_ with
-  | TT_forall { param; return } -> Typer_context.return (param, Ex_term return)
-  | TT_var _ | TT_lambda _ | TT_apply _ | TT_annot _ | TT_loc _ ->
-      error_not_a_forall ~type_
+  let rec split_forall : type a. a term -> _ =
+   fun type_ ->
+    match type_ with
+    | TT_loc { term; loc = _ } -> split_forall term
+    | TT_annot { term; annot = _ } -> split_forall term
+    | TT_forall { param; return } -> Typer_context.return (param, Ex_term return)
+    | TT_var _ | TT_lambda _ | TT_apply _ -> error_not_a_forall ~type_
+  in
+  split_forall type_
 
 let typeof_term term =
   let (TT_annot { term = _; annot }) = term in
@@ -156,7 +159,9 @@ and check_pat :
   (* TODO: expected should be a pattern, to achieve strictness *)
   match (pat, expected) with
   | LP_var { var = name }, expected ->
-      with_binder ~name ~type_:expected @@ fun () ->
+      (* TODO: add different names for left and right *)
+      with_expected_var @@ fun () ->
+      with_received_var ~name ~type_:expected @@ fun () ->
       f @@ tp_annot ~annot:expected @@ TP_var { var = name }
   | LP_pair _, _ -> error_pairs_not_implemented ()
   | LP_annot { pat; annot }, _expected_desc ->


### PR DESCRIPTION
## Goals

Achieve better error messages.

## Context

To have proper error messages Teika should be able to print the name of the variables during typing, this is currently not the case. This PR is a first step, I just track all variables during typing, the next step would be to carry the name of the variable and index to proper printing.