### PR TITLE
teika: support strings

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -53,6 +53,9 @@ module Unify_context = struct
 
   let[@inline always] error_var_occurs ~hole ~in_ =
     fail @@ TError_unify_var_occurs { hole; in_ }
+
+  let[@inline always] error_string_clash ~expected ~received =
+    fail @@ TError_unify_string_clash { expected; received }
 end
 
 module Typer_context = struct
@@ -67,12 +70,13 @@ module Typer_context = struct
   type 'a t = 'a typer_context
 
   let[@inline always] run f =
-    let level = type_level in
+    let level = string_level in
     let names = Name.Map.empty in
-    let type_name = Name.make "Type" in
     let vars =
       (* TODO: better place for constants *)
-      Name.Map.add type_name (type_level, Ex_term tt_type, None) names
+      names
+      |> Name.Map.add (Name.make "Type") (type_level, Ex_term tt_type, None)
+      |> Name.Map.add (Name.make "String") (string_level, Ex_term tt_type, None)
     in
     (* TODO: use proper stack *)
     let received_vars = [ Free ] in
@@ -108,9 +112,6 @@ module Typer_context = struct
 
   let[@inline always] error_pairs_not_implemented () =
     fail @@ TError_typer_pairs_not_implemented
-
-  let[@inline always] error_strings_not_implemented () =
-    fail @@ TError_typer_strings_not_implemented
 
   let[@inline always] error_not_a_forall ~type_ =
     let type_ = Ex_term type_ in

--- a/teika/context.ml
+++ b/teika/context.ml
@@ -109,6 +109,9 @@ module Typer_context = struct
   let[@inline always] error_pairs_not_implemented () =
     fail @@ TError_typer_pairs_not_implemented
 
+  let[@inline always] error_strings_not_implemented () =
+    fail @@ TError_typer_strings_not_implemented
+
   let[@inline always] error_not_a_forall ~type_ =
     let type_ = Ex_term type_ in
     fail @@ TError_typer_not_a_forall { type_ }

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -67,6 +67,7 @@ module Typer_context : sig
 
   (* errors *)
   val error_pairs_not_implemented : unit -> 'a typer_context
+  val error_strings_not_implemented : unit -> 'a typer_context
   val error_not_a_forall : type_:_ term -> 'a typer_context
   val error_var_escape : var:Level.t -> 'a typer_context
 

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -39,6 +39,9 @@ module Unify_context : sig
 
   val error_var_occurs :
     hole:ex_term hole -> in_:ex_term hole -> 'a unify_context
+
+  val error_string_clash :
+    expected:string -> received:string -> 'a unify_context
 end
 
 module Typer_context : sig
@@ -67,7 +70,6 @@ module Typer_context : sig
 
   (* errors *)
   val error_pairs_not_implemented : unit -> 'a typer_context
-  val error_strings_not_implemented : unit -> 'a typer_context
   val error_not_a_forall : type_:_ term -> 'a typer_context
   val error_var_escape : var:Level.t -> 'a typer_context
 

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -30,6 +30,7 @@ let rec escape_check_term : type a. current:_ -> a term -> _ =
   | TT_self { var = _; body } -> escape_check_term body
   | TT_fix { var = _; body } -> escape_check_term body
   | TT_unroll { term } -> escape_check_term term
+  | TT_string { literal = _ } -> return ()
 
 and escape_check_param ~current term =
   (* TODO: check pat? *)

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -37,6 +37,7 @@ let rec expand_head_term : type a. a term -> core term =
   | TT_let { bound = _; value; return } ->
       expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:value return
   | TT_annot { term; annot = _ } -> expand_head_term term
+  | TT_string _ as term -> term
 
 and expand_subst : type a. subst:subst -> a term -> core term =
  fun ~subst term ->
@@ -93,6 +94,7 @@ and expand_subst_bound_term :
   | TT_unroll { term } ->
       let term = tt_subst_bound ~from term in
       TT_unroll { term }
