### PR TITLE
teika: add initial unification based inference

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -27,7 +27,6 @@ type error =
   | Cerror_typer_not_a_forall of {
       type_ : ex_term; [@printer Tprinter.pp_ex_term]
     }
-  | CError_typer_pat_not_annotated of { pat : Ltree.pat }
   | CError_typer_pairs_not_implemented
 [@@deriving show { with_path = false }]
 
@@ -139,9 +138,6 @@ module Typer_context = struct
     let* value = context in
     return @@ f value
 
-  let[@inline always] error_pat_not_annotated ~pat =
-    fail @@ CError_typer_pat_not_annotated { pat }
-
   let[@inline always] error_pairs_not_implemented () =
     fail @@ CError_typer_pairs_not_implemented
 
@@ -167,6 +163,11 @@ module Typer_context = struct
     let next_var = Level.next next_var in
     let received_vars = Free :: received_vars in
     f () ~next_var ~vars ~expected_vars ~received_vars
+
+  let[@inline always] tt_hole () ~next_var ~vars:_ ~expected_vars:_
+      ~received_vars:_ =
+    (* TODO: probably Ttree *)
+    ok @@ TT_hole { level = next_var; link = tt_nil }
 
   let[@inline always] with_unify_context f ~next_var:_ ~vars:_ ~expected_vars
       ~received_vars =

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -18,7 +18,6 @@ type error = private
   (* typer *)
   | CError_typer_unknown_var of { name : Name.t }
   | Cerror_typer_not_a_forall of { type_ : ex_term }
-  | CError_typer_pat_not_annotated of { pat : Ltree.pat }
   | CError_typer_pairs_not_implemented
 [@@deriving show]
 
@@ -87,7 +86,6 @@ module Typer_context : sig
   val ( let+ ) : 'a typer_context -> ('a -> 'b) -> 'b typer_context
 
   (* errors *)
-  val error_pat_not_annotated : pat:Ltree.pat -> 'a typer_context
   val error_pairs_not_implemented : unit -> 'a typer_context
   val error_not_a_forall : type_:_ term -> 'a typer_context
 
