### PR TITLE
smol: extend syntax to support induction

### DIFF
--- a/smol/lparser.ml
+++ b/smol/lparser.ml
@@ -24,6 +24,7 @@ let rec parse_term ~loc term =
       let lambda = parse_term ~loc lambda in
       let arg = parse_term ~loc arg in
       LT_apply { lambda; arg }
+  | ST_self _ | ST_fix _ | ST_unroll _ -> raise (Invalid_notation { loc })
   | ST_alias { bound; value; return } ->
       let bound = parse_pat ~loc bound in
       let value = parse_term ~loc value in
@@ -45,5 +46,6 @@ and parse_pat ~loc term =
       let pat = parse_pat ~loc pat in
       let annot = parse_term ~loc annot in
       LP_annot { pat; annot }
-  | ST_forall _ | ST_lambda _ | ST_apply _ | ST_alias _ ->
+  | ST_forall _ | ST_lambda _ | ST_apply _ | ST_self _ | ST_fix _ | ST_unroll _
+  | ST_alias _ ->
       raise (Invalid_notation { loc })

--- a/smol/slexer.ml
+++ b/smol/slexer.ml
@@ -14,8 +14,10 @@ let rec tokenizer buf =
   match%sedlex buf with
   | whitespace -> tokenizer buf
   | variable -> VAR (lexeme buf)
-  | "->" -> ARROW
-  | "=>" -> FAT_ARROW
+  | "->" -> FORALL
+  | "=>" -> LAMBDA
+  | "@->" -> SELF
+  | "@=>" -> FIX
   | "===" -> ALIAS
   | ":" -> COLON
   | ";" -> SEMICOLON

--- a/smol/stree.ml
+++ b/smol/stree.ml
@@ -5,6 +5,9 @@ type term =
   | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
+  | ST_fix of { param : term; return : term }
+  | ST_self of { param : term; return : term }
+  | ST_unroll of { term : term }
   | ST_alias of { bound : term; value : term; return : term }
   | ST_annot of { term : term; annot : term }
 [@@deriving show { with_path = false }]

--- a/smol/stree.mli
+++ b/smol/stree.mli
@@ -5,6 +5,9 @@ type term =
   | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
+  | ST_fix of { param : term; return : term }
+  | ST_self of { param : term; return : term }
+  | ST_unroll of { term : term }
   | ST_alias of { bound : term; value : term; return : term }
   | ST_annot of { term : term; annot : term }
 [@@deriving show]


### PR DESCRIPTION
## Goals

Prepare self / fix / unroll syntax to fully implement #104.

## Context

Currently Smol only implements the CoC and `Type : Type` side of #104, induction and recursion are missing, those will be achieved through self / fix. This is the first step in that direction.

## Related

- #104
- #106