### PR TITLE
smol: implement fixpoint

### DIFF
--- a/smol/slexer.ml
+++ b/smol/slexer.ml
@@ -18,6 +18,7 @@ let rec tokenizer buf =
   | "=>" -> LAMBDA
   | "@->" -> SELF
   | "@=>" -> FIX
+  | "@" -> UNROLL
   | "===" -> ALIAS
   | ":" -> COLON
   | ";" -> SEMICOLON

--- a/smol/test.ml
+++ b/smol/test.ml
@@ -42,6 +42,16 @@ let false_ =
     {|((A : Type) => (x : A) => (y : A) => y
       :(A : Type) -> (x : A) -> (y : A) -> A)|}
 
+let falseT =
+  type_term "FalseT"
+    {|((False : False @-> (f : f @-> @False f) -> Type) @=>
+        (f : f @-> @False f) => (P : (f : f @-> @False f) -> Type) -> P f)|}
+
+let unitT =
+  type_term "UnitT"
+    {|(Unit @-> (unit : unit @-> @Unit unit unit) ->
+        (u : u @-> @Unit u u) -> Type : Type)|}
+
 let tests =
   [
     id;
@@ -52,6 +62,8 @@ let tests =
     true_;
     (* true_propagate; *)
     false_;
+    falseT;
+    unitT;
   ]
 
 let type_term term =


### PR DESCRIPTION
## Goals

Actually support typing, self, fix and unroll.

## Context

This is a simple change as following #130 all the tooling for typing self is already present. Tests for FalseT and UnitT was added, but currently this only ensures the type of the type constructor is valid.

## Related

- #106