### PR TITLE
smol: rename arrows to forall

### DIFF
--- a/smol/lparser.ml
+++ b/smol/lparser.ml
@@ -12,10 +12,10 @@ let rec parse_term ~loc term =
       LT_loc { term; loc }
   | ST_parens { term } -> parse_term ~loc term
   | ST_var { var } -> LT_var { var }
-  | ST_arrow { param; return } ->
+  | ST_forall { param; return } ->
       let param = parse_pat ~loc param in
       let return = parse_term ~loc return in
-      LT_arrow { param; return }
+      LT_forall { param; return }
   | ST_lambda { param; return } ->
       let param = parse_pat ~loc param in
       let return = parse_term ~loc return in
@@ -41,5 +41,5 @@ and parse_pat ~loc term =
       LP_loc { pat; loc }
   | ST_parens { term = pat } -> parse_pat ~loc pat
   | ST_var { var } -> LP_var { var }
-  | ST_arrow _ | ST_lambda _ | ST_apply _ | ST_alias _ | ST_annot _ ->
+  | ST_forall _ | ST_lambda _ | ST_apply _ | ST_alias _ | ST_annot _ ->
       raise (Invalid_notation { loc })

--- a/smol/ltree.ml
+++ b/smol/ltree.ml
@@ -1,7 +1,7 @@
 type term =
   | LT_loc of { term : term; loc : Location.t [@opaque] }
   | LT_var of { var : Name.t }
-  | LT_arrow of { param : pat; return : term }
+  | LT_forall of { param : pat; return : term }
   | LT_lambda of { param : pat; return : term }
   | LT_apply of { lambda : term; arg : term }
   | LT_alias of { bound : pat; value : term; return : term }

--- a/smol/ltree.mli
+++ b/smol/ltree.mli
@@ -3,7 +3,7 @@ type term =
   (* x *)
   | LT_var of { var : Name.t }
   (* P -> T *)
-  | LT_arrow of { param : pat; return : term }
+  | LT_forall of { param : pat; return : term }
   (* P => m *)
   | LT_lambda of { param : pat; return : term }
   (* (m n) *)

--- a/smol/sparser.mly
+++ b/smol/sparser.mly
@@ -40,7 +40,7 @@ let term_rec_alias :=
 
 let term_rec_funct :=
   | term_rec_apply
-  | term_arrow(term_rec_funct, term_rec_apply)
+  | term_forall(term_rec_funct, term_rec_apply)
   | term_lambda(term_rec_funct, term_rec_apply)
 
 let term_rec_apply :=
@@ -54,9 +54,9 @@ let term_atom :=
 let term_var ==
   | var = VAR;
     { wrap $loc @@ ST_var { var = Name.make var } }
-let term_arrow(self, lower) ==
+let term_forall(self, lower) ==
   | param = lower; ARROW; return = self;
-    { wrap $loc @@ ST_arrow { param; return } }
+    { wrap $loc @@ ST_forall { param; return } }
 let term_lambda(self, lower) ==
   | param = lower; FAT_ARROW; return = self;
     { wrap $loc @@ ST_lambda { param; return } }

--- a/smol/stree.ml
+++ b/smol/stree.ml
@@ -2,7 +2,7 @@ type term =
   | ST_loc of { term : term; loc : Location.t [@opaque] }
   | ST_parens of { term : term }
   | ST_var of { var : Name.t }
-  | ST_arrow of { param : term; return : term }
+  | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
   | ST_alias of { bound : term; value : term; return : term }

--- a/smol/stree.mli
+++ b/smol/stree.mli
@@ -2,7 +2,7 @@ type term =
   | ST_loc of { term : term; loc : Location.t }
   | ST_parens of { term : term }
   | ST_var of { var : Name.t }
-  | ST_arrow of { param : term; return : term }
+  | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
   | ST_alias of { bound : term; value : term; return : term }

--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -8,7 +8,7 @@ type _ term =
   | TT_typed : { term : _ term; type_ : _ term } -> typed term
   | TT_subst : { from : Var.t; to_ : _ term; term : _ term } -> subst term
   | TT_var : { var : Var.t } -> core term
-  | TT_arrow : { param : typed pat; return : _ term } -> core term
+  | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
 

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -9,7 +9,7 @@ type _ term =
   (* WARNING: Explicit Substitutions, HACKING.md *)
   | TT_subst : { from : Var.t; to_ : _ term; term : _ term } -> subst term
   | TT_var : { var : Var.t } -> core term
-  | TT_arrow : { param : typed pat; return : _ term } -> core term
+  | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
 


### PR DESCRIPTION
## Goals

Have a consistency forall naming.

## Context

Currently on Smol all foralls are called arrows, while they do have an arrow-like syntax it is not right to call them simply arrows, as they allow for dependency.