### PR TITLE
teika: remove escape check during unification

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -14,11 +14,11 @@ type error = private
     }
   (* TODO: lazy names for errors *)
   | CError_unify_var_occurs of { hole : hole; in_ : hole }
-  | CError_unify_var_escape of { hole : hole; var : Level.t }
   (* typer *)
   | CError_typer_unknown_var of { name : Name.t }
-  | Cerror_typer_not_a_forall of { type_ : ex_term }
+  | CError_typer_not_a_forall of { type_ : ex_term }
   | CError_typer_pairs_not_implemented
+  | CError_typer_var_escape of { var : Level.t }
 [@@deriving show]
 
 type var_info = Free
@@ -58,7 +58,6 @@ module Unify_context : sig
     'a unify_context
 
   val error_var_occurs : hole:hole -> in_:hole -> 'a unify_context
-  val error_var_escape : hole:hole -> var:Level.t -> 'a unify_context
 end
 
 module Typer_context : sig
@@ -88,6 +87,10 @@ module Typer_context : sig
   (* errors *)
   val error_pairs_not_implemented : unit -> 'a typer_context
   val error_not_a_forall : type_:_ term -> 'a typer_context
+  val error_var_escape : var:Level.t -> 'a typer_context
+
+  (* level *)
+  val level : unit -> Level.t typer_context
 
   (* vars *)
   val lookup_var : name:Name.t -> (Level.t * ex_term) typer_context
@@ -98,8 +101,6 @@ module Typer_context : sig
     type_:_ term ->
     (unit -> 'a typer_context) ->
     'a typer_context
-
-  val tt_hole : unit -> core term typer_context
 
   (* unify *)
   val with_unify_context : (unit -> 'a Unify_context.t) -> 'a typer_context

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -1,0 +1,28 @@
+open Context.Typer_context
+open Ttree
+open Expand_head
+
+let rec escape_check : type a. current:_ -> a term -> _ =
+ fun ~current term ->
+  let escape_check term = escape_check ~current term in
+  (* TODO: check without expand_head? *)
+  match expand_head_term term with
+  | TT_bound_var { index = _ } -> (* TODO: also check bound var *) return ()
+  | TT_free_var { level } -> (
+      match Level.(current < level) with
+      | true -> error_var_escape ~var:level
+      | false -> return ())
+  | TT_hole _hole -> return ()
+  | TT_forall { param; return } ->
+      let* () = escape_check param in
+      escape_check return
+  | TT_lambda { param; return } ->
+      let* () = escape_check param in
+      escape_check return
+  | TT_apply { lambda; arg } ->
+      let* () = escape_check lambda in
+      escape_check arg
+
+let escape_check term =
+  let* current = level () in
+  escape_check ~current term

--- a/teika/escape_check.mli
+++ b/teika/escape_check.mli
@@ -1,0 +1,4 @@
+open Context.Typer_context
+open Ttree
+
+val escape_check : _ term -> unit typer_context

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -7,7 +7,7 @@ let rec expand_head_term : type a. a term -> core term =
   | TT_typed { term; annot = _ } -> expand_head_term term
   | TT_bound_var _ as term -> term
   | TT_free_var _ as term -> term
-  | TT_hole { level = _; link } as term -> (
+  | TT_hole { link } as term -> (
       (* TODO: move this to machinery *)
       match link == tt_nil with true -> term | false -> expand_head_term link)
   | TT_forall _ as term -> term

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -279,6 +279,7 @@ module Typer = struct
     Check { name; annotated_term; wrapper }
 
   (* TODO: write tests for locations and names / offset *)
+  (* TODO: write tests for escape check *)
   let id =
     check "id" ~wrapper:false
       {|(((A : Type) => (x : A) => x)

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -11,7 +11,7 @@ module Ptree = struct
     | PT_var_name of { name : Name.t }
     | PT_var_index of { index : Index.t }
     | PT_var_level of { level : Level.t }
-    | PT_hole_var_full of { id : int; level : Level.t }
+    | PT_hole_var_full of { id : int }
     | PT_forall of { var : Name.t; param : term; return : term }
     | PT_lambda of { var : Name.t; param : term; return : term }
     | PT_apply of { lambda : term; arg : term }
@@ -37,8 +37,7 @@ module Ptree = struct
     | PT_var_name { name } -> fprintf fmt "%s" (Name.repr name)
     | PT_var_index { index } -> fprintf fmt "\\-%a" Index.pp index
     | PT_var_level { level } -> fprintf fmt "\\+%a" Level.pp level
-    | PT_hole_var_full { id; level } ->
-        fprintf fmt "_x%d\\+%a" id Level.pp level
+    | PT_hole_var_full { id } -> fprintf fmt "_x%d" id
     | PT_forall { var; param; return } ->
         fprintf fmt "(%s : %a) -> %a" (Name.repr var) pp_wrapped param pp_funct
           return
@@ -154,7 +153,7 @@ and ptree_of_hole config next holes hole =
       | Some term -> term
       | None ->
           let id = !next in
-          let term = PT_hole_var_full { id; level = hole.level } in
+          let term = PT_hole_var_full { id } in
           next := id + 1;
           Hashtbl.add holes hole term;
           term)

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -25,7 +25,7 @@ type _ term =
   | TT_let : { value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
-and hole = { mutable level : Level.t; mutable link : core term }
+and hole = { mutable link : core term }
 
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 
@@ -33,3 +33,4 @@ let nil_level = Level.zero
 let type_level = Level.next nil_level
 let tt_nil = TT_free_var { level = nil_level }
 let tt_type = TT_free_var { level = type_level }
+let tt_hole () = TT_hole { link = tt_nil }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -23,11 +23,14 @@ type _ term =
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
-and hole = { mutable level : Level.t; mutable link : core term }
+and hole = { mutable link : core term }
 
 type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 
 val nil_level : Level.t
 val type_level : Level.t
+
+(* constructors *)
 val tt_nil : core term
 val tt_type : core term
+val tt_hole : unit -> core term

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -34,17 +34,11 @@ let rec occurs_term : type a. _ -> in_:a term -> _ =
   let occurs_term ~in_ = occurs_term hole ~in_ in
   match expand_head_term in_ with
   | TT_bound_var { index = _ } -> return ()
-  | TT_free_var { level } -> (
-      (* TODO: what if hole.level == level *)
-      match hole.level >= level with
-      | true -> return ()
-      | false -> error_var_escape ~hole ~var:level)
+  | TT_free_var { level = _ } -> return ()
   | TT_hole in_ -> (
       match hole == in_ with
       | true -> error_var_occurs ~hole ~in_
-      | false ->
-          in_.level <- min hole.level in_.level;
-          return ())
+      | false -> return ())
   | TT_forall { param; return } ->
       let* () = occurs_term ~in_:param in
       occurs_term ~in_:return


### PR DESCRIPTION
## Goals

Develop unification engine without needing to track levels everywhere.

## Context

Currently the level on holes are used to do escape checking, while this approach leads to a faster algorithm and better error messages it is annoying and I don't want to think about it right now.

It should be back in the future, but by removing it the progress on the typer becomes much easier.