### PR TITLE
teika: patterns and holes

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -15,8 +15,8 @@ type error =
     }
     (* TODO: lazy names for errors *)
   | CError_unify_var_occurs of {
-      hole : hole; [@printer Tprinter.pp_hole]
-      in_ : hole; [@printer Tprinter.pp_hole]
+      hole : ex_term hole; [@printer Tprinter.pp_ex_term_hole]
+      in_ : ex_term hole; [@printer Tprinter.pp_ex_term_hole]
     }
   (* typer *)
   | CError_typer_unknown_var of { name : Name.t }

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -13,7 +13,7 @@ type error = private
       received_norm : core term;
     }
   (* TODO: lazy names for errors *)
-  | CError_unify_var_occurs of { hole : hole; in_ : hole }
+  | CError_unify_var_occurs of { hole : ex_term hole; in_ : ex_term hole }
   (* typer *)
   | CError_typer_unknown_var of { name : Name.t }
   | CError_typer_not_a_forall of { type_ : ex_term }
@@ -61,7 +61,8 @@ module Unify_context : sig
     received_norm:core term ->
     'a unify_context
 
-  val error_var_occurs : hole:hole -> in_:hole -> 'a unify_context
+  val error_var_occurs :
+    hole:ex_term hole -> in_:ex_term hole -> 'a unify_context
 end
 
 module Typer_context : sig

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -2,9 +2,10 @@ open Context.Typer_context
 open Ttree
 open Expand_head
 
-let rec escape_check : type a. current:_ -> a term -> _ =
+let rec escape_check_term : type a. current:_ -> a term -> _ =
  fun ~current term ->
-  let escape_check term = escape_check ~current term in
+  let escape_check_term term = escape_check_term ~current term in
+  let escape_check_param pat = escape_check_param ~current pat in
   (* TODO: check without expand_head? *)
   match expand_head_term term with
   | TT_bound_var { index = _ } ->
@@ -18,18 +19,23 @@ let rec escape_check : type a. current:_ -> a term -> _ =
       | false -> return ())
   | TT_hole _hole -> return ()
   | TT_forall { param; return } ->
-      let* () = escape_check param in
-      escape_check return
+      let* () = escape_check_param param in
+      escape_check_term return
   | TT_lambda { param; return } ->
-      let* () = escape_check param in
-      escape_check return
+      let* () = escape_check_param param in
+      escape_check_term return
   | TT_apply { lambda; arg } ->
-      let* () = escape_check lambda in
-      escape_check arg
-  | TT_self { body } -> escape_check body
-  | TT_fix { body } -> escape_check body
-  | TT_unroll { term } -> escape_check term
+      let* () = escape_check_term lambda in
+      escape_check_term arg
+  | TT_self { var = _; body } -> escape_check_term body
+  | TT_fix { var = _; body } -> escape_check_term body
+  | TT_unroll { term } -> escape_check_term term
 
-let escape_check term =
+and escape_check_param ~current term =
+  (* TODO: check pat? *)
+  let (TP_typed { pat = _; annot }) = term in
+  escape_check_term ~current annot
+
+let escape_check_term term =
   let* current = level () in
-  escape_check ~current term
+  escape_check_term ~current term

--- a/teika/escape_check.mli
+++ b/teika/escape_check.mli
@@ -1,4 +1,4 @@
 open Context.Typer_context
 open Ttree
 
-val escape_check : _ term -> unit typer_context
+val escape_check_term : _ term -> unit typer_context

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -23,7 +23,7 @@ let rec expand_head_term : type a. a term -> core term =
       match expand_head_term lambda with
       | TT_lambda { param = _; return } ->
           (* TODO: param is not used here,
-              but it would be cool to check when in debug *)
+             but it would be cool to check when in debug *)
           (* TODO: this could be done in O(1) with context extending *)
           expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:arg return
       | _lambda ->
@@ -33,20 +33,24 @@ let rec expand_head_term : type a. a term -> core term =
   | TT_fix _ as term -> term
   | TT_unroll _ as term -> term
   | TT_unfold { term } -> expand_head_term term
