### PR TITLE
smol: add machinery to handle self types

### DIFF
--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -12,7 +12,7 @@ type _ term =
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
   | TT_self : { bound : _ pat; body : _ term } -> core term
-  | TT_fix : { bound : _ pat; body : _ term } -> core term
+  | TT_fix : { bound : typed pat; body : _ term } -> core term
   | TT_unroll : { term : _ term } -> core term
 
 and _ pat =

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -13,7 +13,9 @@ type _ term =
   | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
   | TT_self : { bound : _ pat; body : _ term } -> core term
-  | TT_fix : { bound : _ pat; body : _ term } -> core term
+  (* TODO: this typed term on the body is probably not needed
+      but this project tries to play very safe *)
+  | TT_fix : { bound : typed pat; body : _ term } -> core term
   | TT_unroll : { term : _ term } -> core term
 
 and _ pat =


### PR DESCRIPTION
## Goals

Prepare machinery for elaboration of self types.

## Context

Self types are the main component to achieve induction on Smol, they essentially describe the behavior of the dependent fix point combinator.

This PR implements a version of them described at #104.

## Alpha Conversion

Alpha conversion needs to be tweaked, as it appears that self types allows for different types of graphs.

```rust
Unit @-> (unit : unit @-> Unit unit unit) @-> (u @-> Unit unit u) -> Type

// This leads to a scenario where the following happens
received : unit @-> Unit unit unit
expected : u @-> Unit unit u
```

This solution was considered reasonable, as such behavior doesn't seems to happen with de-bruijin indices, essentially avoiding the issue above.

## Related

- #104
- #106 