### PR TITLE
teika: drop names from typed tree

### DIFF
--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -14,7 +14,7 @@ let rec expand_head_term : type a. a term -> core term =
   | TT_lambda _ as term -> term
   | TT_apply { lambda; arg } -> (
       match expand_head_term lambda with
-      | TT_lambda { var = _name; param = _; return } ->
+      | TT_lambda { param = _; return } ->
           (* TODO: param is not used here,
               but it would be cool to check when in debug *)
           let (Ex_term return) =
@@ -24,7 +24,7 @@ let rec expand_head_term : type a. a term -> core term =
       | _lambda ->
           (* TODO: use expanded? *)
           TT_apply { lambda; arg })
-  | TT_let { var = _name; value; return } ->
+  | TT_let { value; return } ->
       (* TODO: this could be done in O(1) with context extending *)
       let (Ex_term return) =
         Subst.subst_bound ~from:Index.zero ~to_:value return

--- a/teika/subst.ml
+++ b/teika/subst.ml
@@ -23,25 +23,25 @@ let rec subst_bound_term : type a. from:_ -> to_:_ -> a term -> ex_term =
       match hole.link == tt_nil with
       | true -> Ex_term (TT_hole hole)
       | false -> subst_bound_term ~from hole.link)
-  | TT_forall { var; param; return } ->
+  | TT_forall { param; return } ->
       let from = Index.(from + one) in
       let (Ex_term param) = subst_bound_term ~from param in
       let (Ex_term return) = subst_bound_term ~from return in
-      Ex_term (TT_forall { var; param; return })
-  | TT_lambda { var; param; return } ->
+      Ex_term (TT_forall { param; return })
+  | TT_lambda { param; return } ->
       let from = Index.(from + one) in
       let (Ex_term param) = subst_bound_term ~from param in
       let (Ex_term return) = subst_bound_term ~from return in
-      Ex_term (TT_lambda { var; param; return })
+      Ex_term (TT_lambda { param; return })
   | TT_apply { lambda; arg } ->
       let (Ex_term lambda) = subst_bound_term ~from lambda in
       let (Ex_term arg) = subst_bound_term ~from arg in
       Ex_term (TT_apply { lambda; arg })
-  | TT_let { var; value; return } ->
+  | TT_let { value; return } ->
       let (Ex_term value) = subst_bound_term ~from value in
       let from = Index.(from + one) in
       let (Ex_term return) = subst_bound_term ~from return in
-      Ex_term (TT_let { var; value; return })
+      Ex_term (TT_let { value; return })
   | TT_annot { term; annot } ->
       let (Ex_term annot) = subst_bound_term ~from annot in
       let (Ex_term term) = subst_bound_term ~from term in

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -119,11 +119,13 @@ let rec ptree_of_term : type a. _ -> _ -> _ -> a term -> _ =
   | TT_bound_var { index } -> PT_var_index { index }
   | TT_free_var { level } -> PT_var_level { level }
   | TT_hole hole -> ptree_of_hole hole
-  | TT_forall { var; param; return } ->
+  | TT_forall { param; return } ->
+      let var = Name.make "_" in
       let param = ptree_of_term param in
       let return = ptree_of_term return in
       PT_forall { var; param; return }
-  | TT_lambda { var; param; return } ->
+  | TT_lambda { param; return } ->
+      let var = Name.make "_" in
       let param = ptree_of_term param in
       let return = ptree_of_term return in
       PT_lambda { var; param; return }
@@ -131,7 +133,8 @@ let rec ptree_of_term : type a. _ -> _ -> _ -> a term -> _ =
       let lambda = ptree_of_term lambda in
       let arg = ptree_of_term arg in
       PT_apply { lambda; arg }
-  | TT_let { var; value; return } ->
+  | TT_let { value; return } ->
+      let var = Name.make "_" in
       let value = ptree_of_term value in
       let return = ptree_of_term return in
       PT_let { var; value; return }

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -19,10 +19,10 @@ type _ term =
   | TT_bound_var : { index : Index.t } -> core term
   | TT_free_var : { level : Level.t } -> core term
   | TT_hole : hole -> core term
-  | TT_forall : { var : Name.t; param : _ term; return : _ term } -> core term
-  | TT_lambda : { var : Name.t; param : _ term; return : _ term } -> core term
+  | TT_forall : { param : _ term; return : _ term } -> core term
+  | TT_lambda : { param : _ term; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
-  | TT_let : { var : Name.t; value : _ term; return : _ term } -> sugar term
+  | TT_let : { value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
 and hole = { mutable level : Level.t; mutable link : core term }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -13,13 +13,13 @@ type _ term =
   (* _x/+n *)
   | TT_hole : hole -> core term
   (* (x : A) -> B *)
-  | TT_forall : { var : Name.t; param : _ term; return : _ term } -> core term
+  | TT_forall : { param : _ term; return : _ term } -> core term
   (* (x : A) => e *)
-  | TT_lambda : { var : Name.t; param : _ term; return : _ term } -> core term
+  | TT_lambda : { param : _ term; return : _ term } -> core term
   (* l a *)
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
   (* x = t; u *)
-  | TT_let : { var : Name.t; value : _ term; return : _ term } -> sugar term
+  | TT_let : { value : _ term; return : _ term } -> sugar term
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -45,10 +45,10 @@ let rec occurs_term : type a. _ -> in_:a term -> _ =
       | false ->
           in_.level <- min hole.level in_.level;
           return ())
-  | TT_forall { var = _; param; return } ->
+  | TT_forall { param; return } ->
       let* () = occurs_term ~in_:param in
       occurs_term ~in_:return
-  | TT_lambda { var = _; param; return } ->
+  | TT_lambda { param; return } ->
       let* () = occurs_term ~in_:param in
       occurs_term ~in_:return
   | TT_apply { lambda; arg } ->
@@ -72,15 +72,13 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       (* TODO: maybe unify against non expanded? *)
       unify_hole hole ~to_
   (* TODO: track whenever it is unified and locations, visualizing inference *)
-  | ( TT_forall { var = _; param = expected_param; return = expected_return },
-      TT_forall { var = _; param = received_param; return = received_return } )
-    ->
+  | ( TT_forall { param = expected_param; return = expected_return },
+      TT_forall { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
       let* () = unify_term ~expected:expected_param ~received:received_param in
       unify_term ~expected:expected_return ~received:received_return
-  | ( TT_lambda { var = _; param = expected_param; return = expected_return },
-      TT_lambda { var = _; param = received_param; return = received_return } )
-    ->
+  | ( TT_lambda { param = expected_param; return = expected_return },
+      TT_lambda { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
       let* () = unify_term ~expected:expected_param ~received:received_param in
       unify_term ~expected:expected_return ~received:received_return


### PR DESCRIPTION
## Goals

Avoid noise related to names.

## Context

When the pattern language was removed at #140, names were added to the typed tree, those names are currently not used and add some noise when changing code in general.