-  | TT_let { value; return } ->
+  | TT_let { bound = _; value; return } ->
       expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:value return
   | TT_annot { term; annot = _ } -> expand_head_term term
 
 and expand_subst : type a. subst:subst -> a term -> core term =
  fun ~subst term ->
   match subst with
-  | TS_subst_bound { from; to_ } -> expand_subst_bound ~from ~to_ term
-  | TS_subst_free { from; to_ } -> expand_subst_free ~from ~to_ term
-  | TS_open_bound { from; to_ } -> expand_open_bound ~from ~to_ term
-  | TS_close_free { from; to_ } -> expand_close_free ~from ~to_ term
+  | TS_subst_bound { from; to_ } -> expand_subst_bound_term ~from ~to_ term
+  | TS_subst_free { from; to_ } -> expand_subst_free_term ~from ~to_ term
+  | TS_open_bound { from; to_ } -> expand_open_bound_term ~from ~to_ term
+  | TS_close_free { from; to_ } -> expand_close_free_term ~from ~to_ term
 
-and expand_subst_bound : type a t. from:_ -> to_:t term -> a term -> core term =
+and expand_subst_bound_term :
+    type a t. from:_ -> to_:t term -> a term -> core term =
  fun ~from ~to_ term ->
+  let expand_subst_bound_param ~from pat =
+    expand_subst_bound_param ~from ~to_ pat
+  in
   let tt_subst_bound ~from term = tt_subst_bound ~from ~to_ term in
   match expand_head_term term with
   | TT_bound_var { index } as term -> (
@@ -56,14 +60,14 @@ and expand_subst_bound : type a t. from:_ -> to_:t term -> a term -> core term =
   | TT_free_var { level = _ } as term -> term
   | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
-      let param = tt_subst_bound ~from param in
+      let param = expand_subst_bound_param ~from param in
       let return =
         let from = Index.(from + one) in
         tt_subst_bound ~from return
       in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = tt_subst_bound ~from param in
+      let param = expand_subst_bound_param ~from param in
       let return =
         let from = Index.(from + one) in
         tt_subst_bound ~from return
@@ -73,24 +77,32 @@ and expand_subst_bound : type a t. from:_ -> to_:t term -> a term -> core term =
       let lambda = tt_subst_bound ~from lambda in
       let arg = tt_subst_bound ~from arg in
       TT_apply { lambda; arg }
-  | TT_self { body } ->
+  | TT_self { var; body } ->
       let body =
         let from = Index.(from + one) in
         tt_subst_bound ~from body
       in
-      TT_self { body }
-  | TT_fix { body } ->
+      TT_self { var; body }
+  | TT_fix { var; body } ->
       let body =
         let from = Index.(from + one) in
         tt_subst_bound ~from body
       in
-      TT_fix { body }
+      TT_fix { var; body }
   | TT_unroll { term } ->
       let term = tt_subst_bound ~from term in
       TT_unroll { term }
 
-and expand_subst_free : type a t. from:_ -> to_:t term -> a term -> core term =
+and expand_subst_bound_param : type t. from:_ -> to_:t term -> _ -> _ =
+ fun ~from ~to_ pat ->
+  let (TP_typed { pat; annot }) = pat in
+  let annot = tt_subst_bound ~from ~to_ annot in
+  TP_typed { pat; annot }
+
+and expand_subst_free_term :
+    type a t. from:_ -> to_:t term -> a term -> core term =
  fun ~from ~to_ term ->
+  let expand_subst_free_param pat = expand_subst_free_param ~from ~to_ pat in
   let tt_subst_free term = tt_subst_free ~from ~to_ term in
   match expand_head_term term with
   | TT_bound_var { index = _ } as term -> term
@@ -100,29 +112,38 @@ and expand_subst_free : type a t. from:_ -> to_:t term -> a term -> core term =
       | false -> term)
   | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
-      let param = tt_subst_free param in
+      let param = expand_subst_free_param param in
       let return = tt_subst_free return in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = tt_subst_free param in
+      let param = expand_subst_free_param param in
       let return = tt_subst_free return in
       TT_lambda { param; return }
   | TT_apply { lambda; arg } ->
       let lambda = tt_subst_free lambda in
       let arg = tt_subst_free arg in
       TT_apply { lambda; arg }
