### PR TITLE
teika: higher order unification

### DIFF
--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,5 +1,4 @@
 type loc = Loc
-type subst = Subst
 type typed = Typed
 type core = Core
 type sugar = Sugar
@@ -7,40 +6,14 @@ type sugar = Sugar
 type _ term =
   | TT_loc : { term : _ term; loc : Location.t } -> loc term
   | TT_typed : { term : _ term; annot : _ term } -> typed term
-  (* M[-n := N]*)
-  | TT_subst_bound : {
-      from : Index.t;
-      to_ : _ term;
-      term : _ term;
-    }
-      -> subst term
-  (* M[+f := N]*)
-  | TT_subst_free : {
-      from : Level.t;
-      to_ : _ term;
-      term : _ term;
-    }
-      -> subst term
-  (* M[-f `open` +t]*)
-  | TT_open_bound : {
-      from : Index.t;
-      to_ : Level.t;
-      term : _ term;
-    }
-      -> subst term
-  (* M[+f `close` -t]*)
-  | TT_close_free : {
-      from : Level.t;
-      to_ : Index.t;
-      term : _ term;
-    }
-      -> subst term
+  (* M[S]*)
+  | TT_subst : { subst : subst; term : _ term } -> subst term
   (* x/-n *)
   | TT_bound_var : { index : Index.t } -> core term
   (* x/+n *)
   | TT_free_var : { level : Level.t } -> core term
   (* _x/+n *)
-  | TT_hole : hole -> core term
+  | TT_hole : { hole : hole; substs : subst list } -> core term
   (* (x : A) -> B *)
   | TT_forall : { param : _ term; return : _ term } -> core term
   (* (x : A) => e *)
@@ -52,9 +25,20 @@ type _ term =
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
-and hole = { mutable link : core term }
+(* TODO: I really don't like this ex_term *)
+and hole = { mutable link : ex_term }
 
-type ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+and subst =
+  (* -f := N *)
+  | TS_subst_bound : { from : Index.t; to_ : _ term } -> subst
+  (* +f := N *)
+  | TS_subst_free : { from : Level.t; to_ : _ term } -> subst
+  (* -f `open` +t *)
+  | TS_open_bound : { from : Index.t; to_ : Level.t } -> subst
+  (* +f `open` -t *)
+  | TS_close_free : { from : Level.t; to_ : Index.t } -> subst
+
+and ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 
 val nil_level : Level.t
 val type_level : Level.t
@@ -67,3 +51,4 @@ val tt_close_free : from:Level.t -> to_:Index.t -> _ term -> subst term
 val tt_nil : core term
 val tt_type : core term
 val tt_hole : unit -> core term
+val is_tt_nil : _ term -> bool

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -7,11 +7,6 @@ open Escape_check
 let unify_term ~expected ~received =
   with_unify_context @@ fun () -> Unify.unify_term ~expected ~received
 
-let open_term term =
-  (* TODO: this opening is weird *)
-  let+ to_ = level () in
-  tt_open_bound ~from:Index.zero ~to_ term
-
 let close_term term =
   (* TODO: this closing is weird *)
   let+ from = level () in
@@ -20,7 +15,7 @@ let close_term term =
 let split_forall (type a) (type_ : a term) =
   let param = tt_hole () in
   (* TODO: this is needed because unification is monomorphic *)
-  let* return = open_term (tt_hole ()) in
+  let return = tt_hole () in
   let* expected =
     let+ return = close_term return in
     TT_forall { param; return }

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -35,7 +35,8 @@ let rec occurs_term : type a. _ -> in_:a term -> _ =
   match expand_head_term in_ with
   | TT_bound_var { index = _ } -> return ()
   | TT_free_var { level = _ } -> return ()
-  | TT_hole in_ -> (
+  (* TODO: use this substs? *)
+  | TT_hole { hole = in_; substs = _ } -> (
       match hole == in_ with
       | true -> error_var_occurs ~hole ~in_
       | false -> return ())
@@ -49,6 +50,17 @@ let rec occurs_term : type a. _ -> in_:a term -> _ =
       let* () = occurs_term ~in_:lambda in
       occurs_term ~in_:arg
 
+(* TODO: better place for this *)
+let inverse_subst subst =
+  match subst with
+  (* TODO: subst of this could definitely be inversed *)
+  | TS_subst_bound _ -> None
+  | TS_subst_free _ -> None
+  | TS_open_bound { from; to_ } ->
+      Some (TS_close_free { from = to_; to_ = from })
+  | TS_close_free { from; to_ } ->
+      Some (TS_open_bound { from = to_; to_ = from })
+
 let rec unify_term : type e r. expected:e term -> received:r term -> _ =
  fun ~expected ~received ->
   (* TODO: short circuit physical equality *)
@@ -61,10 +73,9 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       match Level.equal expected received with
       | true -> return ()
       | false -> error_free_var_clash ~expected ~received)
-  | TT_hole hole, to_ | to_, TT_hole hole ->
-      (* TODO: prefer a direction when both are holes? *)
+  | TT_hole { hole; substs }, to_ | to_, TT_hole { hole; substs } ->
       (* TODO: maybe unify against non expanded? *)
-      unify_hole hole ~to_
+      unify_hole hole ~substs ~to_
   (* TODO: track whenever it is unified and locations, visualizing inference *)
   | ( TT_forall { param = expected_param; return = expected_return },
       TT_forall { param = received_param; return = received_return } ) ->
@@ -88,11 +99,19 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       as received_norm) ) ->
       error_type_clash ~expected ~expected_norm ~received ~received_norm
 
-and unify_hole hole ~to_ =
-  match to_ with
-  (* TODO: similar checking exists in occurs *)
-  | TT_hole to_ when hole == to_ -> return ()
-  | to_ ->
-      let* () = occurs_term hole ~in_:to_ in
-      hole.link <- to_;
-      return ()
+and unify_hole hole ~substs ~to_ =
+  let to_ =
+    List.fold_right
+      (fun subst (Ex_term to_) ->
+        match inverse_subst subst with
+        | Some subst -> Ex_term (TT_subst { subst; term = to_ })
+        | None -> Ex_term to_)
+      substs (Ex_term to_)
+  in
+  (* TODO: prefer a direction when both are holes? *)
+  let* () =
+    let (Ex_term to_) = to_ in
+    occurs_term hole ~in_:to_
+  in
+  hole.link <- to_;
+  return ()


### PR DESCRIPTION
## Goals

Simpler and more powerful inference.

## Context

Currently there is zero support to higher order unification, aka inversing substitutions during unification. This makes so that some features such as type propagation needs to be hacked around to work, by supporting at least some level of higher order unification this can be made much more natural.