+  | TT_string _ as term -> term
 
 and expand_subst_bound_param : type t. from:_ -> to_:t term -> _ -> _ =
  fun ~from ~to_ pat ->
@@ -133,6 +135,7 @@ and expand_subst_free_term :
   | TT_unroll { term } ->
       let term = tt_subst_free term in
       TT_unroll { term }
+  | TT_string _ as term -> term
 
 and expand_subst_free_param : type t. from:_ -> to_:t term -> _ -> _ =
  fun ~from ~to_ pat ->
@@ -186,6 +189,7 @@ and expand_open_bound_term : type a. from:_ -> to_:_ -> a term -> core term =
   | TT_unroll { term } ->
       let term = tt_open_bound ~from term in
       TT_unroll { term }
+  | TT_string _ as term -> term
 
 and expand_open_bound_param ~from ~to_ pat =
   let (TP_typed { pat; annot }) = pat in
@@ -238,6 +242,7 @@ and expand_close_free_term : type a. from:_ -> to_:_ -> a term -> core term =
   | TT_unroll { term } ->
       let term = tt_close_free ~to_ term in
       TT_unroll { term }
+  | TT_string _ as term -> term
 
 and expand_close_free_param : from:_ -> to_:_ -> _ -> _ =
  fun ~from ~to_ pat ->

--- a/teika/lparser.ml
+++ b/teika/lparser.ml
@@ -33,7 +33,8 @@ let rec parse_term term =
             let right = parse_annot right in
             LT_exists { left; right }
         | ST_var _ | ST_extension _ | ST_forall _ | ST_lambda _ | ST_apply _
-        | ST_pair _ | ST_both _ | ST_semi _ | ST_parens _ | ST_braces _ ->
+        | ST_pair _ | ST_both _ | ST_semi _ | ST_string _ | ST_parens _
+        | ST_braces _ ->
             invalid_notation loc)
     | ST_both _ -> invalid_notation loc
     | ST_bind _ -> invalid_notation loc
@@ -49,13 +50,14 @@ let rec parse_term term =
             let return = parse_term right in
             LT_let { bound; return }
         | ST_var _ | ST_extension _ | ST_forall _ | ST_lambda _ | ST_apply _
-        | ST_pair _ | ST_both _ | ST_semi _ | ST_annot _ | ST_parens _
-        | ST_braces _ ->
+        | ST_pair _ | ST_both _ | ST_semi _ | ST_annot _ | ST_string _
+        | ST_parens _ | ST_braces _ ->
             invalid_notation left_loc)
     | ST_annot { value; annot } ->
         let term = parse_term value in
         let annot = parse_term annot in
         LT_annot { term; annot }
+    | ST_string { literal } -> LT_string { literal }
     | ST_braces _ -> invalid_notation loc
   in
   LT_loc { term; loc }
@@ -89,7 +91,7 @@ and parse_pat term =
         let annot = parse_term annot in
         LP_annot { pat; annot }
     | ST_extension _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_both _
-    | ST_bind _ | ST_semi _ | ST_braces _ ->
+    | ST_bind _ | ST_semi _ | ST_string _ | ST_braces _ ->
         invalid_notation loc
   in
   LP_loc { pat; loc }
@@ -103,7 +105,7 @@ and parse_annot annot =
       let annot = parse_term annot in
       LAnnot { loc; pat; annot }
   | ST_var _ | ST_extension _ | ST_forall _ | ST_lambda _ | ST_apply _
-  | ST_pair _ | ST_both _ | ST_bind _ | ST_semi _ | ST_braces _ ->
+  | ST_pair _ | ST_both _ | ST_bind _ | ST_semi _ | ST_string _ | ST_braces _ ->
       invalid_notation loc
 
 and parse_bind bind =
@@ -115,7 +117,8 @@ and parse_bind bind =
       let value = parse_term value in
       LBind { loc; pat; value }
   | ST_var _ | ST_extension _ | ST_forall _ | ST_lambda _ | ST_apply _
