### PR TITLE
teika: make current level the same as of variables

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -74,7 +74,7 @@ module Typer_context : sig
 
   (* TODO: next_var must be bigger than type_of_types *)
   val test :
-    next_var:Level.t ->
+    level:Level.t ->
     vars:(Level.t * ex_term) Name.Map.t ->
     expected_vars:var_info list ->
     received_vars:var_info list ->
@@ -99,6 +99,7 @@ module Typer_context : sig
 
   (* level *)
   val level : unit -> Level.t typer_context
+  val enter_level : (unit -> 'a typer_context) -> 'a typer_context
 
   (* vars *)
   val lookup_var : name:Name.t -> (Level.t * ex_term) typer_context


### PR DESCRIPTION
## Goals

A more intuitive mechanism for referencing to the last introduced free variable.

## Context

Currently there is no way to reference the last included free variable, making so that the only way of closing a term is by leaving the current level first, which is painful at some points and generate some uglier code, this PR changes the mechanism, to make so that the current level is actually the same of the last included free varfiable.