-  | TT_self { body } ->
+  | TT_self { var; body } ->
       let body = tt_subst_free body in
-      TT_self { body }
-  | TT_fix { body } ->
+      TT_self { var; body }
+  | TT_fix { var; body } ->
       let body = tt_subst_free body in
-      TT_fix { body }
+      TT_fix { var; body }
   | TT_unroll { term } ->
       let term = tt_subst_free term in
       TT_unroll { term }
 
-and expand_open_bound : type a. from:_ -> to_:_ -> a term -> core term =
+and expand_subst_free_param : type t. from:_ -> to_:t term -> _ -> _ =
+ fun ~from ~to_ pat ->
+  let (TP_typed { pat; annot }) = pat in
+  let annot = tt_subst_free ~from ~to_ annot in
+  TP_typed { pat; annot }
+
+and expand_open_bound_term : type a. from:_ -> to_:_ -> a term -> core term =
  fun ~from ~to_ term ->
+  let expand_open_bound_param ~from pat =
+    expand_open_bound_param ~from ~to_ pat
+  in
   let tt_open_bound ~from term = tt_open_bound ~from ~to_ term in
   match expand_head_term term with
   | TT_bound_var { index } as term -> (
@@ -132,14 +153,14 @@ and expand_open_bound : type a. from:_ -> to_:_ -> a term -> core term =
   | TT_free_var { level = _ } as term -> term
   | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
-      let param = tt_open_bound ~from param in
+      let param = expand_open_bound_param ~from param in
       let return =
         let from = Index.(from + one) in
         tt_open_bound ~from return
       in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = tt_open_bound ~from param in
+      let param = expand_open_bound_param ~from param in
       let return =
         let from = Index.(from + one) in
         tt_open_bound ~from return
@@ -149,24 +170,32 @@ and expand_open_bound : type a. from:_ -> to_:_ -> a term -> core term =
       let lambda = tt_open_bound ~from lambda in
       let arg = tt_open_bound ~from arg in
       TT_apply { lambda; arg }
-  | TT_self { body } ->
+  | TT_self { var; body } ->
       let body =
         let from = Index.(from + one) in
         tt_open_bound ~from body
       in
-      TT_self { body }
-  | TT_fix { body } ->
+      TT_self { var; body }
+  | TT_fix { var; body } ->
       let body =
         let from = Index.(from + one) in
         tt_open_bound ~from body
       in
-      TT_fix { body }
+      TT_fix { var; body }
   | TT_unroll { term } ->
       let term = tt_open_bound ~from term in
       TT_unroll { term }
 
-and expand_close_free : type a. from:_ -> to_:_ -> a term -> core term =
+and expand_open_bound_param ~from ~to_ pat =
+  let (TP_typed { pat; annot }) = pat in
+  let annot = tt_open_bound ~from ~to_ annot in
+  TP_typed { pat; annot }
+
+and expand_close_free_term : type a. from:_ -> to_:_ -> a term -> core term =
  fun ~from ~to_ term ->
+  let expand_close_free_param ~to_ pat =
+    expand_close_free_param ~from ~to_ pat
+  in
   let tt_close_free ~to_ term = tt_close_free ~from ~to_ term in
   match expand_head_term term with
   | TT_bound_var { index = _ } as term -> term
@@ -176,14 +205,14 @@ and expand_close_free : type a. from:_ -> to_:_ -> a term -> core term =
       | false -> term)
   | TT_hole { hole = _ } as term -> term
   | TT_forall { param; return } ->
-      let param = tt_close_free ~to_ param in
+      let param = expand_close_free_param ~to_ param in
       let return =
         let to_ = Index.(to_ + one) in
         tt_close_free ~to_ return
       in
       TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = tt_close_free ~to_ param in
+      let param = expand_close_free_param ~to_ param in
       let return =
         let to_ = Index.(to_ + one) in
         tt_close_free ~to_ return
@@ -193,18 +222,39 @@ and expand_close_free : type a. from:_ -> to_:_ -> a term -> core term =
       let lambda = tt_close_free ~to_ lambda in
       let arg = tt_close_free ~to_ arg in
       TT_apply { lambda; arg }
-  | TT_self { body } ->
+  | TT_self { var; body } ->
       let body =
         let to_ = Index.(to_ + one) in
         tt_close_free ~to_ body
       in
