### PR TITLE
jsend: initial jtree design

### DIFF
--- a/jsend/emit.ml
+++ b/jsend/emit.ml
@@ -1,0 +1,31 @@
+open Utree
+open Jtree
+
+let rec emit_term : Utree.term -> expression =
+ fun term ->
+  match term with
+  (* TODO: sourcemap *)
+  | UT_loc { term; loc = _ } -> emit_term term
+  | UT_var { var } -> JE_var { var }
+  | UT_lambda { param; return } ->
+      let return = emit_term return in
+      JE_generator { param; return }
+  | UT_apply { lambda; arg } ->
+      let lambda = emit_term lambda in
+      let arg = emit_term arg in
+      let call = JE_call { lambda; arg } in
+      (* TODO: test optimization, if instanceof before yield *)
+      JE_yield { expression = call }
+  | UT_string { literal } -> JE_string { literal }
+  | UT_external { external_ } -> translate_external external_
+
+and translate_external : external_ -> expression =
+ fun external_ ->
+  let var =
+    match external_ with
+    | UE_type -> Var.type_
+    | UE_fix -> Var.fix
+    | UE_unit -> Var.unit
+    | UE_debug -> Var.debug
+  in
+  JE_var { var }

--- a/jsend/emit.mli
+++ b/jsend/emit.mli
@@ -1,0 +1,1 @@
+val emit_term : Utree.term -> Jtree.expression

--- a/jsend/jprinter.ml
+++ b/jsend/jprinter.ml
@@ -1,0 +1,37 @@
+open Jtree
+open Format
+
+(* TODO: identation *)
+let rec pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom fmt expression =
+  let pp_expression_syntax fmt expression =
+    pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom fmt expression
+  in
+  match expression with
+  | JE_loc { expression; loc = _ } -> pp_expression_syntax fmt expression
+  | JE_var { var } -> Var.pp fmt var
+  | JE_generator { param; return } ->
+      (* TODO: names on functions? *)
+      fprintf fmt "function* (%a) { return %a; }" Var.pp param pp_wrapped return
+  | JE_call { lambda; arg } ->
+      fprintf fmt "%a(%a)" pp_call lambda pp_wrapped arg
+  | JE_yield { expression } -> fprintf fmt "yield %a" pp_call expression
+  | JE_string { literal } ->
+      (* TODO: proper JS escaping *)
+      fprintf fmt "%S" literal
+
+type prec = Wrapped | Call | Atom
+
+let rec pp_expression prec fmt expression =
+  let pp_wrapped fmt term = pp_expression Wrapped fmt term in
+  let pp_call fmt term = pp_expression Call fmt term in
+  let pp_atom fmt term = pp_expression Atom fmt term in
+  match (expression, prec) with
+  | JE_loc { expression; loc = _ }, prec -> pp_expression prec fmt expression
+  | (JE_var _ | JE_string _), (Wrapped | Call | Atom)
+  | JE_call _, (Wrapped | Call)
+  | (JE_generator _ | JE_yield _), Wrapped ->
+      pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom fmt expression
+  | JE_call _, Atom | (JE_generator _ | JE_yield _), (Call | Atom) ->
+      fprintf fmt "(%a)" pp_wrapped expression
+
+let pp_expression fmt expression = pp_expression Wrapped fmt expression

--- a/jsend/jprinter.mli
+++ b/jsend/jprinter.mli
@@ -1,0 +1,2 @@
+val pp_expression : Format.formatter -> Jtree.expression -> unit
+

--- a/jsend/jtree.ml
+++ b/jsend/jtree.ml
@@ -1,0 +1,7 @@
+type expression =
+  | JE_loc of { expression : expression; loc : Location.t }
+  | JE_var of { var : Var.t }
+  | JE_generator of { param : Var.t; return : expression }
+  | JE_call of { lambda : expression; arg : expression }
+  | JE_yield of { expression : expression }
+  | JE_string of { literal : string }

--- a/jsend/jtree.mli
+++ b/jsend/jtree.mli
@@ -1,0 +1,8 @@
+type expression =
+  | JE_loc of { expression : expression; loc : Location.t }
+  | JE_var of { var : Var.t }
+  | JE_generator of { param : Var.t; return : expression }
+  (* TODO: not really a lambda and arg *)
+  | JE_call of { lambda : expression; arg : expression }
+  | JE_yield of { expression : expression }
+  | JE_string of { literal : string }

--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -1,0 +1,24 @@
+open Teika
+open Jsend
+
+let compile code =
+  let term = Option.get @@ Slexer.from_string Sparser.term_opt code in
+  let term = Lparser.from_stree term in
+  let term =
+    match Context.Typer_context.run @@ fun () -> Typer.infer_term term with
+    | Ok ttree -> ttree
+    | Error error ->
+        Format.eprintf "%a\n%!" Terror.pp error;
+        failwith "infer"
+  in
+
+  let term = Untype.untype_term term in
+  let term = Emit.emit_term term in
+  Format.printf "%a" Jprinter.pp_expression term
+
+let () =
+  compile
+    {|
+      Bool = (A : Type) -> (t : A) -> (f : A) -> A;
+      (A => t => f => t : Bool)
+    |}


### PR DESCRIPTION
## Goals

An initial implementation of the pipeline described at #159.

## Context

This implements the JavaScript tree, emit's jtree from utree and then print the jtree. This is a hackish implementation and currently relies heavily on the OCaml runtime.