### PR TITLE
teika: separate {user,typer} annotation

### DIFF
--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -4,6 +4,7 @@ let rec expand_head : type a. a term -> core term =
  fun term ->
   match term with
   | TT_loc { term; loc = _ } -> expand_head term
+  | TT_typed { term; annot = _ } -> expand_head term
   | TT_var _ -> term
   | TT_forall _ -> term
   | TT_lambda _ -> term
@@ -18,9 +19,10 @@ let rec expand_head : type a. a term -> core term =
 and elim_apply : type p r a. pat:p pat -> return:r term -> arg:a term -> _ =
  fun ~pat ~return ~arg ->
   match (pat, arg) with
-  | TP_annot { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg
   | TP_loc { pat; loc = _ }, arg -> elim_apply ~pat ~return ~arg
+  | TP_typed { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg
   | TP_var { var = _ }, arg ->
       let from = Offset.zero in
       let (Ex_term return) = Subst.subst_term ~from ~to_:arg return in
       expand_head return
+  | TP_annot { pat; annot = _ }, arg -> elim_apply ~pat ~return ~arg

--- a/teika/expand_head.mli
+++ b/teika/expand_head.mli
@@ -1,3 +1,3 @@
 open Ttree
 
-val expand_head : 'a term -> core term
+val expand_head : _ term -> core term

--- a/teika/shift.ml
+++ b/teika/shift.ml
@@ -8,6 +8,10 @@ let rec shift_term : type a. by:_ -> depth:_ -> a term -> a term =
   | TT_loc { term; loc } ->
       let term = shift_term ~depth term in
       TT_loc { term; loc }
+  | TT_typed { term; annot } ->
+      let term = shift_term ~depth term in
+      let annot = shift_term ~depth annot in
+      TT_typed { term; annot }
   | TT_var { offset = var } ->
       let var =
         match Offset.(var < depth) with
@@ -40,6 +44,10 @@ and shift_pat :
   match pat with
   | TP_loc { pat; loc } ->
       shift_pat ~depth pat @@ fun ~depth pat -> f ~depth (TP_loc { pat; loc })
+  | TP_typed { pat; annot } ->
+      let annot = shift_term ~depth annot in
+      shift_pat ~depth pat @@ fun ~depth pat ->
+      f ~depth (TP_typed { pat; annot })
   | TP_var { var } ->
       let depth = Offset.(depth + one) in
       f ~depth (TP_var { var })

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -10,6 +10,10 @@ let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
   | TT_loc { term; loc } ->
       let (Ex_term term) = subst_term ~from term in
       Ex_term (TT_loc { term; loc })
+  | TT_typed { term; annot } ->
+      let (Ex_term annot) = subst_term ~from annot in
+      let (Ex_term term) = subst_term ~from term in
+      Ex_term (TT_typed { term; annot })
   | TT_var { offset = var } -> (
       match Offset.equal var from with
       | true -> Ex_term (shift_term ~offset:from to_)
@@ -45,6 +49,9 @@ and subst_pat :
   match pat with
   | TP_loc { pat; loc } ->
       subst_pat pat @@ fun ~from pat -> f ~from (TP_loc { pat; loc })
+  | TP_typed { pat; annot } ->
+      let (Ex_term annot) = subst_term ~from annot in
+      subst_pat pat @@ fun ~from pat -> f ~from (TP_typed { pat; annot })
   | TP_var { var } ->
       let from = Offset.(from + one) in
       f ~from (TP_var { var })

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -7,6 +7,7 @@ module Ptree = struct
 
   type term =
     | PT_loc of { term : term; loc : Location.t }
+    | PT_typed of { term : term; annot : term }
     | PT_var_index of { index : Offset.t }
     | PT_var_name of { name : Name.t }
     | PT_forall of { param : term; return : term }
@@ -28,6 +29,8 @@ module Ptree = struct
   let pp_term_syntax ~pp_wrapped ~pp_funct ~pp_apply ~pp_atom fmt term =
     match term with
     | PT_loc { term; loc } -> fprintf fmt "%a#%a" pp_atom term pp_loc loc
+    | PT_typed { term; annot } ->
+        fprintf fmt "%a #:# %a" pp_funct term pp_wrapped annot
     | PT_var_index { index } -> fprintf fmt "\\%d" (Offset.repr index)
     | PT_var_name { name } -> fprintf fmt "%s" (Name.repr name)
     | PT_forall { param; return } ->
@@ -51,70 +54,91 @@ module Ptree = struct
         (Wrapped | Funct | Apply | Atom) )
     | PT_apply _, (Wrapped | Funct | Apply)
     | (PT_forall _ | PT_lambda _), (Wrapped | Funct)
-    | PT_annot _, Wrapped ->
+    | (PT_typed _ | PT_annot _), Wrapped ->
         pp_term_syntax ~pp_wrapped ~pp_funct ~pp_apply ~pp_atom fmt term
     | PT_apply _, Atom
     | (PT_forall _ | PT_lambda _), (Apply | Atom)
-    | PT_annot _, (Funct | Apply | Atom) ->
+    | (PT_typed _ | PT_annot _), (Funct | Apply | Atom) ->
         fprintf fmt "(%a)" pp_wrapped term
 
   let pp_term fmt term = pp_term Wrapped fmt term
 end
 (* TODO: probably make printer tree *)
 
+type typed_mode = Typed_default | Typed_force
 type loc_mode = Loc_default | Loc_meaningful | Loc_force
 type var_mode = Var_name | Var_index | Var_both
 
-let should_print_loc ~loc_mode ~loc =
-  match loc_mode with
+type config = {
+  typed_mode : typed_mode;
+  loc_mode : loc_mode;
+  var_mode : var_mode;
+}
+
+let should_print_typed config =
+  match config.typed_mode with Typed_default -> false | Typed_force -> true
+
+let should_print_loc config ~loc =
+  match config.loc_mode with
   | Loc_default -> false
   | Loc_force -> true
   | Loc_meaningful -> not (Location.is_none loc)
 
-let rec ptree_of_term : type a. loc_mode:_ -> var_mode:_ -> _ -> a term -> _ =
- fun ~loc_mode ~var_mode offset (term : a term) ->
+let rec ptree_of_term : type a. _ -> a term -> _ =
+ fun config (term : a term) ->
   let open Ptree in
-  let ptree_of_term offset term =
-    ptree_of_term ~loc_mode ~var_mode offset term
-  in
-  let ptree_of_pat offset pat = ptree_of_pat ~loc_mode ~var_mode offset pat in
+  let ptree_of_term term = ptree_of_term config term in
+  let ptree_of_pat pat = ptree_of_pat config pat in
   match term with
   | TT_loc { term; loc } -> (
-      let term = ptree_of_term offset term in
-      match should_print_loc ~loc_mode ~loc with
+      let term = ptree_of_term term in
+      match should_print_loc config ~loc with
       | true -> PT_loc { term; loc }
       | false -> term)
-  | TT_var { offset = index } ->
-      let index = Offset.(offset + index) in
-      PT_var_index { index }
+  | TT_typed { term; annot } -> (
+      let term = ptree_of_term term in
+      match should_print_typed config with
+      | true ->
+          let annot = ptree_of_term annot in
+          PT_typed { term; annot }
+      | false -> term)
+  | TT_var { offset = index } -> PT_var_index { index }
   | TT_forall { param; return } ->
-      let param = ptree_of_pat offset param in
-      let return = ptree_of_term offset return in
+      let param = ptree_of_pat param in
+      let return = ptree_of_term return in
       PT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = ptree_of_pat offset param in
-      let return = ptree_of_term offset return in
+      let param = ptree_of_pat param in
+      let return = ptree_of_term return in
       PT_lambda { param; return }
   | TT_apply { lambda; arg } ->
-      let lambda = ptree_of_term offset lambda in
-      let arg = ptree_of_term offset arg in
+      let lambda = ptree_of_term lambda in
+      let arg = ptree_of_term arg in
       PT_apply { lambda; arg }
   | TT_annot { term; annot } ->
-      let term = ptree_of_term offset term in
-      let annot = ptree_of_term offset annot in
+      let term = ptree_of_term term in
+      let annot = ptree_of_term annot in
       PT_annot { term; annot }
 
-and ptree_of_pat : type a. loc_mode:_ -> var_mode:_ -> _ -> a pat -> _ =
- fun ~loc_mode ~var_mode offset pat ->
+and ptree_of_pat : type a. _ -> a pat -> _ =
+ fun config pat ->
   let open Ptree in
-  let ptree_of_term term = ptree_of_term ~loc_mode ~var_mode offset term in
-  let ptree_of_pat pat = ptree_of_pat ~loc_mode ~var_mode offset pat in
+  let ptree_of_term term = ptree_of_term config term in
+  let ptree_of_pat pat = ptree_of_pat config pat in
   match pat with
   | TP_loc { pat; loc } -> (
       let pat = ptree_of_pat pat in
-      match should_print_loc ~loc_mode ~loc with
+      match should_print_loc config ~loc with
       (* TODO: calling this term is weird *)
       | true -> PT_loc { term = pat; loc }
+      | false -> pat)
+  | TP_typed { pat; annot } -> (
+      let pat = ptree_of_pat pat in
+      match should_print_typed config with
+      | true ->
+          let annot = ptree_of_term annot in
+          (* TODO: calling this term is weird *)
+          PT_typed { term = pat; annot }
       | false -> pat)
   | TP_var { var = name } -> PT_var_name { name }
   | TP_annot { pat; annot } ->
@@ -122,15 +146,15 @@ and ptree_of_pat : type a. loc_mode:_ -> var_mode:_ -> _ -> a pat -> _ =
       let annot = ptree_of_term annot in
       PT_annot { term = pat; annot }
 
-let loc_mode = Loc_default
-let var_mode = Var_index
+let config =
+  { typed_mode = Typed_default; loc_mode = Loc_default; var_mode = Var_index }
 
 let pp_term fmt term =
-  let pterm = ptree_of_term ~loc_mode ~var_mode Offset.zero term in
+  let pterm = ptree_of_term config term in
   Ptree.pp_term fmt pterm
 
 let pp_pat fmt pat =
-  let pterm = ptree_of_pat ~loc_mode ~var_mode Offset.zero pat in
+  let pterm = ptree_of_pat config pat in
   Ptree.pp_term fmt pterm
 
 let pp_ex_term fmt (Ex_term term) = pp_term fmt term

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -9,22 +9,24 @@
 
 (* TODO: try parametric hoas *)
 type loc = Loc
-type offset = Offset
-type annot = Annot
+type typed = Typed
 type core = Core
+type sugar = Sugar
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
+  | TT_typed : { term : _ term; annot : _ term } -> typed term
   | TT_var : { offset : Offset.t } -> core term
-  | TT_forall : { param : annot pat; return : _ term } -> core term
-  | TT_lambda : { param : annot pat; return : _ term } -> core term
+  | TT_forall : { param : typed pat; return : _ term } -> core term
+  | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
-  | TT_annot : { term : _ term; annot : _ term } -> annot term
+  | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
 and _ pat =
   | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
+  | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
   | TP_var : { var : Name.t } -> core pat
-  | TP_annot : { pat : _ pat; annot : _ term } -> annot pat
+  | TP_annot : { pat : _ pat; annot : _ term } -> sugar pat
 
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,27 +1,29 @@
 type loc = Loc
-type offset = Offset
-type annot = Annot
+type typed = Typed
 type core = Core
+type sugar = Sugar
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
+  | TT_typed : { term : _ term; annot : _ term } -> typed term
   (* x *)
   | TT_var : { offset : Offset.t } -> core term
   (* (x : A) -> B *)
-  | TT_forall : { param : annot pat; return : _ term } -> core term
+  | TT_forall : { param : typed pat; return : _ term } -> core term
   (* (x : A) => e *)
-  | TT_lambda : { param : annot pat; return : _ term } -> core term
+  | TT_lambda : { param : typed pat; return : _ term } -> core term
   (* l a *)
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
   (* (v : T) *)
-  | TT_annot : { term : _ term; annot : _ term } -> annot term
+  | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
 and _ pat =
   | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
+  | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
   (* x *)
   | TP_var : { var : Name.t } -> core pat
   (* (p : T) *)
-  | TP_annot : { pat : _ pat; annot : _ term } -> annot pat
+  | TP_annot : { pat : _ pat; annot : _ term } -> sugar pat
 
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/teika/typer.mli
+++ b/teika/typer.mli
@@ -1,4 +1,4 @@
 open Context
 open Ttree
 
-val infer_term : Ltree.term -> annot term Typer_context.t
+val infer_term : Ltree.term -> typed term Typer_context.t


### PR DESCRIPTION
## Goals

Be able to distinguish between typer generated annotations and user annotations.

## Context

When printing or compiling the typed tree it is useful to know what are typer generated annotations and user generated annotations, as the typer generated ones should guide your compiling and the user generated ones should be ignored. This is currently not possible as they're both represented in the same way.