-      TT_self { body }
-  | TT_fix { body } ->
+      TT_self { var; body }
+  | TT_fix { var; body } ->
       let body =
         let to_ = Index.(to_ + one) in
         tt_close_free ~to_ body
       in
-      TT_fix { body }
+      TT_fix { var; body }
   | TT_unroll { term } ->
       let term = tt_close_free ~to_ term in
       TT_unroll { term }
+
+and expand_close_free_param : from:_ -> to_:_ -> _ -> _ =
+ fun ~from ~to_ pat ->
+  let (TP_typed { pat; annot }) = pat in
+  let annot = tt_close_free ~from ~to_ annot in
+  TP_typed { pat; annot }
+
+and expand_head_pat : type a. a pat -> _ =
+ fun pat ->
+  match pat with
+  | TP_typed { pat; annot = _ } -> expand_head_pat pat
+  | TP_hole { hole } as pat -> (
+      (* TODO: path compression *)
+      (* TODO: move this to machinery *)
+      let link = hole.link in
+      match is_tp_nil link with
+      | true -> pat
+      | false ->
+          (* TODO: path compression *)
+          expand_head_pat link)
+  | TP_var _ as pat -> pat

--- a/teika/expand_head.mli
+++ b/teika/expand_head.mli
@@ -1,3 +1,4 @@
 open Ttree
 
 val expand_head_term : _ term -> core term
+val expand_head_pat : _ pat -> core pat

--- a/teika/lparser.ml
+++ b/teika/lparser.ml
@@ -63,6 +63,7 @@ let rec parse_term term =
 and parse_apply lambda arg =
   let (ST { loc; desc }) = lambda in
   match desc with
+  (* TODO: ST_parens? *)
   | ST_extension { extension } ->
       let payload = parse_term arg in
       let term = LT_extension { extension; payload } in

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -377,11 +377,8 @@ module Typer = struct
       Format.sprintf
         {|((P => x => @unfold x) : 
           (P : (False : (f : @self(f -> @unroll (%s) f)) -> Type) -> Type) ->
-          (x : P (@unroll (%s))) -> P (
-              (f : @self(f -> @unroll (%s) f)) =>
-                (P : (f : @self(f -> @unroll (%s) f)) -> Type) -> P f
-            ))
-        |}
+          (x : P (@unroll (%s))) -> P ((f : @self(f -> @unroll (%s) f)) =>
+              (P : (f : @self(f -> @unroll (%s) f)) -> Type) -> P f))|}
         ind_false ind_false ind_false ind_false
     in
     check "unfold False" ~wrapper:false code
@@ -418,7 +415,9 @@ module Typer = struct
       | Some stree -> (
           let ltree = Lparser.from_stree stree in
           match infer_term ltree with
-          | Ok _ttree -> ()
+          | Ok _ttree ->
+              Format.eprintf "%a\n%!" Tprinter.pp_term _ttree;
+              ()
           | Error error ->
               failwith @@ Format.asprintf "error: %a\n%!" Context.pp_error error
           )

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -195,7 +195,7 @@ let pp_term fmt term =
   let pterm = ptree_of_term config next holes term in
   Ptree.pp_term fmt pterm
 
-let pp_hole fmt hole =
+let pp_ex_term_hole fmt hole =
   let next = ref 0 in
   let holes = Hashtbl.create 8 in
   let pterm = ptree_of_hole config next holes ~hole in

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -13,11 +13,11 @@ module Ptree = struct
     | PT_var_index of { index : Index.t }
     | PT_var_level of { level : Level.t }
     | PT_hole_var_full of { id : int }
-    | PT_forall of { var : Name.t; param : term; return : term }
-    | PT_lambda of { var : Name.t; param : term; return : term }
+    | PT_forall of { param : term; return : term }
+    | PT_lambda of { param : term; return : term }
     | PT_apply of { lambda : term; arg : term }
-    | PT_self of { var : Name.t; body : term }
-    | PT_fix of { var : Name.t; body : term }
+    | PT_self of { bound : term; body : term }
+    | PT_fix of { bound : term; body : term }
     | PT_unroll of { term : term }
     | PT_let of { var : Name.t; value : term; return : term }
     | PT_annot of { term : term; annot : term }
