### PR TITLE
teika: support subst free and open bound

### DIFF
--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -7,7 +7,11 @@ let rec escape_check : type a. current:_ -> a term -> _ =
   let escape_check term = escape_check ~current term in
   (* TODO: check without expand_head? *)
   match expand_head_term term with
-  | TT_bound_var { index = _ } -> (* TODO: also check bound var *) return ()
+  | TT_bound_var { index = _ } ->
+      (* TODO: also check bound var *)
+      (* TODO: very very important to check for bound vars, unification
+            may unify variables outside of their binders *)
+      return ()
   | TT_free_var { level } -> (
       match Level.(current < level) with
       | true -> error_var_escape ~var:level

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -5,12 +5,14 @@ let rec expand_head_term : type a. a term -> core term =
   match term with
   | TT_loc { term; loc = _ } -> expand_head_term term
   | TT_typed { term; annot = _ } -> expand_head_term term
-  | TT_subst_bound { from; to_; term } ->
-      expand_subst_bound_term ~from ~to_ term
+  | TT_subst_bound { from; to_; term } -> expand_subst_bound ~from ~to_ term
+  | TT_subst_free { from; to_; term } -> expand_subst_free ~from ~to_ term
+  | TT_open_bound { from; to_; term } -> expand_open_bound ~from ~to_ term
   | TT_close_free { from; to_; term } -> expand_close_free ~from ~to_ term
   | TT_bound_var _ as term -> term
   | TT_free_var _ as term -> term
   | TT_hole { link } as term -> (
+      (* TODO: path compression *)
       (* TODO: move this to machinery *)
       match link == tt_nil with true -> term | false -> expand_head_term link)
   | TT_forall _ as term -> term
@@ -29,8 +31,7 @@ let rec expand_head_term : type a. a term -> core term =
       expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:value return
   | TT_annot { term; annot = _ } -> expand_head_term term
 
-and expand_subst_bound_term :
-    type a t. from:_ -> to_:t term -> a term -> core term =
+and expand_subst_bound : type a t. from:_ -> to_:t term -> a term -> core term =
  fun ~from ~to_ term ->
   let tt_subst_bound ~from term = tt_subst_bound ~from ~to_ term in
   match expand_head_term term with
@@ -58,6 +59,60 @@ and expand_subst_bound_term :
   | TT_apply { lambda; arg } ->
       let lambda = tt_subst_bound ~from lambda in
       let arg = tt_subst_bound ~from arg in
+      TT_apply { lambda; arg }
+
+and expand_subst_free : type a t. from:_ -> to_:t term -> a term -> core term =
+ fun ~from ~to_ term ->
+  let tt_subst_free term = tt_subst_free ~from ~to_ term in
+  match expand_head_term term with
+  | TT_bound_var { index = _ } as term -> term
+  | TT_free_var { level } as term -> (
+      match Level.equal from level with
+      | true -> expand_head_term to_
+      | false -> term)
+  (* TODO: expand subst into hole, magic could be done here *)
+  | TT_hole _hole as term -> term
+  | TT_forall { param; return } ->
+      let param = tt_subst_free param in
+      let return = tt_subst_free return in
+      TT_forall { param; return }
+  | TT_lambda { param; return } ->
+      let param = tt_subst_free param in
+      let return = tt_subst_free return in
+      TT_lambda { param; return }
+  | TT_apply { lambda; arg } ->
+      let lambda = tt_subst_free lambda in
+      let arg = tt_subst_free arg in
+      TT_apply { lambda; arg }
+
+and expand_open_bound : type a. from:_ -> to_:_ -> a term -> core term =
+ fun ~from ~to_ term ->
+  let tt_open_bound ~from term = tt_open_bound ~from ~to_ term in
+  match expand_head_term term with
+  | TT_bound_var { index } as term -> (
+      match Index.equal from index with
+      | true -> TT_free_var { level = to_ }
+      | false -> term)
+  | TT_free_var { level = _ } as term -> term
+  (* TODO: expand subst into hole, magic could be done here *)
+  | TT_hole _hole as term -> term
+  | TT_forall { param; return } ->
+      let param = tt_open_bound ~from param in
+      let return =
+        let from = Index.(from + one) in
+        tt_open_bound ~from return
+      in
+      TT_forall { param; return }
+  | TT_lambda { param; return } ->
+      let param = tt_open_bound ~from param in
+      let return =
+        let from = Index.(from + one) in
+        tt_open_bound ~from return
+      in
+      TT_lambda { param; return }
+  | TT_apply { lambda; arg } ->
+      let lambda = tt_open_bound ~from lambda in
+      let arg = tt_open_bound ~from arg in
       TT_apply { lambda; arg }
 
 and expand_close_free : type a. from:_ -> to_:_ -> a term -> core term =

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -23,6 +23,18 @@ type _ term =
       term : _ term;
     }
       -> subst term
