### PR TITLE
teika: support let aliasing

### DIFF
--- a/teika/context.mli
+++ b/teika/context.mli
@@ -51,7 +51,7 @@ module Typer_context : sig
   (* TODO: next_var must be bigger than type_of_types *)
   val test :
     level:Level.t ->
-    vars:(Level.t * ex_term) Name.Map.t ->
+    vars:(Level.t * ex_term * ex_term option) Name.Map.t ->
     expected_vars:var_info list ->
     received_vars:var_info list ->
     (unit -> 'a typer_context) ->
@@ -78,12 +78,15 @@ module Typer_context : sig
   val enter_level : (unit -> 'a typer_context) -> 'a typer_context
 
   (* vars *)
-  val lookup_var : name:Name.t -> (Level.t * ex_term) typer_context
+  val lookup_var :
+    name:Name.t -> (Level.t * ex_term * ex_term option) typer_context
+
   val with_expected_var : (unit -> 'a typer_context) -> 'a typer_context
 
   val with_received_var :
     name:Name.t ->
     type_:_ term ->
+    alias:_ term option ->
     (unit -> 'a typer_context) ->
     'a typer_context
 

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -13,7 +13,7 @@ let rec escape_check_term : type a. current:_ -> a term -> _ =
       (* TODO: very very important to check for bound vars, unification
             may unify variables outside of their binders *)
       return ()
-  | TT_free_var { level } -> (
+  | TT_free_var { level; alias = _ } -> (
       match Level.(current < level) with
       | true -> error_var_escape ~var:level
       | false -> return ())

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -383,6 +383,13 @@ module Typer = struct
     in
     check "unfold False" ~wrapper:false code
 
+  let let_alias =
+    check "let_alias" ~wrapper:false
+      {|
+        Id = (A : Type) => A;
+        (A => (x : A) => (x : Id A))
+      |}
+
   let tests =
     [
       id;
@@ -400,6 +407,7 @@ module Typer = struct
       ind_false_T;
       ind_false;
       unfold_false;
+      let_alias;
       (*
           pair;
           left_unpair;

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -132,7 +132,7 @@ let rec ptree_of_term : type a. _ -> _ -> _ -> a term -> _ =
   (* TODO: print details *)
   match expand_head_term term with
   | TT_bound_var { index } -> PT_var_index { index }
-  | TT_free_var { level } -> PT_var_level { level }
+  | TT_free_var { level; alias = _ } -> PT_var_level { level }
   | TT_hole { hole } -> ptree_of_hole @@ Ex_hole hole
   | TT_forall { param; return } ->
       let param = ptree_of_param param in

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -18,7 +18,7 @@ type _ term =
   | TT_typed : { term : _ term; annot : _ term } -> typed term
   | TT_subst : { subst : subst; term : _ term } -> subst term
   | TT_bound_var : { index : Index.t } -> core term
-  | TT_free_var : { level : Level.t } -> core term
+  | TT_free_var : { level : Level.t; alias : _ term option } -> core term
   | TT_hole : { hole : ex_term hole } -> core term
   | TT_forall : { param : typed pat; return : _ term } -> core term
   | TT_lambda : { param : typed pat; return : _ term } -> core term
@@ -63,8 +63,8 @@ let tt_open_bound ~from ~to_ term =
 let tt_close_free ~from ~to_ term =
   TT_subst { subst = TS_close_free { from; to_ }; term }
 
-let tt_nil = TT_free_var { level = nil_level }
-let tt_type = TT_free_var { level = type_level }
+let tt_nil = TT_free_var { level = nil_level; alias = None }
+let tt_type = TT_free_var { level = type_level; alias = None }
 
 let tt_hole () =
   let hole = { link = Ex_term tt_nil } in
@@ -74,7 +74,7 @@ let is_tt_nil (type a) (term : a term) =
   (* TODO: why not physical equality?
       Because TT_free_var is rebuilt in a couple places *)
   match term with
-  | TT_free_var { level } -> Level.equal nil_level level
+  | TT_free_var { level; alias = None } -> Level.equal nil_level level
   | _ -> false
 
 (* TODO: ugly hack *)

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -11,7 +11,8 @@ type _ term =
   (* x/-n *)
   | TT_bound_var : { index : Index.t } -> core term
   (* x/+n *)
-  | TT_free_var : { level : Level.t } -> core term
+  (* TODO: this alias is a hack *)
+  | TT_free_var : { level : Level.t; alias : _ term option } -> core term
   (* TODO: I really don't like this ex_term *)
   (* _x/+n *)
   | TT_hole : { hole : ex_term hole } -> core term

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -35,7 +35,7 @@ let rec occurs_term : type a. _ -> in_:a term -> _ =
   let occurs_param ~in_ = occurs_param hole ~in_ in
   match expand_head_term in_ with
   | TT_bound_var { index = _ } -> return ()
-  | TT_free_var { level = _ } -> return ()
+  | TT_free_var { level = _; alias = _ } -> return ()
   (* TODO: use this substs? *)
   | TT_hole { hole = in_ } -> (
       match hole == in_ with
@@ -67,7 +67,8 @@ let rec unify_term : type e r. expected:e term -> received:r term -> _ =
       match Index.equal expected received with
       | true -> return ()
       | false -> error_bound_var_clash ~expected ~received)
-  | TT_free_var { level = expected }, TT_free_var { level = received } -> (
+  | ( TT_free_var { level = expected; alias = _ },
+      TT_free_var { level = received; alias = _ } ) -> (
       match Level.equal expected received with
       | true -> return ()
       | false -> error_free_var_clash ~expected ~received)


### PR DESCRIPTION
## Goals

Support type aliases.

## Context

Teika currently doesn't support type aliases, as let is sugar to lambdas and the only way of introducing aliases is through let, this PR hacks around that, this solution is clearly not ideal but allows me to move with next steps for Teika.