@@ -59,18 +59,16 @@ module Ptree = struct
     | PT_var_index { index } -> fprintf fmt "\\-%a" Index.pp index
     | PT_var_level { level } -> fprintf fmt "\\+%a" Level.pp level
     | PT_hole_var_full { id } -> fprintf fmt "_x%d" id
-    | PT_forall { var; param; return } ->
-        fprintf fmt "(%s : %a) -> %a" (Name.repr var) pp_wrapped param pp_funct
-          return
-    | PT_lambda { var; param; return } ->
-        fprintf fmt "(%s : %a) => %a" (Name.repr var) pp_wrapped param pp_funct
-          return
+    | PT_forall { param; return } ->
+        fprintf fmt "%a -> %a" pp_atom param pp_funct return
+    | PT_lambda { param; return } ->
+        fprintf fmt "%a => %a" pp_atom param pp_funct return
     | PT_apply { lambda; arg } ->
         fprintf fmt "%a %a" pp_apply lambda pp_atom arg
-    | PT_self { var; body } ->
-        fprintf fmt "@self(%s -> %a)" (Name.repr var) pp_wrapped body
-    | PT_fix { var; body } ->
-        fprintf fmt "@fix(%s => %a)" (Name.repr var) pp_wrapped body
+    | PT_self { bound; body } ->
+        fprintf fmt "@self(%a -> %a)" pp_atom bound pp_wrapped body
+    | PT_fix { bound; body } ->
+        fprintf fmt "@fix(%a => %a)" pp_atom bound pp_wrapped body
     | PT_unroll { term } -> fprintf fmt "@unroll(%a)" pp_wrapped term
     | PT_let { var; value; return } ->
         fprintf fmt "%s = %a; %a" (Name.repr var) pp_funct value pp_let return
@@ -128,39 +126,58 @@ let rec ptree_of_term : type a. _ -> _ -> _ -> a term -> _ =
  fun config next holes (term : a term) ->
   let open Ptree in
   let ptree_of_term term = ptree_of_term config next holes term in
-  let ptree_of_hole ~hole = ptree_of_hole config next holes ~hole in
+  let ptree_of_pat pat = ptree_of_pat config next holes pat in
+  let ptree_of_param pat = ptree_of_param config next holes pat in
+  let ptree_of_hole hole = ptree_of_hole config next holes hole in
   (* TODO: print details *)
   match expand_head_term term with
   | TT_bound_var { index } -> PT_var_index { index }
   | TT_free_var { level } -> PT_var_level { level }
-  | TT_hole { hole } -> ptree_of_hole ~hole
+  | TT_hole { hole } -> ptree_of_hole @@ Ex_hole hole
   | TT_forall { param; return } ->
-      let var = Name.make "_" in
-      let param = ptree_of_term param in
+      let param = ptree_of_param param in
       let return = ptree_of_term return in
-      PT_forall { var; param; return }
+      PT_forall { param; return }
   | TT_lambda { param; return } ->
-      let var = Name.make "_" in
-      let param = ptree_of_term param in
+      let param = ptree_of_param param in
       let return = ptree_of_term return in
-      PT_lambda { var; param; return }
+      PT_lambda { param; return }
   | TT_apply { lambda; arg } ->
       let lambda = ptree_of_term lambda in
       let arg = ptree_of_term arg in
       PT_apply { lambda; arg }
-  | TT_self { body } ->
-      let var = Name.make "_" in
+  | TT_self { var; body } ->
+      let bound = ptree_of_pat var in
       let body = ptree_of_term body in
-      PT_self { var; body }
-  | TT_fix { body } ->
-      let var = Name.make "_" in
+      PT_self { bound; body }
+  | TT_fix { var; body } ->
+      let bound = ptree_of_pat var in
       let body = ptree_of_term body in
-      PT_fix { var; body }
+      PT_fix { bound; body }
   | TT_unroll { term } ->
       let term = ptree_of_term term in
       PT_unroll { term }
 
