### PR TITLE
teika: drop higher order unification

### DIFF
--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -8,7 +8,7 @@ let rec expand_head_term : type a. a term -> core term =
   | TT_subst { subst; term } -> expand_subst ~subst term
   | TT_bound_var _ as term -> term
   | TT_free_var _ as term -> term
-  | TT_hole { hole; substs = _ } as term -> (
+  | TT_hole { hole } as term -> (
       (* TODO: path compression *)
       (* TODO: move this to machinery *)
       let (Ex_term link) = hole.link in
@@ -50,9 +50,7 @@ and expand_subst_bound : type a t. from:_ -> to_:t term -> a term -> core term =
       | true -> expand_head_term to_
       | false -> term)
   | TT_free_var { level = _ } as term -> term
-  | TT_hole { hole; substs } ->
-      let substs = TS_subst_bound { from; to_ } :: substs in
-      TT_hole { hole; substs }
+  | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
       let param = tt_subst_bound ~from param in
       let return =
@@ -81,9 +79,7 @@ and expand_subst_free : type a t. from:_ -> to_:t term -> a term -> core term =
       match Level.equal from level with
       | true -> expand_head_term to_
       | false -> term)
-  | TT_hole { hole; substs } ->
-      let substs = TS_subst_free { from; to_ } :: substs in
-      TT_hole { hole; substs }
+  | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
       let param = tt_subst_free param in
       let return = tt_subst_free return in
@@ -106,9 +102,7 @@ and expand_open_bound : type a. from:_ -> to_:_ -> a term -> core term =
       | true -> TT_free_var { level = to_ }
       | false -> term)
   | TT_free_var { level = _ } as term -> term
-  | TT_hole { hole; substs } ->
-      let substs = TS_open_bound { from; to_ } :: substs in
-      TT_hole { hole; substs }
+  | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
       let param = tt_open_bound ~from param in
       let return =
@@ -137,9 +131,7 @@ and expand_close_free : type a. from:_ -> to_:_ -> a term -> core term =
       match Level.equal from level with
       | true -> TT_bound_var { index = to_ }
       | false -> term)
-  | TT_hole { hole; substs } ->
-      let substs = TS_close_free { from; to_ } :: substs in
-      TT_hole { hole; substs }
+  | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
       let param = tt_close_free ~to_ param in
       let return =

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -19,7 +19,7 @@ type _ term =
   | TT_subst : { subst : subst; term : _ term } -> subst term
   | TT_bound_var : { index : Index.t } -> core term
   | TT_free_var : { level : Level.t } -> core term
-  | TT_hole : { hole : hole; substs : subst list } -> core term
+  | TT_hole : { hole : hole } -> core term
   | TT_forall : { param : _ term; return : _ term } -> core term
   | TT_lambda : { param : _ term; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
@@ -56,7 +56,7 @@ let tt_type = TT_free_var { level = type_level }
 
 let tt_hole () =
   let hole = { link = Ex_term tt_nil } in
-  TT_hole { hole; substs = [] }
+  TT_hole { hole }
 
 let is_tt_nil (type a) (term : a term) =
   match term with

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -13,7 +13,7 @@ type _ term =
   (* x/+n *)
   | TT_free_var : { level : Level.t } -> core term
   (* _x/+n *)
-  | TT_hole : { hole : hole; substs : subst list } -> core term
+  | TT_hole : { hole : hole } -> core term
   (* (x : A) -> B *)
   | TT_forall : { param : _ term; return : _ term } -> core term
   (* (x : A) => e *)

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -7,6 +7,11 @@ open Escape_check
 let unify_term ~expected ~received =
   with_unify_context @@ fun () -> Unify.unify_term ~expected ~received
 
+let open_term term =
+  (* TODO: this opening is weird *)
+  let+ to_ = level () in
+  tt_open_bound ~from:Index.zero ~to_ term
+
 let close_term term =
   (* TODO: this closing is weird *)
   let+ from = level () in
@@ -15,7 +20,7 @@ let close_term term =
 let split_forall (type a) (type_ : a term) =
   let param = tt_hole () in
   (* TODO: this is needed because unification is monomorphic *)
-  let return = tt_hole () in
+  let* return = open_term @@ tt_hole () in
   let* expected =
     let+ return = close_term return in
     TT_forall { param; return }


### PR DESCRIPTION
## Goals

Simplify the development of the typer.

## Context

In a previous PR higher order unification was added, but due to an increase in complexity I will be dropping this again, until a better approach is found.