-  | ST_pair _ | ST_both _ | ST_semi _ | ST_annot _ | ST_braces _ ->
+  | ST_pair _ | ST_both _ | ST_semi _ | ST_annot _ | ST_string _ | ST_braces _
+    ->
       invalid_notation loc
 
 (* TODO: rename this*)

--- a/teika/ltree.ml
+++ b/teika/ltree.ml
@@ -8,6 +8,7 @@ type term =
   | LT_pair of { left : bind; right : bind }
   | LT_let of { bound : bind; return : term }
   | LT_annot of { term : term; annot : term }
+  | LT_string of { literal : string }
   | LT_loc of { term : term; loc : Location.t [@opaque] }
 
 and pat =

--- a/teika/ltree.mli
+++ b/teika/ltree.mli
@@ -17,6 +17,8 @@ type term =
   | LT_let of { bound : bind; return : term }
   (* (v : T) *)
   | LT_annot of { term : term; annot : term }
+  (* ".." *)
+  | LT_string of { literal : string }
   | LT_loc of { term : term; loc : Location.t }
 
 and pat =

--- a/teika/slexer.ml
+++ b/teika/slexer.ml
@@ -9,6 +9,7 @@ let alphabet = [%sedlex.regexp? 'a' .. 'z' | 'A' .. 'Z']
 let digit = [%sedlex.regexp? '0' .. '9']
 let variable = [%sedlex.regexp? (alphabet | '_'), Star (alphabet | digit | '_')]
 let extension = [%sedlex.regexp? '@', variable]
+let string = [%sedlex.regexp? '"', Star (Sub (any, '"')), '"']
 
 let rec tokenizer buf =
   match%sedlex buf with
@@ -18,11 +19,16 @@ let rec tokenizer buf =
   | ":" -> COLON
   | "->" -> ARROW
   | "=>" -> FAT_ARROW
-  | "=>" -> FAT_ARROW
   | "=" -> EQUAL
   | "," -> COMMA
   | "&" -> AMPERSAND
   | ";" -> SEMICOLON
+  | string ->
+      (* TODO: this should probably be somewhere else *)
+      let literal = lexeme buf in
+      (* TODO: this is dangerous *)
+      let literal = String.sub literal 1 (String.length literal - 2) in
+      STRING literal
   | "(" -> LEFT_PARENS
   | ")" -> RIGHT_PARENS
   | "{" -> LEFT_BRACE

--- a/teika/sparser.mly
+++ b/teika/sparser.mly
@@ -13,6 +13,7 @@ let mk (loc_start, loc_end) =
 %token COMMA (* , *)
 %token AMPERSAND (* & *)
 %token SEMICOLON (* ; *)
