### PR TITLE
teika: add support to native operations

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -123,6 +123,9 @@ module Typer_context = struct
   let[@inline always] error_typer_unknown_extension ~extension ~payload =
     fail @@ TError_typer_unknown_extension { extension; payload }
 
+  let[@inline always] error_typer_unknown_native ~native =
+    fail @@ TError_typer_unknown_native { native }
+
   let[@inline always] lookup_var ~name ~level:_ ~vars ~expected_vars:_
       ~received_vars:_ =
     match Name.Map.find_opt name vars with

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -76,6 +76,8 @@ module Typer_context : sig
   val error_typer_unknown_extension :
     extension:Name.t -> payload:Ltree.term -> 'a typer_context
 
+  val error_typer_unknown_native : native:string -> 'a typer_context
+
   (* level *)
   val level : unit -> Level.t typer_context
   val enter_level : (unit -> 'a typer_context) -> 'a typer_context

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -31,6 +31,7 @@ let rec escape_check_term : type a. current:_ -> a term -> _ =
   | TT_fix { var = _; body } -> escape_check_term body
   | TT_unroll { term } -> escape_check_term term
   | TT_string { literal = _ } -> return ()
+  | TT_native { native = _ } -> return ()
 
 and escape_check_param ~current term =
   (* TODO: check pat? *)

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -27,6 +27,7 @@ let rec expand_head_term : type a. a term -> core term =
              but it would be cool to check when in debug *)
           (* TODO: this could be done in O(1) with context extending *)
           expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:arg return
+      | TT_native { native } -> expand_head_native native ~arg
       | _lambda ->
           (* TODO: use expanded? *)
           term)
@@ -38,6 +39,10 @@ let rec expand_head_term : type a. a term -> core term =
       expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:value return
   | TT_annot { term; annot = _ } -> expand_head_term term
   | TT_string _ as term -> term
+  | TT_native _ as term -> term
+
+and expand_head_native : type a. _ -> arg:a term -> core term =
+ fun native ~arg -> match native with TN_debug -> expand_head_term arg
 
 and expand_subst : type a. subst:subst -> a term -> core term =
  fun ~subst term ->
@@ -95,6 +100,7 @@ and expand_subst_bound_term :
       let term = tt_subst_bound ~from term in
       TT_unroll { term }
   | TT_string _ as term -> term
+  | TT_native _ as term -> term
 
 and expand_subst_bound_param : type t. from:_ -> to_:t term -> _ -> _ =
  fun ~from ~to_ pat ->
@@ -136,6 +142,7 @@ and expand_subst_free_term :
       let term = tt_subst_free term in
       TT_unroll { term }
   | TT_string _ as term -> term
+  | TT_native _ as term -> term
 
 and expand_subst_free_param : type t. from:_ -> to_:t term -> _ -> _ =
  fun ~from ~to_ pat ->
@@ -190,6 +197,7 @@ and expand_open_bound_term : type a. from:_ -> to_:_ -> a term -> core term =
       let term = tt_open_bound ~from term in
       TT_unroll { term }
   | TT_string _ as term -> term
+  | TT_native _ as term -> term
 
 and expand_open_bound_param ~from ~to_ pat =
   let (TP_typed { pat; annot }) = pat in
@@ -243,6 +251,7 @@ and expand_close_free_term : type a. from:_ -> to_:_ -> a term -> core term =
       let term = tt_close_free ~to_ term in
       TT_unroll { term }
   | TT_string _ as term -> term
+  | TT_native _ as term -> term
 
 and expand_close_free_param : from:_ -> to_:_ -> _ -> _ =
  fun ~from ~to_ pat ->

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -30,5 +30,6 @@ type error =
       extension : Name.t;
       payload : Ltree.term;
     }
+  | TError_typer_unknown_native of { native : string }
 
 and t = error [@@deriving show { with_path = false }]

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -23,5 +23,6 @@ type error =
       extension : Name.t;
       payload : Ltree.term;
     }
+  | TError_typer_unknown_native of { native : string }
 
 type t = error [@@deriving show]

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -30,6 +30,7 @@ type _ term =
   | TT_let : { bound : _ pat; value : _ term; return : _ term } -> sugar term
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
   | TT_string : { literal : string } -> core term
+  | TT_native : { native : native } -> core term
 
 and _ pat =
   (* TODO: TP_loc *)
@@ -45,6 +46,7 @@ and subst =
   | TS_open_bound : { from : Index.t; to_ : Level.t } -> subst
   | TS_close_free : { from : Level.t; to_ : Index.t } -> subst
 
+and native = TN_debug
 and ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 and ex_pat = Ex_pat : _ term -> ex_pat [@@ocaml.unboxed]
 and ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -39,6 +39,8 @@ type _ term =
   | TT_annot : { term : _ term; annot : _ term } -> sugar term
   (* ".." *)
   | TT_string : { literal : string } -> core term
+  (* @native("debug") *)
+  | TT_native : { native : native } -> core term
 
 and _ pat =
   | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
@@ -58,6 +60,7 @@ and subst =
   (* +f `open` -t *)
   | TS_close_free : { from : Level.t; to_ : Index.t } -> subst
 
+and native = TN_debug
 and ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
 and ex_pat = Ex_pat : _ term -> ex_pat [@@ocaml.unboxed]
 and ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]


### PR DESCRIPTION
## Goals

Setup environment for easy native operations.

## Context

Currently there are no native operations in Teika, as only the calculus is implemented, this should change soon, while native operations may be worse for writing proofs they make up for it by being quite cheap to implement.