### PR TITLE
smol: remove locations from typed tree

### DIFF
--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -3,7 +3,6 @@ type typed = Typed
 type core = Core
 
 type _ term =
-  | TT_loc : { term : _ term; loc : Location.t } -> loc term
   | TT_var : { var : Var.t } -> core term
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
@@ -13,7 +12,6 @@ type _ term =
   | TT_unroll : { term : _ term } -> core term
 
 and _ pat =
-  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
   | TP_typed : { pat : _ pat; type_ : _ term } -> typed pat
   | TP_var : { var : Var.t } -> core pat
 

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -3,7 +3,6 @@ type typed = Typed
 type core = Core
 
 type _ term =
-  | TT_loc : { term : _ term; loc : Location.t } -> loc term
   | TT_var : { var : Var.t } -> core term
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
@@ -15,7 +14,6 @@ type _ term =
   | TT_unroll : { term : _ term } -> core term
 
 and _ pat =
-  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
   | TP_typed : { pat : _ pat; type_ : _ term } -> typed pat
   | TP_var : { var : Var.t } -> core pat
 


### PR DESCRIPTION
## Goals

Simplify even further the typed tree for Smol.

## Context

When doing some operations on the Smol typed tree locations are not preserved and preserving them would be way more work. Additionally those locations are not necessary for proper error messages.

Maybe I can add them back in the future if needed for code generation, but currently it doesn't seems to be needed.

## Related

- #106
