### PR TITLE
smol: compact the typed tree

### DIFF
--- a/smol/tprinter.ml
+++ b/smol/tprinter.ml
@@ -123,13 +123,6 @@ let rec ptree_of_term : type a. _ -> a term -> _ =
       match should_print_loc config ~loc with
       | true -> PT_loc { term; loc }
       | false -> term)
-  | TT_typed { term; type_ } -> (
-      let term = ptree_of_term term in
-      match should_print_typed config with
-      | true ->
-          let type_ = ptree_of_term type_ in
-          PT_typed { term; type_ }
-      | false -> term)
   | TT_var { var } -> ptree_of_var var
   | TT_forall { param; return } ->
       let param = ptree_of_pat param in

--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -4,7 +4,6 @@ type core = Core
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
-  | TT_typed : { term : _ term; type_ : _ term } -> typed term
   | TT_var : { var : Var.t } -> core term
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
@@ -18,5 +17,6 @@ and _ pat =
   | TP_typed : { pat : _ pat; type_ : _ term } -> typed pat
   | TP_var : { var : Var.t } -> core pat
 
+type ty_term = TT_typed : { term : _ term; type_ : _ term } -> ty_term
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -4,7 +4,6 @@ type core = Core
 
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
-  | TT_typed : { term : _ term; type_ : _ term } -> typed term
   | TT_var : { var : Var.t } -> core term
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
@@ -20,5 +19,6 @@ and _ pat =
   | TP_typed : { pat : _ pat; type_ : _ term } -> typed pat
   | TP_var : { var : Var.t } -> core pat
 
+type ty_term = TT_typed : { term : _ term; type_ : _ term } -> ty_term
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]


### PR DESCRIPTION
## Goals

Simplify the typed tree for Smol.

## Context

Current typed tree generated by Smol is quite big as every node will be annotated with a type. By removing such annotations the tree can be simplified and reduced in size, additionally it allows for a bit more flexibility which is needed during typing of self.

## Related

- #106