### PR TITLE
teika: add support to simple extensions

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -25,6 +25,10 @@ type error =
     }
   | CError_typer_pairs_not_implemented
   | CError_typer_var_escape of { var : Level.t }
+  | CError_typer_unknown_extension of {
+      extension : Name.t;
+      payload : Ltree.term;
+    }
 [@@deriving show { with_path = false }]
 
 type ('a, 'b) result = { match_ : 'k. ok:('a -> 'k) -> error:('b -> 'k) -> 'k }
@@ -141,6 +145,9 @@ module Typer_context = struct
 
   let[@inline always] error_var_escape ~var =
     fail @@ CError_typer_var_escape { var }
+
+  let[@inline always] error_typer_unknown_extension ~extension ~payload =
+    fail @@ CError_typer_unknown_extension { extension; payload }
 
   let[@inline always] lookup_var ~name ~next_var:_ ~vars ~expected_vars:_
       ~received_vars:_ =

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -19,6 +19,10 @@ type error = private
   | CError_typer_not_a_forall of { type_ : ex_term }
   | CError_typer_pairs_not_implemented
   | CError_typer_var_escape of { var : Level.t }
+  | CError_typer_unknown_extension of {
+      extension : Name.t;
+      payload : Ltree.term;
+    }
 [@@deriving show]
 
 type var_info = Free
@@ -88,6 +92,9 @@ module Typer_context : sig
   val error_pairs_not_implemented : unit -> 'a typer_context
   val error_not_a_forall : type_:_ term -> 'a typer_context
   val error_var_escape : var:Level.t -> 'a typer_context
+
+  val error_typer_unknown_extension :
+    extension:Name.t -> payload:Ltree.term -> 'a typer_context
 
   (* level *)
   val level : unit -> Level.t typer_context

--- a/teika/ltree.ml
+++ b/teika/ltree.ml
@@ -1,5 +1,6 @@
 type term =
   | LT_var of { var : Name.t }
+  | LT_extension of { extension : Name.t; payload : term }
   | LT_forall of { param : pat; return : term }
   | LT_lambda of { param : pat; return : term }
   | LT_apply of { lambda : term; arg : term }

--- a/teika/ltree.mli
+++ b/teika/ltree.mli
@@ -1,6 +1,8 @@
 type term =
   (* x *)
   | LT_var of { var : Name.t }
+  (* @x(e) *)
+  | LT_extension of { extension : Name.t; payload : term }
   (* (x : A) -> (z : B) *)
   | LT_forall of { param : pat; return : term }
   (* (x : A) => e *)

--- a/teika/slexer.ml
+++ b/teika/slexer.ml
@@ -8,11 +8,13 @@ let whitespace = [%sedlex.regexp? Plus (' ' | '\t' | '\n')]
 let alphabet = [%sedlex.regexp? 'a' .. 'z' | 'A' .. 'Z']
 let digit = [%sedlex.regexp? '0' .. '9']
 let variable = [%sedlex.regexp? (alphabet | '_'), Star (alphabet | digit | '_')]
+let extension = [%sedlex.regexp? '@', variable]
 
 let rec tokenizer buf =
   match%sedlex buf with
   | whitespace -> tokenizer buf
   | variable -> VAR (lexeme buf)
+  | extension -> EXTENSION (lexeme buf)
   | ":" -> COLON
   | "->" -> ARROW
   | "=>" -> FAT_ARROW

--- a/teika/sparser.mly
+++ b/teika/sparser.mly
@@ -17,6 +17,7 @@ let mk (loc_start, loc_end) =
 %token RIGHT_PARENS (* ) *)
 %token LEFT_BRACE (* { *)
 %token RIGHT_BRACE (* } *)
+%token <string> EXTENSION (* @x *)
 
 %token EOF
 
@@ -51,6 +52,7 @@ let term_rec_apply :=
 
 let term_atom :=
   | term_var
+  | term_extension
   | term_parens(term_wrapped)
   | term_braces(term_wrapped)
 
@@ -71,6 +73,9 @@ let term_rec_annot :=
 let term_var ==
   | var = VAR;
     { st_var (mk $loc) ~var:(Name.make var) }
+let term_extension ==
+  | extension = EXTENSION;
+    { st_extension (mk $loc) ~extension:(Name.make extension) }
 let term_forall(self, lower) ==
   | param = lower; ARROW; return = self;
     { st_forall (mk $loc) ~param ~return }

--- a/teika/stree.ml
+++ b/teika/stree.ml
@@ -2,6 +2,7 @@ type term = ST of { loc : Location.t; [@opaque] desc : term_desc }
 
 and term_desc =
   | ST_var of { var : Name.t }
+  | ST_extension of { extension : Name.t }
   | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
@@ -16,6 +17,7 @@ and term_desc =
 
 let st loc desc = ST { loc; desc }
 let st_var loc ~var = st loc (ST_var { var })
+let st_extension loc ~extension = st loc (ST_extension { extension })
 let st_forall loc ~param ~return = st loc (ST_forall { param; return })
 let st_lambda loc ~param ~return = st loc (ST_lambda { param; return })
 let st_apply loc ~lambda ~arg = st loc (ST_apply { lambda; arg })

--- a/teika/stree.mli
+++ b/teika/stree.mli
@@ -2,6 +2,7 @@ type term = private ST of { loc : Location.t; desc : term_desc }
 
 and term_desc = private
   | ST_var of { var : Name.t }
+  | ST_extension of { extension : Name.t }
   | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
@@ -15,6 +16,7 @@ and term_desc = private
 [@@deriving show]
 
 val st_var : Location.t -> var:Name.t -> term
+val st_extension : Location.t -> extension:Name.t -> term
 val st_forall : Location.t -> param:term -> return:term -> term
 val st_lambda : Location.t -> param:term -> return:term -> term
 val st_apply : Location.t -> lambda:term -> arg:term -> term

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -51,6 +51,8 @@ let rec check_term : type a. _ -> expected:a term -> _ =
       let* level, Ex_term received = lookup_var ~name in
       let* () = unify_term ~received ~expected in
       wrapped @@ TT_free_var { level }
+  | LT_extension { extension; payload } ->
+      check_term_extension ~extension ~payload ~expected
   | LT_forall { param; return } ->
       (* TODO: this could in theory be improved by expected term *)
       (* TODO: this could also be checked after the return *)
@@ -111,6 +113,12 @@ let rec check_term : type a. _ -> expected:a term -> _ =
       wrapped @@ TT_annot { term; annot }
   | LT_loc { term; loc } ->
       with_tt_loc ~loc @@ fun () -> check_term term ~expected
+
+and check_term_extension :
+    type a. extension:_ -> payload:_ -> expected:a term -> _ =
+ fun ~extension ~payload ~expected:_ ->
+  match (Name.repr extension, payload) with
+  | _ -> error_typer_unknown_extension ~extension ~payload
 
 and check_annot term = check_term term ~expected:tt_type
 


### PR DESCRIPTION
## Goals

Support extension points / attributes.

## Context

Teika will support extension points / attributes in the future, but this will also be used internally by the language to achieve things such as features that are unstable, should not be exposed to the user or are "platform dependent".