### PR TITLE
teika: drop pattern language

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -13,10 +13,6 @@ type error =
       received : ex_term; [@printer Tprinter.pp_ex_term]
       received_norm : core term; [@printer Tprinter.pp_term]
     }
-  | CError_unify_pat_clash of {
-      expected : ex_pat; [@printer Tprinter.pp_ex_pat]
-      received : ex_pat; [@printer Tprinter.pp_ex_pat]
-    }
   (* typer *)
   | CError_typer_unknown_var of { name : Name.t }
   | Cerror_typer_not_a_forall of {
@@ -75,11 +71,6 @@ module Unify_context = struct
     fail
     @@ CError_unify_type_clash
          { expected; expected_norm; received; received_norm }
-
-  let[@inline always] error_pat_clash ~expected ~received =
-    let expected = Ex_pat expected in
-    let received = Ex_pat received in
-    fail @@ CError_unify_pat_clash { expected; received }
 end
 
 module Typer_context = struct

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -12,7 +12,6 @@ type error = private
       received : ex_term;
       received_norm : core term;
     }
-  | CError_unify_pat_clash of { expected : ex_pat; received : ex_pat }
   (* typer *)
   | CError_typer_unknown_var of { name : Name.t }
   | Cerror_typer_not_a_forall of { type_ : ex_term }
@@ -55,8 +54,6 @@ module Unify_context : sig
     received:_ term ->
     received_norm:core term ->
     'a unify_context
-
-  val error_pat_clash : expected:_ pat -> received:_ pat -> 'a unify_context
 end
 
 module Typer_context : sig

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -10,28 +10,21 @@ let rec expand_head_term : type a. a term -> core term =
   | TT_forall _ as term -> term
   | TT_lambda _ as term -> term
   | TT_apply { lambda; arg } -> (
-      let lambda = expand_head_term lambda in
-      match lambda with
-      | TT_lambda { param; return } -> elim_apply ~pat:param ~return ~arg
-      | _lambda -> TT_apply { lambda; arg })
-  | TT_let { pat; value; return } -> elim_apply ~pat ~return ~arg:value
-  | TT_annot { term; annot = _ } -> expand_head_term term
-
-and expand_head_pat : type a. a pat -> _ =
- fun pat ->
-  match pat with
-  | TP_loc { pat; loc = _ } -> expand_head_pat pat
-  | TP_typed { pat; annot = _ } -> expand_head_pat pat
-  | TP_var { var = _ } as pat -> pat
-  | TP_annot { pat; annot = _ } -> expand_head_pat pat
-
-(* TODO: weird *)
-and elim_apply : type p r a. pat:p pat -> return:r term -> arg:a term -> _ =
- fun ~pat ~return ~arg ->
-  match (expand_head_pat pat, arg) with
-  | TP_var { var = _name }, arg ->
+      match expand_head_term lambda with
+      | TT_lambda { var = _name; param = _; return } ->
+          (* TODO: param is not used here,
+              but it would be cool to check when in debug *)
+          let (Ex_term return) =
+            Subst.subst_bound ~from:Index.zero ~to_:arg return
+          in
+          expand_head_term return
+      | _lambda ->
+          (* TODO: use expanded? *)
+          TT_apply { lambda; arg })
+  | TT_let { var = _name; value; return } ->
       (* TODO: this could be done in O(1) with context extending *)
       let (Ex_term return) =
-        Subst.subst_bound ~from:Index.zero ~to_:arg return
+        Subst.subst_bound ~from:Index.zero ~to_:value return
       in
       expand_head_term return
+  | TT_annot { term; annot = _ } -> expand_head_term term

--- a/teika/expand_head.mli
+++ b/teika/expand_head.mli
@@ -1,4 +1,3 @@
 open Ttree
 
 val expand_head_term : _ term -> core term
-val expand_head_pat : _ pat -> core pat

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -3,7 +3,6 @@ open Ttree
 let rec subst_bound_term : type a. from:_ -> to_:_ -> a term -> ex_term =
  fun ~from ~to_ term ->
   let subst_bound_term ~from term = subst_bound_term ~from ~to_ term in