+  | TT_subst_free : {
+      from : Level.t;
+      to_ : _ term;
+      term : _ term;
+    }
+      -> subst term
+  | TT_open_bound : {
+      from : Index.t;
+      to_ : Level.t;
+      term : _ term;
+    }
+      -> subst term
   | TT_close_free : {
       from : Level.t;
       to_ : Index.t;
@@ -45,6 +57,8 @@ type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 let nil_level = Level.zero
 let type_level = Level.next nil_level
 let tt_subst_bound ~from ~to_ term = TT_subst_bound { from; to_; term }
+let tt_subst_free ~from ~to_ term = TT_subst_free { from; to_; term }
+let tt_open_bound ~from ~to_ term = TT_open_bound { from; to_; term }
 let tt_close_free ~from ~to_ term = TT_close_free { from; to_; term }
 let tt_nil = TT_free_var { level = nil_level }
 let tt_type = TT_free_var { level = type_level }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -14,6 +14,20 @@ type _ term =
       term : _ term;
     }
       -> subst term
+  (* M[+f := N]*)
+  | TT_subst_free : {
+      from : Level.t;
+      to_ : _ term;
+      term : _ term;
+    }
+      -> subst term
+  (* M[-f `open` +t]*)
+  | TT_open_bound : {
+      from : Index.t;
+      to_ : Level.t;
+      term : _ term;
+    }
+      -> subst term
   (* M[+f `close` -t]*)
   | TT_close_free : {
       from : Level.t;
@@ -47,6 +61,8 @@ val type_level : Level.t
 
 (* constructors *)
 val tt_subst_bound : from:Index.t -> to_:_ term -> _ term -> subst term
+val tt_subst_free : from:Level.t -> to_:_ term -> _ term -> subst term
+val tt_open_bound : from:Index.t -> to_:Level.t -> _ term -> subst term
 val tt_close_free : from:Level.t -> to_:Index.t -> _ term -> subst term
 val tt_nil : core term
 val tt_type : core term

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -9,9 +9,8 @@ let unify_term ~expected ~received =
 
 let open_term term =
   (* TODO: this opening is weird *)
-  let+ level = level () in
-  let to_ = TT_free_var { level } in
-  tt_subst_bound ~from:Index.zero ~to_ term
+  let+ to_ = level () in
+  tt_open_bound ~from:Index.zero ~to_ term
 
 let close_term term =
   (* TODO: this closing is weird *)
@@ -77,9 +76,9 @@ let rec check_term : type a. _ -> expected:a term -> _ =
       let* arg_type, return_type = split_forall lambda_type in
       let* arg = check_term arg ~expected:arg_type in
       let* () =
-        (* TODO: this is clearly a hack *)
-        let* return_type = close_term return_type in
-        let received = tt_subst_bound ~from:Index.zero ~to_:arg return_type in
+        (* TODO: abstract this *)
+        let* from = level () in
+        let received = tt_subst_free ~from ~to_:arg return_type in
         unify_term ~received ~expected
       in
       wrapped @@ TT_apply { lambda; arg }
@@ -96,11 +95,10 @@ let rec check_term : type a. _ -> expected:a term -> _ =
         check_pat pat ~expected:value_type @@ fun () ->
         check_term return ~expected:return_type
       in
-      let* return_type = close_term return_type in
       let* () =
-        (* TODO: this technically works here, but bad *)
-        (* TODO: tt_subst_free *)
-        let received = tt_subst_bound ~from:Index.zero ~to_:value return_type in
+        (* TODO: abstract this *)
+        let* from = level () in
+        let received = tt_subst_free ~from ~to_:value return_type in
         unify_term ~received ~expected
       in
       wrapped @@ TT_let { value; return }


### PR DESCRIPTION
## Goals

Allows for inversing of operations during unification.

## Context

To achieve higher order unification operations needs to be inversed, a closing on one side may become an opening, this is currently not possible as there is no negative of `TT_close_free`. Additionally there is no way to substitute free variables which happens on `let`.