### PR TITLE
smol: remove explicit substitutions

### DIFF
--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -1,12 +1,10 @@
 type loc = Location
 type typed = Typed
-type subst = Subst
 type core = Core
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
   | TT_typed : { term : _ term; type_ : _ term } -> typed term
-  | TT_subst : { from : Var.t; to_ : _ term; term : _ term } -> subst term
   | TT_var : { var : Var.t } -> core term
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -1,13 +1,10 @@
 type loc = Location
 type typed = Typed
-type subst = Subst
 type core = Core
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
   | TT_typed : { term : _ term; type_ : _ term } -> typed term
-  (* WARNING: Explicit Substitutions, HACKING.md *)
-  | TT_subst : { from : Var.t; to_ : _ term; term : _ term } -> subst term
   | TT_var : { var : Var.t } -> core term
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term

--- a/smol/ttyper.ml
+++ b/smol/ttyper.ml
@@ -9,13 +9,9 @@ let rec pat_var : type a. a pat -> _ =
   | TP_typed { pat; type_ = _ } -> pat_var pat
   | TP_var { var } -> var
 
-let lazy_subst_term ~from ~to_ term = TT_subst { from; to_; term }
-
 let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
  fun ~from ~to_ term ->
   let subst_term term = subst_term ~from ~to_ term in
-  (* TODO: to go further on lazy substitutions, rename the function below *)
-  let lazy_subst_term term = lazy_subst_term ~from ~to_ term in
   let subst_pat pat = subst_pat ~from ~to_ pat in
   match term with
   | TT_loc { term; loc } ->
@@ -23,11 +19,8 @@ let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
       Ex_term (TT_loc { term; loc })
   | TT_typed { term; type_ } ->
       let (Ex_term term) = subst_term term in
-      let type_ = lazy_subst_term type_ in
+      let (Ex_term type_) = subst_term type_ in
       Ex_term (TT_typed { term; type_ })
-  | TT_subst _ as term ->
-      (* TODO: does this makes sense? *)
-      Ex_term (lazy_subst_term term)
   | TT_var { var } -> (
       match Var.equal var from with
       | true -> Ex_term to_
@@ -55,7 +48,7 @@ let rec subst_term : type a. from:_ -> to_:_ -> a term -> ex_term =
 
 and subst_pat : type a. from:_ -> to_:_ -> a pat -> a pat =
  fun ~from ~to_ pat ->
-  let lazy_subst_term term = TT_subst { from; to_; term } in
+  let subst_term term = subst_term ~from ~to_ term in
   let subst_pat pat = subst_pat ~from ~to_ pat in
   match pat with
   | TP_loc { pat; loc } ->
@@ -63,7 +56,7 @@ and subst_pat : type a. from:_ -> to_:_ -> a pat -> a pat =
       TP_loc { pat; loc }
   | TP_typed { pat; type_ } ->
       let pat = subst_pat pat in
-      let type_ = lazy_subst_term type_ in
+      let (Ex_term type_) = subst_term type_ in
       TP_typed { pat; type_ }
   | TP_var _ as pat -> pat
 
@@ -72,10 +65,6 @@ let rec expand_head : type a. a term -> _ =
   match term with
   | TT_loc { term; loc = _ } -> expand_head term
   | TT_typed { term; type_ = _ } -> expand_head term
-  | TT_subst { from; to_; term } ->
-      let term = expand_head term in
-      let (Ex_term term) = subst_term ~from ~to_ term in
-      expand_head term
   | TT_var _ as term -> term
   | TT_forall _ as term -> term
   | TT_lambda _ as term -> term
@@ -238,9 +227,9 @@ let rec infer_term ctx term =
             let (Ex_term expected) = typeof_pat param in
             check_term ctx arg ~expected
           in
-          let type_ =
+          let (Ex_term type_) =
             let from = pat_var param in
-            lazy_subst_term ~from ~to_:arg return
+            subst_term ~from ~to_:arg return
           in
           wrap_term type_ @@ TT_apply { lambda; arg }
       | _ -> failwith "not a function")


### PR DESCRIPTION
## Goals

Simplify Smol design.

## Context

Explicit Substitutions were introduced to make substitutions lazy, which helps a lot on big trees where every node is annotated with a type as the tree grows exponentially fast.

This is the case for the current version of Smol, but it will not be in a future change, so ES will be removed to simplify the pipeline.

## Related

- #106