+%token <string> STRING (* ".." *)
 %token LEFT_PARENS (* ( *)
 %token RIGHT_PARENS (* ) *)
 %token LEFT_BRACE (* { *)
@@ -53,6 +54,7 @@ let term_rec_apply :=
 let term_atom :=
   | term_var
   | term_extension
+  | term_string
   | term_parens(term_wrapped)
   | term_braces(term_wrapped)
 
@@ -100,6 +102,9 @@ let term_semi(self, lower) ==
 let term_annot(self, lower) ==
   | value = lower; COLON; annot = self;
     { st_annot (mk $loc) ~value ~annot }
+let term_string ==
+  | literal = STRING;
+    { st_string (mk $loc) ~literal }
 let term_parens(content) ==
   | LEFT_PARENS; content = content; RIGHT_PARENS;
     { st_parens (mk $loc) ~content }

--- a/teika/stree.ml
+++ b/teika/stree.ml
@@ -11,6 +11,7 @@ and term_desc =
   | ST_bind of { bound : term; value : term }
   | ST_semi of { left : term; right : term }
   | ST_annot of { value : term; annot : term }
+  | ST_string of { literal : string }
   | ST_parens of { content : term }
   | ST_braces of { content : term }
 [@@deriving show { with_path = false }]
@@ -26,5 +27,6 @@ let st_both loc ~left ~right = st loc (ST_both { left; right })
 let st_bind loc ~bound ~value = st loc (ST_bind { bound; value })
 let st_semi loc ~left ~right = st loc (ST_semi { left; right })
 let st_annot loc ~value ~annot = st loc (ST_annot { value; annot })
+let st_string loc ~literal = st loc (ST_string { literal })
 let st_parens loc ~content = st loc (ST_parens { content })
 let st_braces loc ~content = st loc (ST_braces { content })

--- a/teika/stree.mli
+++ b/teika/stree.mli
@@ -11,6 +11,7 @@ and term_desc = private
   | ST_bind of { bound : term; value : term }
   | ST_semi of { left : term; right : term }
   | ST_annot of { value : term; annot : term }
+  | ST_string of { literal : string }
   | ST_parens of { content : term }
   | ST_braces of { content : term }
 [@@deriving show]
@@ -25,5 +26,6 @@ val st_both : Location.t -> left:term -> right:term -> term
 val st_bind : Location.t -> bound:term -> value:term -> term
 val st_semi : Location.t -> left:term -> right:term -> term
 val st_annot : Location.t -> value:term -> annot:term -> term
+val st_string : Location.t -> literal:string -> term
 val st_parens : Location.t -> content:term -> term
 val st_braces : Location.t -> content:term -> term

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -18,13 +18,13 @@ type error =
       hole : ex_term hole; [@printer Tprinter.pp_ex_term_hole]
       in_ : ex_term hole; [@printer Tprinter.pp_ex_term_hole]
     }
+  | TError_unify_string_clash of { expected : string; received : string }
   (* typer *)
   | TError_typer_unknown_var of { name : Name.t }
   | TError_typer_not_a_forall of {
       type_ : ex_term; [@printer Tprinter.pp_ex_term]
     }
   | TError_typer_pairs_not_implemented
-  | TError_typer_strings_not_implemented
   | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {
       extension : Name.t;

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -24,6 +24,7 @@ type error =
       type_ : ex_term; [@printer Tprinter.pp_ex_term]
     }
   | TError_typer_pairs_not_implemented
