### PR TITLE
smol: extend typed tree to support induction

### DIFF
--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -11,6 +11,9 @@ type _ term =
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
+  | TT_self : { bound : _ pat; body : _ term } -> core term
+  | TT_fix : { bound : _ pat; body : _ term } -> core term
+  | TT_unroll : { term : _ term } -> core term
 
 and _ pat =
   | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -12,6 +12,9 @@ type _ term =
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
+  | TT_self : { bound : _ pat; body : _ term } -> core term
+  | TT_fix : { bound : _ pat; body : _ term } -> core term
+  | TT_unroll : { term : _ term } -> core term
 
 and _ pat =
   | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat


### PR DESCRIPTION
## Goals

Follow up of #122, prepare typed tree to elaborate self / fix / unroll.

## Additional

This also prepares the printer for it, as this change on itself is not very meaningful.

## Related

- #104 
- #106 