-  let subst_bound_pat ~from pat f = subst_bound_pat ~from ~to_ pat f in
 
   match term with
   | TT_loc { term; loc } ->
@@ -18,44 +17,28 @@ let rec subst_bound_term : type a. from:_ -> to_:_ -> a term -> ex_term =
       | true -> Ex_term to_
       | false -> Ex_term (TT_bound_var { index }))
   | TT_free_var { level } -> Ex_term (TT_free_var { level })
-  | TT_forall { param; return } ->
-      subst_bound_pat ~from param @@ fun ~from param ->
+  | TT_forall { var; param; return } ->
+      let from = Index.(from + one) in
+      let (Ex_term param) = subst_bound_term ~from param in
       let (Ex_term return) = subst_bound_term ~from return in
-      Ex_term (TT_forall { param; return })
-  | TT_lambda { param; return } ->
-      subst_bound_pat ~from param @@ fun ~from param ->
+      Ex_term (TT_forall { var; param; return })
+  | TT_lambda { var; param; return } ->
+      let from = Index.(from + one) in
+      let (Ex_term param) = subst_bound_term ~from param in
       let (Ex_term return) = subst_bound_term ~from return in
-      Ex_term (TT_lambda { param; return })
+      Ex_term (TT_lambda { var; param; return })
   | TT_apply { lambda; arg } ->
       let (Ex_term lambda) = subst_bound_term ~from lambda in
       let (Ex_term arg) = subst_bound_term ~from arg in
       Ex_term (TT_apply { lambda; arg })
-  | TT_let { pat; value; return } ->
+  | TT_let { var; value; return } ->
       let (Ex_term value) = subst_bound_term ~from value in
-      subst_bound_pat ~from pat @@ fun ~from pat ->
+      let from = Index.(from + one) in
       let (Ex_term return) = subst_bound_term ~from return in
-      Ex_term (TT_let { pat; value; return })
+      Ex_term (TT_let { var; value; return })
   | TT_annot { term; annot } ->
       let (Ex_term annot) = subst_bound_term ~from annot in
       let (Ex_term term) = subst_bound_term ~from term in
       Ex_term (TT_annot { term; annot })
-
-and subst_bound_pat :
-    type a k. from:_ -> to_:_ -> a pat -> (from:_ -> a pat -> k) -> k =
- fun ~from ~to_ pat f ->
-  let subst_bound_term ~from term = subst_bound_term ~from ~to_ term in
-  let subst_bound_pat pat f = subst_bound_pat ~from ~to_ pat f in
-  match pat with
-  | TP_loc { pat; loc } ->
-      subst_bound_pat pat @@ fun ~from pat -> f ~from (TP_loc { pat; loc })
-  | TP_typed { pat; annot } ->
-      let (Ex_term annot) = subst_bound_term ~from annot in
-      subst_bound_pat pat @@ fun ~from pat -> f ~from (TP_typed { pat; annot })
-  | TP_var { var } ->
-      let from = Index.(from + one) in
-      f ~from (TP_var { var })
-  | TP_annot { pat; annot } ->
-      let (Ex_term annot) = subst_bound_term ~from annot in
-      subst_bound_pat pat @@ fun ~from pat -> f ~from (TP_annot { pat; annot })
 
 let subst_bound = subst_bound_term

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,6 +1,4 @@
 open Ttree
 
 val pp_term : Format.formatter -> _ term -> unit
-val pp_pat : Format.formatter -> _ pat -> unit
 val pp_ex_term : Format.formatter -> ex_term -> unit
-val pp_ex_pat : Format.formatter -> ex_pat -> unit

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -18,17 +18,10 @@ type _ term =
   | TT_typed : { term : _ term; annot : _ term } -> typed term
   | TT_bound_var : { index : Index.t } -> core term
   | TT_free_var : { level : Level.t } -> core term