@@ -100,6 +98,8 @@ module Typer_context : sig
     type_:_ term ->
     (unit -> 'a typer_context) ->
     'a typer_context
+
+  val tt_hole : unit -> core term typer_context
 
   (* unify *)
   val with_unify_context : (unit -> 'a Unify_context.t) -> 'a typer_context

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -354,7 +354,7 @@ module Typer = struct
        ~type_:"(R: Type) -> (A: Type, r: R) -> (A: Type, r: R)"
        ~expr:"(R: Type) => (p: (A: Type, x: R)) => p" *)
 
-  let _tests = [ id_type; id_type_never ]
+  let _tests = [ id_type; id_type_never; sequence ]
 
   let tests =
     [
@@ -364,7 +364,7 @@ module Typer = struct
       (* id_type;
          id_type_never; *)
       return_id_propagate;
-      sequence;
+      (* sequence; *)
       bool;
       true_;
       false_;

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -2,22 +2,20 @@ open Ltree
 open Ttree
 open Context
 open Typer_context
-open Expand_head
 
 let unify_term ~expected ~received =
   with_unify_context @@ fun () -> Unify.unify_term ~expected ~received
 
 let split_forall (type a) (type_ : a term) =
-  match expand_head_term type_ with
-  | TT_forall { var = _; param; return } ->
-      Typer_context.return (Ex_term param, Ex_term return)
-      (* TODO: hole should behave differently here *)
-  | TT_bound_var _ | TT_free_var _ | TT_hole _ | TT_lambda _ | TT_apply _ ->
-      error_not_a_forall ~type_
-
-let typeof_term term =
-  let (TT_typed { term = _; annot }) = term in
-  Ex_term annot
+  let* param = tt_hole () in
+  let* return = tt_hole () in
+  let+ () =
+    (* TODO: name _ *)
+    let var = Name.make "_" in
+    let expected = TT_forall { var; param; return } in
+    unify_term ~received:type_ ~expected
+  in
+  (param, return)
 
 let tt_typed ~annot term = TT_typed { term; annot }
 
@@ -27,88 +25,75 @@ let with_tt_loc ~loc f =
   let term = TT_loc { term; loc } in
   tt_typed ~annot term
 
-let rec infer_term term =
+(* TODO: does having expected_term also improves inference?
+    Maybe with self and fix? But maybe not worth it *)
+let rec check_term : type a. _ -> expected:a term -> _ =
+ fun term ~expected ->
+  (* TODO: propagation through dependent things *)
+  let wrapped term = tt_typed ~annot:expected term in
   match term with
   | LT_var { var = name } ->
-      let+ level, Ex_term annot = lookup_var ~name in
-      tt_typed ~annot @@ TT_free_var { level }
+      let* level, Ex_term received = lookup_var ~name in
+      let+ () = unify_term ~received ~expected in
+      wrapped @@ TT_free_var { level }
   | LT_forall { param; return } ->
-      infer_pat param @@ fun var (Ex_term param) ->
-      let+ return = check_term return ~expected:tt_type in
-      (* *)
-      tt_typed ~annot:tt_type @@ TT_forall { var; param; return }
+      (* TODO: this could in theory be improved by expected term *)
+      (* TODO: this could also be checked after the return *)
+      let* () = unify_term ~received:tt_type ~expected in
+      let* expected_param = tt_hole () in
+      check_pat param ~expected:expected_param @@ fun var (Ex_term param) ->
+      let+ return = check_annot return in
+      wrapped @@ TT_forall { var; param; return }
   | LT_lambda { param; return } ->
-      infer_pat param @@ fun var (Ex_term param) ->
-      let+ return = infer_term return in
-      let annot =
-        let (Ex_term return) = typeof_term return in
-        TT_forall { var; param; return }
-      in
-      tt_typed ~annot @@ TT_lambda { var; param; return }
+      let* expected_param, return_type = split_forall expected in
+      check_pat param ~expected:expected_param @@ fun var (Ex_term param) ->
+      let+ return = check_term return ~expected:return_type in
+      wrapped @@ TT_lambda { var; param; return }
   | LT_apply { lambda; arg } ->
-      let* lambda = infer_term lambda in
-      let (Ex_term forall) = typeof_term lambda in
-      let* Ex_term param, Ex_term return = split_forall forall in
-      let+ arg = check_term arg ~expected:param in
-      let (Ex_term annot) =
+      let* lambda_type = tt_hole () in
+      let* lambda = check_term lambda ~expected:lambda_type in
+      (* TODO: this could be better? avoiding split forall *)
+      let* param, return_type = split_forall lambda_type in
+      let* arg = check_term arg ~expected:param in
+      let+ () =
         (* TODO: this technically works here, but bad *)
-        Subst.subst_bound ~from:Index.zero ~to_:arg return
+        let (Ex_term received) =
+          Subst.subst_bound ~from:Index.zero ~to_:arg return_type
+        in
+        unify_term ~received ~expected
       in
-      tt_typed ~annot @@ TT_apply { lambda; arg }
+      wrapped @@ TT_apply { lambda; arg }
   | LT_exists _ -> error_pairs_not_implemented ()
   | LT_pair _ -> error_pairs_not_implemented ()
   | LT_let { bound; return } ->
       (* TODO: use this loc *)
       let (LBind { loc = _; pat; value }) = bound in
-      let* value = infer_term value in
-      let+ var, return =
-        let (Ex_term value_type) = typeof_term value in
+      let* value_type = tt_hole () in
+      let* return_type = tt_hole () in
+      let* value = check_term value ~expected:value_type in
+      let* var, return =
+        (* TODO: type pattern first? *)
         check_pat pat ~expected:value_type @@ fun var _annot ->
         (* TODO: this annotation here is not used *)
-        let+ return = infer_term return in
+        let+ return = check_term return ~expected:return_type in
         (var, return)
       in
-      let annot =
-        let (Ex_term return) = typeof_term return in
-        TT_let { var; value; return }
-      in
-      tt_typed ~annot @@ TT_let { var; value; return }
-  | LT_annot { term; annot } ->
-      let* annot = check_term annot ~expected:tt_type in
-      let+ term = check_term term ~expected:annot in
-      tt_typed ~annot @@ TT_annot { term; annot }
-  | LT_loc { term; loc } -> with_tt_loc ~loc @@ fun () -> infer_term term
-
-and check_term : type a. _ -> expected:a term -> _ =
- fun term ~expected ->
-  (* TODO: repr function for term, maybe with_term? *)
-  match (term, expand_head_term expected) with
-  | LT_loc { term; loc }, expected ->
-      with_tt_loc ~loc @@ fun () -> check_term term ~expected
-  | ( LT_lambda { param; return },
-      TT_forall { var = _; param = expected_param; return = expected_return } )
-    ->
-      check_pat param ~expected:expected_param @@ fun var (Ex_term param) ->
-      let+ return = check_term return ~expected:expected_return in
-      tt_typed ~annot:expected @@ TT_lambda { var; param; return }
-  | ( ( LT_var _ | LT_forall _ | LT_lambda _ | LT_apply _ | LT_exists _
-      | LT_pair _ | LT_let _ | LT_annot _ ),
-      expected ) ->
-      let* term = infer_term term in
       let+ () =
-        let (Ex_term received) = typeof_term term in
-        unify_term ~expected ~received
+        (* TODO: this technically works here, but bad *)
+        let (Ex_term received) =
+          Subst.subst_bound ~from:Index.zero ~to_:value return_type
+        in
+        unify_term ~received ~expected
       in
-      term
+      wrapped @@ TT_let { var; value; return }
+  | LT_annot { term; annot } ->
+      let* annot = check_annot annot in
+      let+ term = check_term term ~expected in
+      wrapped @@ TT_annot { term; annot }
+  | LT_loc { term; loc } ->
+      with_tt_loc ~loc @@ fun () -> check_term term ~expected
 
-and infer_pat : type a. _ -> (_ -> _ -> a typer_context) -> a typer_context =
- fun pat f ->
-  match pat with
-  | LP_annot { pat; annot } ->
-      let* annot = check_term annot ~expected:tt_type in
-      check_pat pat ~expected:annot f
-  | LP_loc { pat; loc } -> with_loc ~loc @@ fun () -> infer_pat pat f
-  | LP_var _ | LP_pair _ -> error_pat_not_annotated ~pat
+and check_annot term = check_term term ~expected:tt_type
 
 and check_pat :
     type a k.
@@ -124,8 +109,12 @@ and check_pat :
       f name (Ex_term expected)
   | LP_pair _, _ -> error_pairs_not_implemented ()
   | LP_annot { pat; annot }, _expected_desc ->
-      let* annot = check_term annot ~expected:tt_type in
+      let* annot = check_annot annot in
       let* () = unify_term ~expected ~received:annot in
       check_pat pat ~expected:annot f
   | LP_loc { pat; loc }, _expected_desc ->
       with_loc ~loc @@ fun () -> check_pat pat ~expected f
+
+let infer_term term =
+  let* expected = tt_hole () in
+  check_term term ~expected

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -35,7 +35,8 @@ let rec occurs_term : type a. _ -> in_:a term -> _ =
   match expand_head_term in_ with
   | TT_bound_var { index = _ } -> return ()
   | TT_free_var { level } -> (
-      match level > hole.level with
+      (* TODO: what if hole.level == level *)
+      match hole.level >= level with
       | true -> return ()
       | false -> error_var_escape ~hole ~var:level)
   | TT_hole in_ -> (


### PR DESCRIPTION
## Goals

A checker with a single typing mode.

## Context

Currently Teika has two typing modes, inference and checking, as in a traditional bidirectional type system, but because Teika will support unification this can be done in a single mode, by having everything be in checked mode. This is also similar to how OCaml does typing in general.

## **Warning**

This is still broken and will be fixed in a future PR.