### PR TITLE
smol: fully functional self types

### DIFF
--- a/smol/lparser.ml
+++ b/smol/lparser.ml
@@ -35,6 +35,9 @@ let rec parse_term ~loc term =
   | ST_unroll { term } ->
       let term = parse_term ~loc term in
       LT_unroll { term }
+  | ST_expand { term } ->
+      let term = parse_term ~loc term in
+      LT_expand { term }
   | ST_alias { bound; value; return } ->
       let bound = parse_pat ~loc bound in
       let value = parse_term ~loc value in
@@ -57,5 +60,5 @@ and parse_pat ~loc term =
       let annot = parse_term ~loc annot in
       LP_annot { pat; annot }
   | ST_forall _ | ST_lambda _ | ST_apply _ | ST_self _ | ST_fix _ | ST_unroll _
-  | ST_alias _ ->
+  | ST_expand _ | ST_alias _ ->
       raise (Invalid_notation { loc })

--- a/smol/ltree.ml
+++ b/smol/ltree.ml
@@ -7,6 +7,7 @@ type term =
   | LT_self of { bound : pat; body : term }
   | LT_fix of { bound : pat; body : term }
   | LT_unroll of { term : term }
+  | LT_expand of { term : term }
   | LT_alias of { bound : pat; value : term; return : term }
   | LT_annot of { term : term; annot : term }
 

--- a/smol/ltree.mli
+++ b/smol/ltree.mli
@@ -14,6 +14,8 @@ type term =
   | LT_fix of { bound : pat; body : term }
   (* @m *)
   | LT_unroll of { term : term }
+  (* %expand m *)
+  | LT_expand of { term : term }
   (* P === m; n *)
   | LT_alias of { bound : pat; value : term; return : term }
   (* (m : T) *)

--- a/smol/slexer.ml
+++ b/smol/slexer.ml
@@ -19,6 +19,7 @@ let rec tokenizer buf =
   | "@->" -> SELF
   | "@=>" -> FIX
   | "@" -> UNROLL
+  | "%expand" -> EXPAND
   | "===" -> ALIAS
   | ":" -> COLON
   | ";" -> SEMICOLON

--- a/smol/sparser.mly
+++ b/smol/sparser.mly
@@ -12,6 +12,7 @@ let wrap (loc_start, loc_end) term =
 %token FIX (* @-> *)
 %token SELF (* @=> *)
 %token UNROLL (* @ *)
+%token EXPAND (* %expand *)
 %token ALIAS (* === *)
 %token COLON (* : *)
 %token SEMICOLON (* ; *)
@@ -51,10 +52,11 @@ let term_rec_funct :=
 let term_rec_apply :=
   | term_atom
   | term_apply(term_rec_apply, term_atom)
-  | term_unroll(term_atom)
+  | term_expand(term_atom)
 
 let term_atom :=
   | term_var
+  | term_unroll(term_atom)
   | term_parens(term)
 
 let term_var ==
@@ -75,6 +77,9 @@ let term_fix(self, lower) ==
 let term_unroll(lower) ==
   | UNROLL; term = lower;
     { wrap $loc @@ ST_unroll { term } }
+let term_expand(lower) ==
+  | EXPAND; term = lower;
+    { wrap $loc @@ ST_expand { term } }
 let term_apply(self, lower) ==
   | lambda = self; arg = lower;
     { wrap $loc @@ ST_apply { lambda; arg } }

--- a/smol/stree.ml
+++ b/smol/stree.ml
@@ -8,6 +8,7 @@ type term =
   | ST_fix of { bound : term; body : term }
   | ST_self of { bound : term; body : term }
   | ST_unroll of { term : term }
+  | ST_expand of { term : term }
   | ST_alias of { bound : term; value : term; return : term }
   | ST_annot of { term : term; annot : term }
 [@@deriving show { with_path = false }]

--- a/smol/stree.mli
+++ b/smol/stree.mli
@@ -8,6 +8,7 @@ type term =
   | ST_fix of { bound : term; body : term }
   | ST_self of { bound : term; body : term }
   | ST_unroll of { term : term }
+  | ST_expand of { term : term }
   | ST_alias of { bound : term; value : term; return : term }
   | ST_annot of { term : term; annot : term }
 [@@deriving show]

--- a/smol/test.ml
+++ b/smol/test.ml
@@ -42,15 +42,181 @@ let false_ =
     {|((A : Type) => (x : A) => (y : A) => y
       :(A : Type) -> (x : A) -> (y : A) -> A)|}
 
