### PR TITLE
smol: split elaboration from translation

### DIFF
--- a/smol/test.ml
+++ b/smol/test.ml
@@ -9,8 +9,8 @@ let id =
     {|((A : Type) => (x : A) => x
       :(A : Type) -> (x : A) -> A)|}
 
-let id_propagate =
-  type_term "id_propagate" {|(A => x => x : (A : Type) -> (x : A) -> A)|}
+(* let id_propagate =
+   type_term "id_propagate" {|(A => x => x : (A : Type) -> (x : A) -> A)|} *)
 
 let sequence =
   type_term "sequence"
@@ -22,20 +22,20 @@ let bool =
     {|((A : Type) => (x : A) => (y : A) => x
                :(A : Type) -> (x : A) -> (y : A) -> A)|}
 
-let sequence_propagate =
-  type_term "sequence_propagate"
-    {|(A => x => B => y => y
-      :(A : Type) -> (x : A) -> (B : Type) -> (y : B) -> B)|}
+(* let sequence_propagate =
+   type_term "sequence_propagate"
+     {|(A => x => B => y => y
+       :(A : Type) -> (x : A) -> (B : Type) -> (y : B) -> B)|} *)
 
 let true_ =
   type_term "true"
     {|((A : Type) => (x : A) => (y : A) => x
       :(A : Type) -> (x : A) -> (y : A) -> A)|}
 
-let true_propagate =
-  type_term "true_propagate"
-    {|(A => x => y => x
-      :(A : Type) -> (x : A) -> (y : A) -> A)|}
+(* let true_propagate =
+   type_term "true_propagate"
+     {|(A => x => y => x
+       :(A : Type) -> (x : A) -> (y : A) -> A)|} *)
 
 let false_ =
   type_term "false"
@@ -45,12 +45,12 @@ let false_ =
 let tests =
   [
     id;
-    id_propagate;
+    (* id_propagate; *)
     sequence;
-    sequence_propagate;
+    (* sequence_propagate; *)
     bool;
     true_;
-    true_propagate;
+    (* true_propagate; *)
     false_;
   ]
 
@@ -61,8 +61,13 @@ let type_term term =
     let loc = Location.none in
     Lparser.parse_term ~loc term
   in
+  let term =
+    let open Ttyper in
+    let ctx = Translate.Context.initial in
+    Translate.translate_term ctx term
+  in
   let ctx = Ttyper.Context.initial in
-  Ttyper.infer_ty_term ctx term
+  Ttyper.infer_term ctx term
 
 let test { name; term } =
   let check () =

--- a/smol/var.ml
+++ b/smol/var.ml
@@ -47,3 +47,9 @@ let predef name =
   create name
 
 let type_ = predef "Type"
+
+module Map = Map.Make (struct
+  type t = var
+
+  let compare = compare
+end)

--- a/smol/var.mli
+++ b/smol/var.mli
@@ -9,3 +9,5 @@ val name : var -> Name.t
 (* predefined *)
 (* Type *)
 val type_ : var
+
+module Map : Map.S with type key = t


### PR DESCRIPTION
## Goals

Allow for easy typing of self types.

## Context

Typing of self requires assuming self, currently there is a specific function which the job is only for assumption during self.

This PR changes the design such that first you need to do a translation, which assumes everything to be properly typed and then does type elaboration.

Besides of making sure that the code path is always used, it removes from the checker all the details such as annotations a type propagation, which is currently disabled, but will be added back in a future PR.

## Related

- #106