-  | TT_forall : { param : typed pat; return : _ term } -> core term
-  | TT_lambda : { param : typed pat; return : _ term } -> core term
+  | TT_forall : { var : Name.t; param : _ term; return : _ term } -> core term
+  | TT_lambda : { var : Name.t; param : _ term; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
-  | TT_let : { pat : typed pat; value : _ term; return : _ term } -> sugar term
+  | TT_let : { var : Name.t; value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
-and _ pat =
-  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
-  | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
-  | TP_var : { var : Name.t } -> core pat
-  | TP_annot : { pat : _ pat; annot : _ term } -> sugar pat
-
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
-type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -11,23 +11,14 @@ type _ term =
   (* x/+n *)
   | TT_free_var : { level : Level.t } -> core term
   (* (x : A) -> B *)
-  | TT_forall : { param : typed pat; return : _ term } -> core term
+  | TT_forall : { var : Name.t; param : _ term; return : _ term } -> core term
   (* (x : A) => e *)
-  | TT_lambda : { param : typed pat; return : _ term } -> core term
+  | TT_lambda : { var : Name.t; param : _ term; return : _ term } -> core term
   (* l a *)
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
-  (* (x : A) = t; u *)
-  | TT_let : { pat : typed pat; value : _ term; return : _ term } -> sugar term
+  (* x = t; u *)
+  | TT_let : { var : Name.t; value : _ term; return : _ term } -> sugar term
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
-and _ pat =
-  | TP_loc : { pat : _ pat; loc : Location.t } -> loc pat
-  | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
-  (* x *)
-  | TP_var : { var : Name.t } -> core pat
-  (* (p : T) *)
-  | TP_annot : { pat : _ pat; annot : _ term } -> sugar pat
-
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
-type ex_pat = Ex_pat : _ pat -> ex_pat [@@ocaml.unboxed]

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -9,7 +9,8 @@ let unify_term ~expected ~received =
 
 let split_forall (type a) (type_ : a term) =
   match expand_head_term type_ with
-  | TT_forall { param; return } -> Typer_context.return (param, Ex_term return)
+  | TT_forall { var = _; param; return } ->
+      Typer_context.return (Ex_term param, Ex_term return)
   | TT_bound_var _ | TT_free_var _ | TT_lambda _ | TT_apply _ ->
       error_not_a_forall ~type_
 
@@ -17,12 +18,7 @@ let typeof_term term =
   let (TT_typed { term = _; annot }) = term in
   Ex_term annot
 
-let typeof_pat pat =
-  let (TP_typed { pat = _; annot }) = pat in
-  Ex_term annot
-
 let tt_typed ~annot term = TT_typed { term; annot }
-let tp_typed ~annot pat = TP_typed { pat; annot }
 
 let with_tt_loc ~loc f =
   with_loc ~loc @@ fun () ->
@@ -30,38 +26,29 @@ let with_tt_loc ~loc f =
   let term = TT_loc { term; loc } in
   tt_typed ~annot term
 
-let with_tp_loc ~loc k =
-  with_loc ~loc @@ fun () ->
-  k @@ fun (TP_typed { pat; annot }) k ->
-  let pat = TP_loc { pat; loc } in
-  k @@ tp_typed ~annot pat
-
 let rec infer_term term =
   match term with
   | LT_var { var = name } ->
       let+ level, Ex_term annot = lookup_var ~name in
       tt_typed ~annot @@ TT_free_var { level }
   | LT_forall { param; return } ->
-      infer_pat param @@ fun param ->
+      infer_pat param @@ fun var (Ex_term param) ->
       let+ return = check_term return ~expected:tt_type in
       (* *)
-      tt_typed ~annot:tt_type @@ TT_forall { param; return }
+      tt_typed ~annot:tt_type @@ TT_forall { var; param; return }
   | LT_lambda { param; return } ->
-      infer_pat param @@ fun param ->
+      infer_pat param @@ fun var (Ex_term param) ->
       let+ return = infer_term return in
       let annot =
         let (Ex_term return) = typeof_term return in
-        TT_forall { param; return }
+        TT_forall { var; param; return }
       in
-      tt_typed ~annot @@ TT_lambda { param; return }
+      tt_typed ~annot @@ TT_lambda { var; param; return }
   | LT_apply { lambda; arg } ->
       let* lambda = infer_term lambda in
       let (Ex_term forall) = typeof_term lambda in
-      let* param, Ex_term return = split_forall forall in
-      let+ arg =
-        let (Ex_term param) = typeof_pat param in
-        check_term arg ~expected:param
-      in
+      let* Ex_term param, Ex_term return = split_forall forall in
+      let+ arg = check_term arg ~expected:param in
       let (Ex_term annot) =
         (* TODO: this technically works here, but bad *)
         Subst.subst_bound ~from:Index.zero ~to_:arg return
@@ -73,17 +60,18 @@ let rec infer_term term =
       (* TODO: use this loc *)
       let (LBind { loc = _; pat; value }) = bound in
       let* value = infer_term value in
-      let+ pat, return =
+      let+ var, return =
         let (Ex_term value_type) = typeof_term value in
-        check_pat pat ~expected:value_type @@ fun pat ->
+        check_pat pat ~expected:value_type @@ fun var _annot ->
+        (* TODO: this annotation here is not used *)
         let+ return = infer_term return in
-        (pat, return)
+        (var, return)
       in
       let annot =
         let (Ex_term return) = typeof_term return in
-        TT_let { pat; value; return }
+        TT_let { var; value; return }
       in
-      tt_typed ~annot @@ TT_let { pat; value; return }
+      tt_typed ~annot @@ TT_let { var; value; return }
   | LT_annot { term; annot } ->
       let* annot = check_term annot ~expected:tt_type in
       let+ term = check_term term ~expected:annot in
@@ -97,12 +85,11 @@ and check_term : type a. _ -> expected:a term -> _ =
   | LT_loc { term; loc }, expected ->
       with_tt_loc ~loc @@ fun () -> check_term term ~expected
   | ( LT_lambda { param; return },
-      TT_forall { param = expected_param; return = expected_return } ) ->
-      (* TODO: alpha renaming is bad here *)
-      let (Ex_term expected_param_type) = typeof_pat expected_param in
-      check_pat param ~expected:expected_param_type @@ fun param ->
+      TT_forall { var = _; param = expected_param; return = expected_return } )
+    ->
+      check_pat param ~expected:expected_param @@ fun var (Ex_term param) ->
       let+ return = check_term return ~expected:expected_return in
-      tt_typed ~annot:expected @@ TT_lambda { param; return }
+      tt_typed ~annot:expected @@ TT_lambda { var; param; return }
   | ( ( LT_var _ | LT_forall _ | LT_lambda _ | LT_apply _ | LT_exists _
       | LT_pair _ | LT_let _ | LT_annot _ ),
       expected ) ->
@@ -113,19 +100,18 @@ and check_term : type a. _ -> expected:a term -> _ =
       in
       term
 
-and infer_pat : type a. _ -> (_ -> a typer_context) -> a typer_context =
+and infer_pat : type a. _ -> (_ -> _ -> a typer_context) -> a typer_context =
  fun pat f ->
   match pat with
   | LP_annot { pat; annot } ->
       let* annot = check_term annot ~expected:tt_type in
       check_pat pat ~expected:annot f
-  | LP_loc { pat; loc } ->
-      with_tp_loc ~loc @@ fun k ->
-      infer_pat pat @@ fun pat -> k pat f
+  | LP_loc { pat; loc } -> with_loc ~loc @@ fun () -> infer_pat pat f
   | LP_var _ | LP_pair _ -> error_pat_not_annotated ~pat
 
 and check_pat :
-    type a k. _ -> expected:k term -> (_ -> a typer_context) -> a typer_context
+    type a k.
+    _ -> expected:k term -> (Name.t -> _ -> a typer_context) -> a typer_context
     =
  fun pat ~expected f ->
   (* TODO: expected should be a pattern, to achieve strictness *)
@@ -134,12 +120,11 @@ and check_pat :
       (* TODO: add different names for left and right *)
       with_expected_var @@ fun () ->
       with_received_var ~name ~type_:expected @@ fun () ->
-      f @@ tp_typed ~annot:expected @@ TP_var { var = name }
+      f name (Ex_term expected)
   | LP_pair _, _ -> error_pairs_not_implemented ()
   | LP_annot { pat; annot }, _expected_desc ->
       let* annot = check_term annot ~expected:tt_type in
       let* () = unify_term ~expected ~received:annot in
       check_pat pat ~expected:annot f
   | LP_loc { pat; loc }, _expected_desc ->
-      with_tp_loc ~loc @@ fun k ->
-      check_pat pat ~expected @@ fun pat -> k pat f
+      with_loc ~loc @@ fun () -> check_pat pat ~expected f

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -36,15 +36,17 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       | true -> return ()
       | false -> error_free_var_clash ~expected ~received)
   (* TODO: track whenever it is unified and locations, visualizing inference *)