+  | TError_typer_strings_not_implemented
   | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {
       extension : Name.t;

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -17,6 +17,7 @@ type error =
   | TError_typer_unknown_var of { name : Name.t }
   | TError_typer_not_a_forall of { type_ : ex_term }
   | TError_typer_pairs_not_implemented
+  | TError_typer_strings_not_implemented
   | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {
       extension : Name.t;

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -13,11 +13,11 @@ type error =
       received_norm : core term;
     }
   | TError_unify_var_occurs of { hole : ex_term hole; in_ : ex_term hole }
+  | TError_unify_string_clash of { expected : string; received : string }
   (* typer *)
   | TError_typer_unknown_var of { name : Name.t }
   | TError_typer_not_a_forall of { type_ : ex_term }
   | TError_typer_pairs_not_implemented
-  | TError_typer_strings_not_implemented
   | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {
       extension : Name.t;

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -396,6 +396,9 @@ module Typer = struct
         (A => (x : A) => (x : Id A))
       |}
 
+  let simple_string =
+    check "simple_string" ~wrapper:false {|("simple string" : String)|}
+
   let tests =
     [
       id;
@@ -414,6 +417,7 @@ module Typer = struct
       ind_false;
       unfold_false;
       let_alias;
+      simple_string;
       (*
           pair;
           left_unpair;

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -22,6 +22,7 @@ module Stree_utils = struct
     | ST_bind of { bound : term; value : term }
     | ST_semi of { left : term; right : term }
     | ST_annot of { value : term; annot : term }
+    | ST_string of { literal : string }
     | ST_parens of { content : term }
     | ST_braces of { content : term }
   [@@deriving eq]
@@ -45,6 +46,7 @@ module Stree_utils = struct
   let ( = ) bound value = st_bind loc ~bound ~value
   let ( * ) left right = st_semi loc ~left ~right
   let ( @: ) value annot = st_annot loc ~value ~annot
+  let string literal = st_string loc ~literal
   let parens content = st_parens loc ~content
   let braces content = st_braces loc ~content
 end
@@ -89,6 +91,7 @@ module Sparser = struct
       ("annot", works "(x : y)" (parens (var "x" @: var "y")));
       ( "nested annot",
         works "(x : A : B)" (parens (var "x" @: var "A" @: var "B")) );
+      ("string", works {|"hello"|} (string "hello"));
       ("parens", works "(x)" (parens (var "x")));
       ("braces", works "{x}" (braces (var "x")));
       ( "let",
@@ -143,13 +146,14 @@ module Ltree_utils = struct
     | ( LT_annot { term = a_term; annot = a_annot },
         LT_annot { term = b_term; annot = b_annot } ) ->
         equal_term a_term b_term && equal_term a_annot b_annot
+    | LT_string { literal = a }, LT_string { literal = b } -> String.equal a b
     (* TODO: loc equality *)
     | LT_loc { term = a; loc = _ }, b | a, LT_loc { term = b; loc = _ } ->
         equal_term a b
     | ( ( LT_var _ | LT_extension _ | LT_forall _ | LT_lambda _ | LT_apply _
-        | LT_exists _ | LT_pair _ | LT_let _ | LT_annot _ ),
+        | LT_exists _ | LT_pair _ | LT_let _ | LT_annot _ | LT_string _ ),
         ( LT_var _ | LT_extension _ | LT_forall _ | LT_lambda _ | LT_apply _
-        | LT_exists _ | LT_pair _ | LT_let _ | LT_annot _ ) ) ->
+        | LT_exists _ | LT_pair _ | LT_let _ | LT_annot _ | LT_string _ ) ) ->
         false
 
   and equal_pat a b =
@@ -200,6 +204,7 @@ module Ltree_utils = struct
   let let_ bound return = LT_let { bound; return }
   let ( $ ) left right = left right
   let annot term annot = LT_annot { term; annot }
+  let string literal = LT_string { literal }
   let ( @: ) pat annot = LAnnot { loc = Location.none; pat; annot }
   let ( @= ) pat value = LBind { loc = Location.none; pat; value }
 end
@@ -234,6 +239,7 @@ module Lparser = struct
           (let_ (pvar "x" @= var "y") $ (let_ (pvar "z" @= var "x") $ var "z"))
       );
       ("annot", works "(x : y)" (annot (var "x") (var "y")));
+      ("string", works {|"tuturu"|} (string "tuturu"));
     ]
 
   (* alcotest *)

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -21,6 +21,7 @@ module Ptree = struct
     | PT_unroll of { term : term }
     | PT_let of { var : Name.t; value : term; return : term }
     | PT_annot of { term : term; annot : term }
+    | PT_string of { literal : string }
 
   and subst =
     | PS_subst_bound : { from : Index.t; to_ : term } -> subst
@@ -74,6 +75,9 @@ module Ptree = struct
         fprintf fmt "%s = %a; %a" (Name.repr var) pp_funct value pp_let return
     | PT_annot { term; annot } ->
         fprintf fmt "%a : %a" pp_funct term pp_wrapped annot
+    | PT_string { literal } ->
+        (* TODO: is this correct *)
+        fprintf fmt {|"%S"|} literal
 
   type prec = Wrapped | Let | Funct | Apply | Atom
 
@@ -85,7 +89,7 @@ module Ptree = struct
     let pp_atom fmt term = pp_term Atom fmt term in
     match (term, prec) with
     | ( ( PT_loc _ | PT_var_name _ | PT_var_index _ | PT_var_level _
-        | PT_hole_var_full _ ),
+        | PT_hole_var_full _ | PT_string _ ),
         (Wrapped | Let | Funct | Apply | Atom) )
     | ( (PT_apply _ | PT_self _ | PT_fix _ | PT_unroll _),
         (Wrapped | Let | Funct | Apply) )