-and ptree_of_hole _config next holes ~hole =
+and ptree_of_param config next holes pat =
+  let open Ptree in
+  let ptree_of_term term = ptree_of_term config next holes term in
+  let ptree_of_pat term = ptree_of_pat config next holes term in
+  let (TP_typed { pat; annot }) = pat in
+  (* TODO: calling this term is weird *)
+  let term = ptree_of_pat pat in
+  let annot = ptree_of_term annot in
+  PT_annot { term; annot }
+
+and ptree_of_pat : type a. _ -> _ -> _ -> a pat -> _ =
+ fun config next holes pat ->
+  let open Ptree in
+  let ptree_of_hole hole = ptree_of_hole config next holes hole in
+  (* TODO: expand head here? *)
+  match expand_head_pat pat with
+  | TP_hole { hole } -> ptree_of_hole @@ Ex_hole hole
+  | TP_var { name } -> PT_var_name { name }
+
+and ptree_of_hole _config next holes hole =
   let open Ptree in
   (* TODO: extract this into machinery tooling *)
   (* TODO: allow to print link *)
@@ -198,7 +215,7 @@ let pp_term fmt term =
 let pp_ex_term_hole fmt hole =
   let next = ref 0 in
   let holes = Hashtbl.create 8 in
-  let pterm = ptree_of_hole config next holes ~hole in
+  let pterm = ptree_of_hole config next holes @@ Ex_hole hole in
   Ptree.pp_term fmt pterm
 
 let pp_ex_term fmt (Ex_term term) = pp_term fmt term

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,5 +1,5 @@
 open Ttree
 
 val pp_term : Format.formatter -> _ term -> unit
-val pp_hole : Format.formatter -> hole -> unit
+val pp_ex_term_hole : Format.formatter -> ex_term hole -> unit
 val pp_ex_term : Format.formatter -> ex_term -> unit

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -19,7 +19,7 @@ type _ term =
   | TT_subst : { subst : subst; term : _ term } -> subst term
   | TT_bound_var : { index : Index.t } -> core term
   | TT_free_var : { level : Level.t } -> core term
-  | TT_hole : { hole : hole } -> core term
+  | TT_hole : { hole : ex_term hole } -> core term
   | TT_forall : { param : _ term; return : _ term } -> core term
   | TT_lambda : { param : _ term; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
@@ -30,7 +30,7 @@ type _ term =
   | TT_let : { value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
-and hole = { mutable link : ex_term }
+and 'a hole = { mutable link : 'a }
 
 and subst =
   | TS_subst_bound : { from : Index.t; to_ : _ term } -> subst

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -20,15 +20,21 @@ type _ term =
   | TT_bound_var : { index : Index.t } -> core term
   | TT_free_var : { level : Level.t } -> core term
   | TT_hole : { hole : ex_term hole } -> core term
-  | TT_forall : { param : _ term; return : _ term } -> core term
-  | TT_lambda : { param : _ term; return : _ term } -> core term
+  | TT_forall : { param : typed pat; return : _ term } -> core term
+  | TT_lambda : { param : typed pat; return : _ term } -> core term
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
-  | TT_self : { body : _ term } -> core term
-  | TT_fix : { body : _ term } -> core term
+  | TT_self : { var : core pat; body : _ term } -> core term
+  | TT_fix : { var : core pat; body : _ term } -> core term
   | TT_unroll : { term : _ term } -> core term
   | TT_unfold : { term : _ term } -> sugar term
-  | TT_let : { value : _ term; return : _ term } -> sugar term
+  | TT_let : { bound : _ pat; value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
+
+and _ pat =
+  (* TODO: TP_loc *)
+  | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
+  | TP_hole : { hole : core pat hole } -> core pat
+  | TP_var : { name : Name.t } -> core pat
 
 and 'a hole = { mutable link : 'a }
 
@@ -39,6 +45,8 @@ and subst =
   | TS_close_free : { from : Level.t; to_ : Index.t } -> subst
 
 and ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+and ex_pat = Ex_pat : _ term -> ex_pat [@@ocaml.unboxed]
+and ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]
 
 let nil_level = Level.zero
 let type_level = Level.next nil_level
@@ -63,6 +71,26 @@ let tt_hole () =
   TT_hole { hole }
 
 let is_tt_nil (type a) (term : a term) =
