### PR TITLE
smol: define new typed tree

### DIFF
--- a/smol/HACKING.md
+++ b/smol/HACKING.md
@@ -1,0 +1,15 @@
+# Smol Frontend
+
+## Optimizations
+
+### Explicit Substitutions
+
+This uses explicit substitutions to achieve laziness, similar to λυ.
+
+I think Smol doesn't have metavariables as no unification exists, additionally currently substituions are not used for equality.
+
+Also the failure mode is that it will reject terms not accept terms, which seems to be okay.
+
+- https://drops.dagstuhl.de/opus/volltexte/2014/4858/pdf/34.pdf
+- https://www.irif.fr/~kesner/papers/springer-csl07.pdf
+- https://hal.inria.fr/inria-00074197/document

--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -1,0 +1,21 @@
+type loc = Location
+type typed = Typed
+type subst = Subst
+type core = Core
+
+type _ term =
+  | TT_loc : { term : _ term; loc : Location.t } -> loc term
+  | TT_typed : { term : _ term; type_ : _ term } -> typed term
+  | TT_subst : { from : Var.t; to_ : _ term; term : _ term } -> subst term
+  | TT_var : { var : Var.t } -> core term
+  | TT_arrow : { param : typed pat; return : _ term } -> core term
+  | TT_lambda : { param : typed pat; return : _ term } -> core term
+  | TT_apply : { lambda : _ term; arg : _ term } -> core term
+
+and _ pat =
+  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
+  | TP_typed : { pat : _ pat; type_ : _ term } -> typed pat
+  | TP_var : { var : Var.t } -> core pat
+
+type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -1,0 +1,22 @@
+type loc = Location
+type typed = Typed
+type subst = Subst
+type core = Core
+
+type _ term =
+  | TT_loc : { term : _ term; loc : Location.t } -> loc term
+  | TT_typed : { term : _ term; type_ : _ term } -> typed term
+  (* WARNING: Explicit Substitutions, HACKING.md *)
+  | TT_subst : { from : Var.t; to_ : _ term; term : _ term } -> subst term
+  | TT_var : { var : Var.t } -> core term
+  | TT_arrow : { param : typed pat; return : _ term } -> core term
+  | TT_lambda : { param : typed pat; return : _ term } -> core term
+  | TT_apply : { lambda : _ term; arg : _ term } -> core term
+
+and _ pat =
+  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
+  | TP_typed : { pat : _ pat; type_ : _ term } -> typed pat
+  | TP_var : { var : Var.t } -> core pat
+
+type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]


### PR DESCRIPTION
## Goals

Define new typed tree to be used both during type checking and code generation.

## Context

This is focused on the CoC. It makes so that every term carries it's own type to make typing easier and locations to achieve proper error messages. 

Additionally Smol type checking needs to be reasonably fast as it is intended as a verification and bootstrapping layer for Teika, this uses explicit substitutions to achieve lazy substitutions.
 
## Related

- #104