-let falseT =
-  type_term "FalseT"
-    {|((False : False @-> (f : f @-> @False f) -> Type) @=>
-        (f : f @-> @False f) => (P : (f : f @-> @False f) -> Type) -> P f)|}
+let ind_False =
+  let b_false = {|f @-> (P : (f : @False I_False) -> Type) -> @I_False P f|} in
+  let i_false_t =
+    Format.sprintf
+      {|I_False @-> (P : (f : @False I_False) -> Type) -> (f : %s) -> Type|}
+      b_false
+  in
+  let code =
+    Format.sprintf
+      {|
+        (FalseT : Type) === False @-> (I_False : %s) -> Type;
+        (False : FalseT) @=> (I_False : %s) => %s
+      |}
+      i_false_t i_false_t b_false
+  in
+  type_term "ind_False" code
 
-let unitT =
-  type_term "UnitT"
-    {|(Unit @-> (unit : unit @-> @Unit unit unit) ->
-        (u : u @-> @Unit u u) -> Type : Type)|}
+let ind_Unit =
+  let b_Unit =
+    {|
+      u @-> (P : (x : @Unit I_Unit unit I_unit) -> Type) ->
+        (x : @I_Unit unit I_unit P (@unit I_unit)) -> @I_Unit unit I_unit P u
+    |}
+  in
+  let b_unit =
+    {|
+      (u : u @->
+        (P : (x : @Unit I_Unit unit I_unit) -> Type) ->
+        (a : @I_Unit unit I_unit P (@unit I_unit)) -> @I_Unit unit I_unit P u
+      ) @=> (P : (x : @Unit I_Unit unit I_unit) -> Type) =>
+        (b : @I_Unit unit I_unit P (@unit I_unit)) => @I_unit P b
+    |}
+  in
+  let t_i_unit =
+    Format.sprintf
+      {|
+        I_unit @-> (P : (c : @Unit I_Unit unit I_unit) -> Type) ->
+          (d : @I_Unit unit I_unit P (@unit I_unit)) ->
+          @I_Unit unit I_unit P (%s)
+      |}
+      b_unit
+  in
+  let t_unit =
+    Format.sprintf {|
+      unit @-> (I_unit : %s) -> %s
+    |} t_i_unit b_Unit
+  in
+  let t_i_Unit =
+    Format.sprintf
+      {|
+        I_Unit @-> (unit : %s) -> (I_unit : %s) ->
+          (P : (e : @Unit I_Unit unit I_unit) -> Type) ->
+          (f : %s) -> Type
+      |}
+      t_unit t_i_unit b_Unit
+  in
+  (*
+  {|
+    (UnitT : Type) ===
+      Unit @-> (I_Unit : %s) -> (unit : %s) -> (I_unit : %s) -> Type;
+    (Unit : UnitT) === (Unit : UnitT) @=> 
+      (I_Unit : %s) => (unit : %s) => (I_unit : %s) => %s;
+    (UnitR : Type) === (I_Unit : %s) -> (unit : %s) -> (I_unit : %s) -> Type;
+    (UnitEq : (P : (x : UnitR) -> Type) -> (x : P @Unit) ->
+      P ((I_Unit : %s) => (unit : %s) => (I_unit : %s) => %s)
+    ) === (P : (x : UnitR) -> Type) => (x : P @Unit) => %%expand x;
+    (I_Unit : %s) === (I_Unit : %s) @=> (unit : %s) => (I_unit : %s) =>
+      (P : (f : @Unit I_Unit unit I_unit) -> Type) =>
+        UnitEq ((Unit : UnitR) => (f : Unit I_Unit unit I_unit) -> Type) P;
+    (unit : %s) === (unit : %s) @=> (I_unit : %s) => %s;
+    (I_unitT : Type) === %s;
+    (unitR : Type) === (I_unit : I_unitT) -> %s;
+    (unitEq : (P : (x : unitR) -> Type) -> (x : P @unit) ->
+      P ((I_unit : I_unitT) => %s)) ===
+      (P : (x : unitR) -> Type) => (x : P @unit) => %%expand P;
+    unitEq
+  |}
+  *)
+  let _code =
+    Format.sprintf
+      {|
+        (UnitT : Type) ===
+          Unit @-> (I_Unit : %s) -> (unit : %s) -> (I_unit : %s) -> Type;
+        (I_UnitT : (Unit : UnitT) -> Type) ===
+          (Unit : UnitT) => %s;
+        (unitT : (Unit : UnitT) -> (I_Unit : I_UnitT Unit) -> Type) ===
+          (Unit : UnitT) => (I_Unit : I_UnitT Unit) => %s;
+        (I_unitT : (Unit : UnitT) -> (I_Unit : I_UnitT Unit) ->
+          (unit : unitT Unit I_Unit) -> Type) ===
+          (Unit : UnitT) => (I_Unit : I_UnitT Unit) =>
+          (unit : unitT Unit I_Unit) => %s;
+        (Unit : UnitT) === (Unit : UnitT) @=> 
+          (I_Unit : I_UnitT Unit) => (unit : unitT Unit I_Unit) =>
+            (I_unit : I_unitT Unit I_Unit unit) => %s;
+        (I_UnitT : Type) === I_UnitT Unit;
+        (unitT : (I_Unit : I_UnitT) -> Type) === unitT Unit;
+        (I_unitT : (I_Unit : I_UnitT) ->
+          (unit : unitT I_Unit) -> Type) === I_unitT Unit;
+        (UnitR : Type) === (I_Unit : I_UnitT) -> (unit : unitT I_Unit) ->
+            (I_unit : I_unitT I_Unit unit) -> Type;
+        (UnitEq : (P : (x : UnitR) -> Type) -> (x : P @Unit) ->
+          P (
+          (I_Unit : I_UnitT) => (unit : unitT I_Unit) =>
+            (I_unit : I_unitT I_Unit unit) => %s)
+        ) === (P : (x : UnitR) -> Type) => (x : P @Unit) => %%expand x;
+        (I_Unit : I_UnitT) === (I_Unit : I_UnitT) @=>
+          (unit : unitT I_Unit) => (I_unit : I_unitT I_Unit unit) =>
+          (P : (f : @Unit I_Unit unit I_unit) -> Type) =>
+            UnitEq ((Unit : UnitR) => (f : Unit I_Unit unit I_unit) -> Type) P;
+        (unitT : Type) === unitT I_Unit;
+        (I_unitT : (unit : unitT) -> Type) === I_unitT I_Unit;
+        (unit : unitT) === (unit : unitT) @=>
+          (I_unit : I_unitT unit) => %s;
+        (I_unitT : Type) === I_unitT unit;
+        (unitR : Type) === (I_unit : I_unitT) -> %s;
+        (unitEq : (P : (x : unitR) -> Type) -> (x : P @unit) ->
+          P ((I_unit : I_unitT) => %s)) ===
+            (P : (x : unitR) -> Type) => (x : P @unit) => %%expand x;
+        (I_unit : I_unitT) === (I_unit : I_unitT) @=>
+          (P : (c : @Unit I_Unit unit I_unit) -> Type) =>
+          (d : @I_Unit unit I_unit P (@unit I_unit)) =>
+          unitEq ((at_unit : unitR) => @I_Unit unit I_unit P (at_unit I_unit))
+            d;
+        (UnitEq : (P : (_ : Type) -> Type) ->
+          (x : P (@Unit I_Unit unit I_unit)) -> P (%s)) ===
+          (P : (_ : Type) -> Type) =>
+          (x : P (@Unit I_Unit unit I_unit)) => %%expand x;
+        (RevUnitEq : (P : (_ : Type) -> Type) ->
+          (x : P (%s)) -> P (@Unit I_Unit unit I_unit)) ===
+          (P : (_ : Type) -> Type) =>
+          UnitEq ((T : Type) => (x : P T) -> P (@Unit I_Unit unit I_unit))
+            ((x : P (@Unit I_Unit unit I_unit)) => x);
+        
+        (unitK : @Unit I_Unit unit I_unit) === RevUnitEq ((X : Type) => X) (@unit I_unit);
+        @(%%expand unitK)
+      |}
+      t_i_Unit t_unit t_i_unit t_i_Unit t_unit t_i_unit b_Unit b_Unit b_unit
+      b_Unit b_unit b_Unit b_Unit
+  in
+  let code =
+    Format.sprintf
+      {|
+        (UnitT : Type) ===
+          Unit @-> (I_Unit : %s) -> (unit : %s) -> (I_unit : %s) -> Type;
+        (I_UnitT : (Unit : UnitT) -> Type) ===
+          (Unit : UnitT) => %s;
+        (unitT : (Unit : UnitT) -> (I_Unit : I_UnitT Unit) -> Type) ===
+          (Unit : UnitT) => (I_Unit : I_UnitT Unit) => %s;
+        (I_unitT : (Unit : UnitT) -> (I_Unit : I_UnitT Unit) ->
+          (unit : unitT Unit I_Unit) -> Type) ===
+          (Unit : UnitT) => (I_Unit : I_UnitT Unit) =>
+          (unit : unitT Unit I_Unit) => %s;
+        (Unit : UnitT) === (Unit : UnitT) @=> 
+          (I_Unit : I_UnitT Unit) => (unit : unitT Unit I_Unit) =>
+            (I_unit : I_unitT Unit I_Unit unit) => %s;
+        (I_UnitT : Type) === I_UnitT Unit;
+        (unitT : (I_Unit : I_UnitT) -> Type) === unitT Unit;
+        (I_unitT : (I_Unit : I_UnitT) ->
+          (unit : unitT I_Unit) -> Type) === I_unitT Unit;
+        (UnitR : Type) === (I_Unit : I_UnitT) -> (unit : unitT I_Unit) ->
+            (I_unit : I_unitT I_Unit unit) -> Type;
+        (UnitEq : (P : (x : UnitR) -> Type) -> (x : P @Unit) ->
+          P (
+          (I_Unit : I_UnitT) => (unit : unitT I_Unit) =>
+            (I_unit : I_unitT I_Unit unit) => %s)
+        ) === (P : (x : UnitR) -> Type) => (x : P @Unit) => %%expand x;
+        (I_Unit : I_UnitT) === (I_Unit : I_UnitT) @=>
+          (unit : unitT I_Unit) => (I_unit : I_unitT I_Unit unit) =>
+          (P : (f : @Unit I_Unit unit I_unit) -> Type) =>
+            UnitEq ((Unit : UnitR) => (f : Unit I_Unit unit I_unit) -> Type) P;
+        I_Unit
+      |}
+      t_i_Unit t_unit t_i_unit t_i_Unit t_unit t_i_unit b_Unit b_Unit
+  in
+  type_term "ind_Unit" code
 
 let tests =
   [
@@ -62,8 +228,8 @@ let tests =
     true_;
     (* true_propagate; *)
     false_;
-    falseT;
-    unitT;
+    ind_False;
+    ind_Unit;
   ]
 
 let type_term term =