@@ -157,6 +161,7 @@ let rec ptree_of_term : type a. _ -> _ -> _ -> a term -> _ =
   | TT_unroll { term } ->
       let term = ptree_of_term term in
       PT_unroll { term }
+  | TT_string { literal } -> PT_string { literal }
 
 and ptree_of_param config next holes pat =
   let open Ptree in

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -29,6 +29,7 @@ type _ term =
   | TT_unfold : { term : _ term } -> sugar term
   | TT_let : { bound : _ pat; value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
+  | TT_string : { literal : string } -> core term
 
 and _ pat =
   (* TODO: TP_loc *)
@@ -50,6 +51,7 @@ and ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]
 
 let nil_level = Level.zero
 let type_level = Level.next nil_level
+let string_level = Level.next type_level
 
 let tt_subst_bound ~from ~to_ term =
   TT_subst { subst = TS_subst_bound { from; to_ }; term }
@@ -65,6 +67,7 @@ let tt_close_free ~from ~to_ term =
 
 let tt_nil = TT_free_var { level = nil_level; alias = None }
 let tt_type = TT_free_var { level = type_level; alias = None }
+let string_type = TT_free_var { level = string_level; alias = None }
 
 let tt_hole () =
   let hole = { link = Ex_term tt_nil } in

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -37,6 +37,8 @@ type _ term =
   | TT_let : { bound : _ pat; value : _ term; return : _ term } -> sugar term
   (* (v : T) *)
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
+  (* ".." *)
+  | TT_string : { literal : string } -> core term
 
 and _ pat =
   | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
@@ -62,6 +64,7 @@ and ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]
 
 val nil_level : Level.t
 val type_level : Level.t
+val string_level : Level.t
 
 (* constructors *)
 val tt_subst_bound : from:Index.t -> to_:_ term -> _ term -> subst term
@@ -70,6 +73,7 @@ val tt_open_bound : from:Index.t -> to_:Level.t -> _ term -> subst term
 val tt_close_free : from:Level.t -> to_:Index.t -> _ term -> subst term
 val tt_nil : core term
 val tt_type : core term
+val string_type : core term
 val tt_hole : unit -> core term
 val is_tt_nil : _ term -> bool
 val tp_nil : core pat

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -67,6 +67,7 @@ let rec unfold_fix : type a. a term -> core term =
       | TT_fix { var = _; body } as term ->
           expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:term body
       | _ -> term)
+  | TT_string _ as term -> term
 
 let with_tt_loc ~loc f =
   with_loc ~loc @@ fun () ->
@@ -149,7 +150,9 @@ let rec check_term : type a. _ -> expected:a term -> _ =
       (* TODO: unify annot before or after check term *)
       let* term = check_term term ~expected:annot in
       wrapped @@ TT_annot { term; annot }
-  | LT_string _ -> error_strings_not_implemented ()
+  | LT_string { literal } ->
+      let* () = unify_term ~expected ~received:string_type in
+      wrapped @@ TT_string { literal }
   | LT_loc { term; loc } ->
       with_tt_loc ~loc @@ fun () -> check_term term ~expected
 

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -149,6 +149,7 @@ let rec check_term : type a. _ -> expected:a term -> _ =
       (* TODO: unify annot before or after check term *)
       let* term = check_term term ~expected:annot in
       wrapped @@ TT_annot { term; annot }
+  | LT_string _ -> error_strings_not_implemented ()
   | LT_loc { term; loc } ->
       with_tt_loc ~loc @@ fun () -> check_term term ~expected
 


### PR DESCRIPTION
## Goals

Built-in strings are easier to work with.

## Context

Currently strings can be easily encoded in Teika, but this doesn't provide a good UX, in the future we should hopefully have a mechanism to allow this to be described in terms of lambdas, but as this is currently not developed, I will be adding primitive types and operations.