-  | ( TT_forall { param = expected_param; return = expected_return },
-      TT_forall { param = received_param; return = received_return } ) ->
+  | ( TT_forall { var = _; param = expected_param; return = expected_return },
+      TT_forall { var = _; param = received_param; return = received_return } )
+    ->
       (* TODO: contravariance *)
-      let* () = unify_param ~expected:expected_param ~received:received_param in
+      let* () = unify_term ~expected:expected_param ~received:received_param in
       unify_term ~expected:expected_return ~received:received_return
-  | ( TT_lambda { param = expected_param; return = expected_return },
-      TT_lambda { param = received_param; return = received_return } ) ->
+  | ( TT_lambda { var = _; param = expected_param; return = expected_return },
+      TT_lambda { var = _; param = received_param; return = received_return } )
+    ->
       (* TODO: contravariance *)
-      let* () = unify_param ~expected:expected_param ~received:received_param in
+      let* () = unify_term ~expected:expected_param ~received:received_param in
       unify_term ~expected:expected_return ~received:received_return
   | ( TT_apply { lambda = expected_lambda; arg = expected_arg },
       TT_apply { lambda = received_lambda; arg = received_arg } ) ->
@@ -57,26 +59,3 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       ((TT_bound_var _ | TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _)
       as received_norm) ) ->
       error_type_clash ~expected ~expected_norm ~received ~received_norm
