### PR TITLE
smol: add typed tree printer

### DIFF
--- a/smol/sparser.mly
+++ b/smol/sparser.mly
@@ -64,7 +64,7 @@ let term_apply(self, lower) ==
   | lambda = self; arg = lower;
     { wrap $loc @@ ST_apply { lambda; arg } }
 let term_alias(self, lower) ==
-  | bound = lower; ALIAS; value = lower; return = self;
+  | bound = lower; ALIAS; value = lower; SEMICOLON; return = self;
   { wrap $loc @@ ST_alias { bound; value; return } }
 let term_annot(self, lower) ==
   | term = lower; COLON; annot = self;

--- a/smol/tprinter.mli
+++ b/smol/tprinter.mli
@@ -1,0 +1,6 @@
+open Ttree
+
+val pp_term : Format.formatter -> _ term -> unit
+val pp_pat : Format.formatter -> _ pat -> unit
+val pp_ex_term : Format.formatter -> ex_term -> unit
+val pp_ex_pat : Format.formatter -> ex_pat -> unit


### PR DESCRIPTION
## Goals

Pretty printing of terms on tests and error messages.

## Context

Due the usage of GADTs the typed tree doesn't have a generated printer, but a printer is needed for tests and error messages.

Here I add an initial pretty printer, which is essentially a negative version of the parser, line breaking is not present so it is mostly useful to small terms.

## Additional

Alias parsing was broken, but I didn't want to open a PR for a single token.

## Related

- #106