### PR TITLE
teika: add first class support to let

### DIFF
--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -13,6 +13,7 @@ let rec expand_head : type a. a term -> core term =
       match lambda with
       | TT_lambda { param; return } -> elim_apply ~pat:param ~return ~arg
       | _lambda -> TT_apply { lambda; arg })
+  | TT_let { pat; value; return } -> elim_apply ~pat ~return ~arg:value
   | TT_annot { term; annot = _ } -> expand_head term
 
 (* TODO: weird *)

--- a/teika/shift.ml
+++ b/teika/shift.ml
@@ -31,6 +31,11 @@ let rec shift_term : type a. by:_ -> depth:_ -> a term -> a term =
       let lambda = shift_term ~depth lambda in
       let arg = shift_term ~depth arg in
       TT_apply { lambda; arg }
+  | TT_let { pat; value; return } ->
+      let value = shift_term ~depth value in
+      shift_pat ~depth pat @@ fun ~depth pat ->
+      let return = shift_term ~depth return in
+      TT_let { pat; value; return }
   | TT_annot { term; annot } ->
       let term = shift_term ~depth term in
       let annot = shift_term ~depth annot in

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -36,6 +36,11 @@ let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
       let (Ex_term lambda) = subst_term ~from lambda in
       let (Ex_term arg) = subst_term ~from arg in
       Ex_term (TT_apply { lambda; arg })
+  | TT_let { pat; value; return } ->
+      let (Ex_term value) = subst_term ~from value in
+      subst_pat ~from pat @@ fun ~from pat ->
+      let (Ex_term return) = subst_term ~from return in
+      Ex_term (TT_let { pat; value; return })
   | TT_annot { term; annot } ->
       let (Ex_term annot) = subst_term ~from annot in
       let (Ex_term term) = subst_term ~from term in

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -261,21 +261,11 @@ module Ttree_utils = struct
              Format.eprintf "%a\n%!" Context.pp_error error;
              failwith "infer"
        in
-       let (TT_annot { term = _ttree; annot = ttree }) = ttree in
-       let (Ex_term ttree) =
-         match
-           Context.Normalize_context.test ~vars:[ Bound ] @@ fun () ->
-           Normalize.normalize_term ttree
-         with
-         | Ok ttree -> ttree
-         | Error error ->
-             Format.eprintf "%a\n%!" Context.pp_error error;
-             failwith "normal"
-       in
+       let (TT_typed { term = _ttree; annot = ttree }) = ttree in
        Format.eprintf "%a\n%!" Tprinter.pp_term ttree;
        assert false
 
-     let () = dump {|((((id : (A : Type) -> (x : A) -> A) => id)) )|} *)
+     let () = dump {|(id = (A : Type) => (x : A) => x; id)|} *)
 end
 
 module Typer = struct
@@ -297,6 +287,10 @@ module Typer = struct
   let id_propagate =
     check "id_propagate" ~wrapper:false
       {|((A => x => x) : (A : Type) -> (x : A) -> A)|}
+
+  let let_id =
+    check "let_id" ~wrapper:false
+      {|((id = (A : Type) => (x : A) => x; id) : (A : Type) -> (x : A) -> A)|}
 
   let id_type =
     check "id_type" ~wrapper:false
@@ -364,6 +358,7 @@ module Typer = struct
     [
       id;
       id_propagate;
+      let_id;
       id_type;
       id_type_never;
       return_id_propagate;

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -20,6 +20,7 @@ type _ term =
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
+  | TT_let : { pat : typed pat; value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
 and _ pat =

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -14,6 +14,8 @@ type _ term =
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   (* l a *)
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
+  (* (x : A) = t; u *)
+  | TT_let : { pat : typed pat; value : _ term; return : _ term } -> sugar term
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 


### PR DESCRIPTION
## Goals

Better support for let syntax.

## Context

Currently Teika let is implemented as sugar to `(x => t) u`, while this is correct from a checking point of view, it will lead to bad error messages and bad compiler output.