@@ -83,7 +249,8 @@ let type_term term =
 
 let test { name; term } =
   let check () =
-    let _term = type_term term in
+    let _type_ = type_term term in
+    (* Format.eprintf "type_ : %a\n%!" Tprinter.pp_term type_; *)
     ()
   in
   Alcotest.test_case name `Quick check

--- a/smol/ttree.ml
+++ b/smol/ttree.ml
@@ -8,6 +8,7 @@ and term =
   | TT_self of { bound : pat; body : term }
   | TT_fix of { bound : ty_pat; body : term }
   | TT_unroll of { term : term }
+  | TT_expand of { term : term }
 
 and ty_pat = TP_typed of { pat : pat; type_ : term }
 and pat = TP_var of { var : Var.t }

--- a/smol/ttree.mli
+++ b/smol/ttree.mli
@@ -6,10 +6,9 @@ and term =
   | TT_lambda of { param : ty_pat; return : term }
   | TT_apply of { lambda : term; arg : term }
   | TT_self of { bound : pat; body : term }
-  (* TODO: this typed term on the body is probably not needed
-      but this project tries to play very safe *)
   | TT_fix of { bound : ty_pat; body : term }
   | TT_unroll of { term : term }
+  | TT_expand of { term : term }
 
 and ty_pat = TP_typed of { pat : pat; type_ : term }
 and pat = TP_var of { var : Var.t }

--- a/smol/ttyper.ml
+++ b/smol/ttyper.ml
@@ -72,6 +72,9 @@ module Machinery = struct
     | TT_unroll { term } ->
         let term = subst_term term in
         TT_unroll { term }
+    | TT_expand { term } ->
+        let term = subst_term term in
+        TT_expand { term }
 
   and subst_ty_pat ~from ~to_ pat : ty_pat =
     let subst_term term = subst_term ~from ~to_ term in
@@ -100,11 +103,10 @@ module Machinery = struct
         | _ -> TT_apply { lambda; arg })
     | TT_self _ as term -> term
     | TT_fix _ as term -> term
-    | TT_unroll { term } -> (
-        match expand_head term with
-        | TT_fix { bound; body } ->
-            expand_head @@ subst_term ~from:(ty_pat_var bound) ~to_:term body
-        | _ -> TT_unroll { term })
+    | TT_unroll _ as term -> term
+    | TT_expand { term } ->
+        (* TODO: is this safe? *)
+        expand_head term
 
   let rec equal_term ~received ~expected =
     let received = expand_head received in
@@ -150,9 +152,9 @@ module Machinery = struct
     | TT_unroll { term = received }, TT_unroll { term = expected } ->
         equal_term ~received ~expected
     | ( ( TT_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_self _
-        | TT_fix _ | TT_unroll _ ),
+        | TT_fix _ | TT_unroll _ | TT_expand _ ),
         ( TT_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_self _
-        | TT_fix _ | TT_unroll _ ) ) ->
+        | TT_fix _ | TT_unroll _ | TT_expand _ ) ) ->
         failwith "type clash"
 
   and equal_term_alpha_rename ~received_var ~expected_var ~received ~expected =
@@ -164,6 +166,27 @@ module Machinery = struct
     let expected = rename_term ~from:received_var ~to_:skolem_var expected in
     let expected = rename_term ~from:expected_var ~to_:skolem_var expected in
     equal_term ~received ~expected
+
+  let rec expand_unroll term =
+    (* TODO: this only expands shallow for convenience
+        a more principled solution is possible *)
+    (* TODO: why not expand_head? *)
+    match term with
+    | TT_var _ as term -> term
+    | TT_forall _ as term -> term
+    | TT_lambda _ as term -> term
+    | TT_apply { lambda; arg } ->
+        let lambda = expand_unroll lambda in
+        let arg = expand_unroll arg in
+        TT_apply { lambda; arg }
+    | TT_self _ as term -> term
+    | TT_fix _ as term -> term
+    | TT_unroll { term } -> (
+        match expand_head term with
+        | TT_fix { bound; body } as fix ->
+            subst_term ~from:(ty_pat_var bound) ~to_:fix body
+        | _ -> TT_unroll { term })
+    | TT_expand _ as term -> term
 end
 
 module Translate = struct
@@ -254,6 +277,9 @@ module Translate = struct
     | LT_unroll { term } ->
         let term = translate_term ctx term in
         TT_unroll { term }
+    | LT_expand { term } ->
+        let term = translate_term ctx term in
+        TT_expand { term }
     | LT_alias { bound; value; return } ->
         (* TODO: use annotation in bound  *)
         let bound = translate_ty_pat ctx bound in
@@ -317,6 +343,16 @@ let enter_self ~bound ~body ctx =
   let assumption = TT_self { bound; body } in
   Context.enter ~var assumption ctx
 
+let enter_alias ~bound ctx =
+  let (TP_typed { pat; type_ }) = bound in
+  let var = pat_var pat in
+  Context.enter ~var type_ ctx
+
+let split_self term =
+  match expand_head @@ term with
+  | TT_self { bound; body } -> (bound, body)
+  | _ -> failwith "not a self"
+
 let rec infer_term ctx term =
   match term with
   | TT_var { var } -> (
@@ -341,7 +377,7 @@ let rec infer_term ctx term =
       in
       TT_forall { param; return }
   | TT_apply { lambda; arg } -> (
-      match infer_term ctx lambda with
+      match expand_head @@ infer_term ctx lambda with
       | TT_forall { param; return } ->
           let () =
             let expected = typeof_pat param in
@@ -366,11 +402,10 @@ let rec infer_term ctx term =
       let received = TT_self { bound = pat; body } in
       let () = equal_term ~received ~expected in
       expected
-  | TT_unroll { term } -> (
-      match infer_term ctx term with
-      | TT_self { bound; body } ->
-          subst_term ~from:(pat_var bound) ~to_:term body
-      | _ -> failwith "not a self")
+  | TT_unroll { term } ->
+      let bound, body = split_self @@ infer_term ctx term in
+      subst_term ~from:(pat_var bound) ~to_:term body
+  | TT_expand { term } -> expand_unroll @@ infer_term ctx term
 
 and check_term ctx term ~expected =
   let received = infer_term ctx term in


### PR DESCRIPTION
## Goals

Fully support inductive types through self types.

## Context

Currently encoding inductive types is not possible due to uncontrolled fixpoint elimination and lack of substitution while checking the fixpoint.

This PR aims to solve that and provides some test examples, unfortunately, the implementation is not fast enough to type the full version, but I will be working on compressing it.

This is very likely the last change to fixpoint / self as it was tested and it is an elegant solution.

## Related

- #106