-
-and unify_param ~expected ~received =
-  let (TP_typed { pat = expected_pat; annot = expected_annot }) = expected in
-  let (TP_typed { pat = received_pat; annot = received_annot }) = received in
-  let* () = unify_term ~expected:expected_annot ~received:received_annot in
-  unify_pat ~expected:expected_pat ~received:received_pat
-
-and unify_pat : type e r. expected:e pat -> received:r pat -> _ =
- fun ~expected ~received ->
-  match (expected, received) with
-  | TP_loc { pat = expected; loc = _ }, received ->
-      unify_pat ~expected ~received
-  | expected, TP_loc { pat = received; loc = _ } ->
-      unify_pat ~expected ~received
-  | TP_typed { pat = expected; annot = _ }, received ->
-      unify_pat ~expected ~received
-  | expected, TP_typed { pat = received; annot = _ } ->
-      unify_pat ~expected ~received
-  | TP_var { var = _ }, TP_var { var = _ } -> return ()
-  | TP_annot { pat = expected; annot = _ }, received ->
-      unify_pat ~expected ~received
-  | expected, TP_annot { pat = received; annot = _ } ->
-      unify_pat ~expected ~received


### PR DESCRIPTION
## Goals

Make development of core language faster.

## Context

Currently Teika pattern language is limited to only simple variables but just by having a pattern language it makes the development of the typer quite harder as now code needs to account for patterns.

I believe this will get better in the future, but I don't want to work on a pattern language right now.