### PR TITLE
teika: initial representation for holes

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -12,6 +12,9 @@ type error = private
       received : ex_term;
       received_norm : core term;
     }
+  (* TODO: lazy names for errors *)
+  | CError_unify_var_occurs of { hole : hole; in_ : hole }
+  | CError_unify_var_escape of { hole : hole; var : Level.t }
   (* typer *)
   | CError_typer_unknown_var of { name : Name.t }
   | Cerror_typer_not_a_forall of { type_ : ex_term }
@@ -54,6 +57,9 @@ module Unify_context : sig
     received:_ term ->
     received_norm:core term ->
     'a unify_context
+
+  val error_var_occurs : hole:hole -> in_:hole -> 'a unify_context
+  val error_var_escape : hole:hole -> var:Level.t -> 'a unify_context
 end
 
 module Typer_context : sig
@@ -101,7 +107,4 @@ module Typer_context : sig
   (* locs *)
   val with_loc :
     loc:Location.t -> (unit -> 'a typer_context) -> 'a typer_context
-
-  (* ttree *)
-  val tt_type : core term
 end

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -7,6 +7,9 @@ let rec expand_head_term : type a. a term -> core term =
   | TT_typed { term; annot = _ } -> expand_head_term term
   | TT_bound_var _ as term -> term
   | TT_free_var _ as term -> term
+  | TT_hole { level = _; link } as term -> (
+      (* TODO: move this to machinery *)
+      match link == tt_nil with true -> term | false -> expand_head_term link)
   | TT_forall _ as term -> term
   | TT_lambda _ as term -> term
   | TT_apply { lambda; arg } -> (

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -1,5 +1,6 @@
 open Ttree
 
+(* TODO: preserve physical identity more often *)
 let rec subst_bound_term : type a. from:_ -> to_:_ -> a term -> ex_term =
  fun ~from ~to_ term ->
   let subst_bound_term ~from term = subst_bound_term ~from ~to_ term in
@@ -17,6 +18,11 @@ let rec subst_bound_term : type a. from:_ -> to_:_ -> a term -> ex_term =
       | true -> Ex_term to_
       | false -> Ex_term (TT_bound_var { index }))
   | TT_free_var { level } -> Ex_term (TT_free_var { level })
+  | TT_hole hole -> (
+      (* TODO: this should be in machinery *)
+      match hole.link == tt_nil with
+      | true -> Ex_term (TT_hole hole)
+      | false -> subst_bound_term ~from hole.link)
   | TT_forall { var; param; return } ->
       let from = Index.(from + one) in
       let (Ex_term param) = subst_bound_term ~from param in

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,4 +1,5 @@
 open Ttree
 
 val pp_term : Format.formatter -> _ term -> unit
+val pp_hole : Format.formatter -> hole -> unit
 val pp_ex_term : Format.formatter -> ex_term -> unit

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -18,10 +18,18 @@ type _ term =
   | TT_typed : { term : _ term; annot : _ term } -> typed term
   | TT_bound_var : { index : Index.t } -> core term
   | TT_free_var : { level : Level.t } -> core term
+  | TT_hole : hole -> core term
   | TT_forall : { var : Name.t; param : _ term; return : _ term } -> core term
   | TT_lambda : { var : Name.t; param : _ term; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
   | TT_let : { var : Name.t; value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
+and hole = { mutable level : Level.t; mutable link : core term }
+
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+
+let nil_level = Level.zero
+let type_level = Level.next nil_level
+let tt_nil = TT_free_var { level = nil_level }
+let tt_type = TT_free_var { level = type_level }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -10,6 +10,8 @@ type _ term =
   | TT_bound_var : { index : Index.t } -> core term
   (* x/+n *)
   | TT_free_var : { level : Level.t } -> core term
+  (* _x/+n *)
+  | TT_hole : hole -> core term
   (* (x : A) -> B *)
   | TT_forall : { var : Name.t; param : _ term; return : _ term } -> core term
   (* (x : A) => e *)
@@ -21,4 +23,11 @@ type _ term =
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
+and hole = { mutable level : Level.t; mutable link : core term }
+
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+
+val nil_level : Level.t
+val type_level : Level.t
+val tt_nil : core term
+val tt_type : core term

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -11,7 +11,8 @@ let split_forall (type a) (type_ : a term) =
   match expand_head_term type_ with
   | TT_forall { var = _; param; return } ->
       Typer_context.return (Ex_term param, Ex_term return)
-  | TT_bound_var _ | TT_free_var _ | TT_lambda _ | TT_apply _ ->
+      (* TODO: hole should behave differently here *)
+  | TT_bound_var _ | TT_free_var _ | TT_hole _ | TT_lambda _ | TT_apply _ ->
       error_not_a_forall ~type_
 
 let typeof_term term =

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -24,8 +24,39 @@ open Expand_head
 
 (* TODO: diff is a bad name *)
 
+let rec occurs_term : type a. _ -> in_:a term -> _ =
+ fun hole ~in_ ->
+  (* TODO: this is needed because of non injective functions
+       the unification could succeed only if expand_head happened
+
+     maybe should fail anyway ?
+  *)
+  let occurs_term ~in_ = occurs_term hole ~in_ in
+  match expand_head_term in_ with
+  | TT_bound_var { index = _ } -> return ()
+  | TT_free_var { level } -> (
+      match level > hole.level with
+      | true -> return ()
+      | false -> error_var_escape ~hole ~var:level)
+  | TT_hole in_ -> (
+      match hole == in_ with
+      | true -> error_var_occurs ~hole ~in_
+      | false ->
+          in_.level <- min hole.level in_.level;
+          return ())
+  | TT_forall { var = _; param; return } ->
+      let* () = occurs_term ~in_:param in
+      occurs_term ~in_:return
+  | TT_lambda { var = _; param; return } ->
+      let* () = occurs_term ~in_:param in
+      occurs_term ~in_:return
+  | TT_apply { lambda; arg } ->
+      let* () = occurs_term ~in_:lambda in
+      occurs_term ~in_:arg
+
 let rec unify_term : type e r. expected:e term -> received:r term -> _ =
  fun ~expected ~received ->
+  (* TODO: short circuit physical equality *)
   match (expand_head_term expected, expand_head_term received) with
   | TT_bound_var { index = expected }, TT_bound_var { index = received } -> (
       match Index.equal expected received with
@@ -35,6 +66,10 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       match Level.equal expected received with
       | true -> return ()
       | false -> error_free_var_clash ~expected ~received)
+  | TT_hole hole, to_ | to_, TT_hole hole ->
+      (* TODO: prefer a direction when both are holes? *)
+      (* TODO: maybe unify against non expanded? *)
+      unify_hole hole ~to_
   (* TODO: track whenever it is unified and locations, visualizing inference *)
   | ( TT_forall { var = _; param = expected_param; return = expected_return },
       TT_forall { var = _; param = received_param; return = received_return } )
@@ -59,3 +94,12 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       ((TT_bound_var _ | TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _)
       as received_norm) ) ->
       error_type_clash ~expected ~expected_norm ~received ~received_norm
+
+and unify_hole hole ~to_ =
+  match to_ with
+  (* TODO: similar checking exists in occurs *)
+  | TT_hole to_ when hole == to_ -> return ()
+  | to_ ->
+      let* () = occurs_term hole ~in_:to_ in
+      hole.link <- to_;
+      return ()


### PR DESCRIPTION
## Goals

Prepare the typer machinery for inference.

## Context

Holes also known as meta / weak / existential variables, are a way of doing type inference through unification, essentially whenever a hole is unified against another type, it becomes that type. This is the core of the Hindley-Milner inference as seen in the ML family.

Holes also fit super well in a bidirectional model as now both check and infer can be fused together, as every term is also a check, this will be implemented in a future PR.