+  (* TODO: why not physical equality?
+      Because TT_free_var is rebuilt in a couple places *)
   match term with
   | TT_free_var { level } -> Level.equal nil_level level
+  | _ -> false
+
+(* TODO: ugly hack *)
+let nil_name = Name.make "**nil**"
+
+let tp_nil =
+  (* TODO: very distinct way, maybe level on pattern? *)
+  TP_var { name = nil_name }
+
+let tp_hole () =
+  let hole = { link = tp_nil } in
+  TP_hole { hole }
+
+let is_tp_nil (type a) (pat : a pat) =
+  match pat with
+  | TP_var { name } ->
+      (* TODO: physical equality used here *)
+      name == nil_name
   | _ -> false

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -12,28 +12,36 @@ type _ term =
   | TT_bound_var : { index : Index.t } -> core term
   (* x/+n *)
   | TT_free_var : { level : Level.t } -> core term
-  (* _x/+n *)
   (* TODO: I really don't like this ex_term *)
+  (* _x/+n *)
   | TT_hole : { hole : ex_term hole } -> core term
   (* (x : A) -> B *)
-  | TT_forall : { param : _ term; return : _ term } -> core term
+  | TT_forall : { param : typed pat; return : _ term } -> core term
   (* (x : A) => e *)
-  | TT_lambda : { param : _ term; return : _ term } -> core term
+  | TT_lambda : { param : typed pat; return : _ term } -> core term
   (* l a *)
   | TT_apply : { lambda : _ term; arg : _ term } -> core term
   (* @self(x -> e)*)
-  | TT_self : { body : _ term } -> core term
+  (* TODO: why core pat? *)
+  | TT_self : { var : core pat; body : _ term } -> core term
   (* @fix(x => e)*)
-  | TT_fix : { body : _ term } -> core term
+  (* TODO: why core pat? *)
+  | TT_fix : { var : core pat; body : _ term } -> core term
   (* @unroll(e)*)
   | TT_unroll : { term : _ term } -> core term
   (* @unfold(e)*)
   (* TODO: technically not sugar *)
   | TT_unfold : { term : _ term } -> sugar term
   (* x = t; u *)
-  | TT_let : { value : _ term; return : _ term } -> sugar term
+  | TT_let : { bound : _ pat; value : _ term; return : _ term } -> sugar term
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
+
+and _ pat =
+  | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
+  | TP_hole : { hole : core pat hole } -> core pat
+  (* x *)
+  | TP_var : { name : Name.t } -> core pat
 
 and 'a hole = { mutable link : 'a }
 
@@ -48,6 +56,8 @@ and subst =
   | TS_close_free : { from : Level.t; to_ : Index.t } -> subst
 
 and ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
+and ex_pat = Ex_pat : _ term -> ex_pat [@@ocaml.unboxed]
+and ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]
 
 val nil_level : Level.t
 val type_level : Level.t
@@ -61,3 +71,6 @@ val tt_nil : core term
 val tt_type : core term
 val tt_hole : unit -> core term
 val is_tt_nil : _ term -> bool
+val tp_nil : core pat
+val tp_hole : unit -> core pat
+val is_tp_nil : _ pat -> bool

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -13,7 +13,8 @@ type _ term =
   (* x/+n *)
   | TT_free_var : { level : Level.t } -> core term
   (* _x/+n *)
-  | TT_hole : { hole : hole } -> core term
+  (* TODO: I really don't like this ex_term *)
+  | TT_hole : { hole : ex_term hole } -> core term
   (* (x : A) -> B *)
   | TT_forall : { param : _ term; return : _ term } -> core term
   (* (x : A) => e *)
@@ -34,8 +35,7 @@ type _ term =
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
 
-(* TODO: I really don't like this ex_term *)
-and hole = { mutable link : ex_term }
+and 'a hole = { mutable link : 'a }
 
 and subst =
   (* -f := N *)


### PR DESCRIPTION
## Goals

Better error messages and a more unified way of typing patterns.

## Context

Patterns were removed from Teika at #140 because they're annoying to handle when doing elimination, here they're added back but only supported in the simple case of a single variable.

Additionally holes are added to help with resulting type from inference, whenever inference is used on a parameter, now a pattern hole is added there, allowing for further better messages.