### PR TITLE
teika: drop GADTs and closer code gen

### DIFF
--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -20,5 +20,5 @@ let () =
   compile
     {|
       Bool = (A : Type) -> (t : A) -> (f : A) -> A;
-      (A => t => f => t : Bool)
+      @native("debug")(A => t => f => t : Bool)
     |}

--- a/jsend/untype.mli
+++ b/jsend/untype.mli
@@ -1,3 +1,3 @@
 open Teika
 
-val untype_term : _ Ttree.term -> Utree.term
+val untype_term : Ttree.term -> Utree.term

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -24,21 +24,17 @@ module Unify_context : sig
   val ( let+ ) : 'a unify_context -> ('a -> 'b) -> 'b unify_context
 
   (* errors *)
+  val error_subst_found : expected:term -> received:term -> 'a unify_context
+  val error_annot_found : expected:term -> received:term -> 'a unify_context
+
   val error_bound_var_clash :
     expected:Index.t -> received:Index.t -> 'a unify_context
 
   val error_free_var_clash :
     expected:Level.t -> received:Level.t -> 'a unify_context
 
-  val error_type_clash :
-    expected:_ term ->
-    expected_norm:core term ->
-    received:_ term ->
-    received_norm:core term ->
-    'a unify_context
-
-  val error_var_occurs :
-    hole:ex_term hole -> in_:ex_term hole -> 'a unify_context
+  val error_type_clash : expected:term -> received:term -> 'a unify_context
+  val error_var_occurs : hole:term hole -> in_:term hole -> 'a unify_context
 
   val error_string_clash :
     expected:string -> received:string -> 'a unify_context
@@ -54,7 +50,7 @@ module Typer_context : sig
   (* TODO: next_var must be bigger than type_of_types *)
   val test :
     level:Level.t ->
-    vars:(Level.t * ex_term * ex_term option) Name.Map.t ->
+    vars:(Level.t * term * term option) Name.Map.t ->
     expected_vars:var_info list ->
     received_vars:var_info list ->
     (unit -> 'a typer_context) ->
@@ -70,7 +66,7 @@ module Typer_context : sig
 
   (* errors *)
   val error_pairs_not_implemented : unit -> 'a typer_context
-  val error_not_a_forall : type_:_ term -> 'a typer_context
+  val error_not_a_forall : type_:term -> 'a typer_context
   val error_var_escape : var:Level.t -> 'a typer_context
 
   val error_typer_unknown_extension :
@@ -83,15 +79,13 @@ module Typer_context : sig
   val enter_level : (unit -> 'a typer_context) -> 'a typer_context
 
   (* vars *)
-  val lookup_var :
-    name:Name.t -> (Level.t * ex_term * ex_term option) typer_context
-
+  val lookup_var : name:Name.t -> (Level.t * term * term option) typer_context
   val with_expected_var : (unit -> 'a typer_context) -> 'a typer_context
 
   val with_received_var :
     name:Name.t ->
-    type_:_ term ->
-    alias:_ term option ->
+    type_:term ->
+    alias:term option ->
     (unit -> 'a typer_context) ->
     'a typer_context
 

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -2,12 +2,15 @@ open Context.Typer_context
 open Ttree
 open Expand_head
 
-let rec escape_check_term : type a. current:_ -> a term -> _ =
- fun ~current term ->
+let rec escape_check_term ~current term =
   let escape_check_term term = escape_check_term ~current term in
-  let escape_check_param pat = escape_check_param ~current pat in
+  let escape_check_typed_pat pat = escape_check_typed_pat ~current pat in
+
   (* TODO: check without expand_head? *)
-  match expand_head_term term with
+  (* TODO: this should not be here *)
+  match tt_match @@ expand_head_term term with
+  | TT_subst { term; subst } ->
+      escape_check_term @@ expand_subst_term ~subst term
   | TT_bound_var { index = _ } ->
       (* TODO: also check bound var *)
       (* TODO: very very important to check for bound vars, unification
@@ -19,10 +22,10 @@ let rec escape_check_term : type a. current:_ -> a term -> _ =
       | false -> return ())
   | TT_hole _hole -> return ()
   | TT_forall { param; return } ->
-      let* () = escape_check_param param in
+      let* () = escape_check_typed_pat param in
       escape_check_term return
   | TT_lambda { param; return } ->
-      let* () = escape_check_param param in
+      let* () = escape_check_typed_pat param in
       escape_check_term return
   | TT_apply { lambda; arg } ->
       let* () = escape_check_term lambda in
@@ -30,13 +33,21 @@ let rec escape_check_term : type a. current:_ -> a term -> _ =
   | TT_self { var = _; body } -> escape_check_term body
   | TT_fix { var = _; body } -> escape_check_term body
   | TT_unroll { term } -> escape_check_term term
+  | TT_unfold { term } -> escape_check_term term
+  | TT_let { bound; value; return } ->
+      let* () = escape_check_typed_pat bound in
+      let* () = escape_check_term value in
+      escape_check_term return
+  | TT_annot { term; annot } ->
+      let* () = escape_check_term term in
+      escape_check_term annot
   | TT_string { literal = _ } -> return ()
   | TT_native { native = _ } -> return ()
 
-and escape_check_param ~current term =
+and escape_check_typed_pat ~current term =
   (* TODO: check pat? *)
-  let (TP_typed { pat = _; annot }) = term in
-  escape_check_term ~current annot
+  let (TPat { pat = _; type_ }) = term in
+  escape_check_term ~current type_
 
 let escape_check_term term =
   let* current = level () in

--- a/teika/escape_check.mli
+++ b/teika/escape_check.mli
@@ -1,4 +1,4 @@
 open Context.Typer_context
 open Ttree
 
-val escape_check_term : _ term -> unit typer_context
+val escape_check_term : term -> unit typer_context

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -1,82 +1,9 @@
 open Ttree
 
-(* TODO: better place than here  *)
-let tt_subst term subst = TT_subst { subst; term }
-
-let rec expand_head_term : type a. a term -> core term =
- fun term ->
-  match term with
-  | TT_loc { term; loc = _ } -> expand_head_term term
-  | TT_typed { term; annot = _ } -> expand_head_term term
-  | TT_subst { subst; term } -> expand_subst_term ~subst term
-  | TT_bound_var _ as term -> term
-  | TT_free_var { level = _; alias = Some alias } -> expand_head_term alias
-  | TT_free_var _ as term -> term
-  | TT_hole { hole } as term -> (
-      (* TODO: path compression *)
-      (* TODO: move this to machinery *)
-      let (Ex_term link) = hole.link in
-      match is_tt_nil link with
-      | true -> term
-      | false ->
-          (* TODO: path compression *)
-          expand_head_term link)
-  | TT_forall _ as term -> term
-  | TT_lambda _ as term -> term
-  | TT_apply { lambda; arg } as term -> (
-      match expand_head_term lambda with
-      | TT_lambda { param = _; return } ->
-          (* TODO: param is not used here,
-             but it would be cool to check when in debug *)
-          (* TODO: this could be done in O(1) with context extending *)
-          expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:arg return
-      | TT_native { native } -> expand_head_native native ~arg
-      | _lambda ->
-          (* TODO: use expanded? *)
-          term)
-  | TT_self _ as term -> term
-  | TT_fix _ as term -> term
-  | TT_unroll _ as term -> term
-  | TT_unfold { term } -> expand_head_term term
-  | TT_let { bound = _; value; return } ->
-      expand_head_term @@ tt_subst_bound ~from:Index.zero ~to_:value return
-  | TT_annot { term; annot = _ } -> expand_head_term term
-  | TT_string _ as term -> term
-  | TT_native _ as term -> term
-
-and expand_head_native : type a. _ -> arg:a term -> core term =
- fun native ~arg -> match native with TN_debug -> expand_head_term arg
-
-and expand_subst_term : type a. subst:subst -> a term -> core term =
- fun ~subst term ->
-  let expand_subst_param term = expand_subst_param ~subst term in
-  let when_bound_var index =
-    match subst with
-    | TS_subst_bound { from; to_ } -> (
-        match Index.equal from index with
-        | true -> expand_head_term to_
-        | false -> TT_bound_var { index })
-    | TS_subst_free { from = _; to_ = _ } -> TT_bound_var { index }
-    | TS_open_bound { from; to_ } -> (
-        match Index.equal from index with
-        | true -> TT_free_var { level = to_; alias = None }
-        | false -> TT_bound_var { index })
-    | TS_close_free { from = _; to_ = _ } -> TT_bound_var { index }
-  in
-  let when_free_var level =
-    match subst with
-    | TS_subst_bound { from = _; to_ = _ } ->
-        TT_free_var { level; alias = None }
-    | TS_subst_free { from; to_ } -> (
-        match Level.equal from level with
-        | true -> expand_head_term to_
-        | false -> TT_free_var { level; alias = None })
-    | TS_open_bound { from = _; to_ = _ } -> TT_free_var { level; alias = None }
-    | TS_close_free { from; to_ } -> (
-        match Level.equal from level with
-        | true -> TT_bound_var { index = to_ }
-        | false -> TT_free_var { level; alias = None })
-  in
+let rec expand_subst_term ~subst term =
+  (* TODO: check if term has same type as subst *)
+  tt_map_desc term @@ fun ~wrap term desc ->
+  let tt_subst term subst = wrap @@ TT_subst { term; subst } in
   let with_var subst =
     match subst with
     | TS_subst_bound { from; to_ } ->
@@ -92,51 +19,115 @@ and expand_subst_term : type a. subst:subst -> a term -> core term =
         let to_ = Index.(to_ + one) in
         TS_close_free { from; to_ }
   in
-  match expand_head_term term with
-  | TT_bound_var { index } -> when_bound_var index
-  | TT_free_var { level; alias = _ } -> when_free_var level
-  | TT_hole { hole = _ } as term -> term
+  match desc with
+  | TT_subst { term; subst = subst' } ->
+      let term = expand_subst_term ~subst:subst' term in
+      expand_subst_term ~subst term
+  | TT_bound_var { index } -> (
+      match subst with
+      | TS_subst_bound { from; to_ } -> (
+          match Index.equal from index with true -> to_ | false -> term)
+      | TS_subst_free { from = _; to_ = _ } -> term
+      | TS_open_bound { from; to_ } -> (
+          match Index.equal from index with
+          | true -> wrap @@ TT_free_var { level = to_; alias = None }
+          | false -> term)
+      | TS_close_free { from = _; to_ = _ } -> term)
+  | TT_free_var { level; alias = _ } -> (
+      match subst with
+      | TS_subst_bound { from = _; to_ = _ } -> term
+      | TS_subst_free { from; to_ } -> (
+          match Level.equal from level with true -> to_ | false -> term)
+      | TS_open_bound { from = _; to_ = _ } -> term
+      | TS_close_free { from; to_ } -> (
+          match Level.equal from level with
+          | true -> wrap @@ TT_bound_var { index = to_ }
+          | false -> term))
+  (* TODO: subst and hole *)
+  | TT_hole { hole = _ } -> term
   | TT_forall { param; return } ->
-      let param = expand_subst_param param in
+      let param = expand_subst_typed_pat ~subst param in
       let return = tt_subst return @@ with_var subst in
-      TT_forall { param; return }
+      wrap @@ TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = expand_subst_param param in
+      let param = expand_subst_typed_pat ~subst param in
       let return = tt_subst return @@ with_var subst in
-      TT_lambda { param; return }
+      wrap @@ TT_lambda { param; return }
   | TT_apply { lambda; arg } ->
       let lambda = tt_subst lambda subst in
       let arg = tt_subst arg subst in
-      TT_apply { lambda; arg }
+      wrap @@ TT_apply { lambda; arg }
   | TT_self { var; body } ->
       let body = tt_subst body @@ with_var subst in
-      TT_self { var; body }
+      wrap @@ TT_self { var; body }
   | TT_fix { var; body } ->
       let body = tt_subst body @@ with_var subst in
-      TT_fix { var; body }
+      wrap @@ TT_fix { var; body }
   | TT_unroll { term } ->
       let term = tt_subst term subst in
-      TT_unroll { term }
-  | TT_string _ as term -> term
-  | TT_native _ as term -> term
+      wrap @@ TT_unroll { term }
+  | TT_unfold { term } ->
+      let term = tt_subst term subst in
+      wrap @@ TT_unfold { term }
+  | TT_let { bound; value; return } ->
+      let bound = expand_subst_typed_pat ~subst bound in
+      let value = tt_subst value subst in
+      let return = tt_subst return @@ with_var subst in
+      wrap @@ TT_let { bound; value; return }
+  | TT_annot { term; annot } ->
+      let term = tt_subst term subst in
+      let annot = tt_subst annot subst in
+      wrap @@ TT_annot { term; annot }
+  | TT_string _ -> term
+  | TT_native _ -> term
 
-and expand_subst_param : subst:subst -> _ -> _ =
+and expand_subst_typed_pat : subst:subst -> _ -> _ =
  fun ~subst pat ->
-  let (TP_typed { pat; annot }) = pat in
-  let annot = tt_subst annot subst in
-  TP_typed { pat; annot }
+  let (TPat { pat; type_ }) = pat in
+  let type_ = expand_subst_term ~subst type_ in
+  TPat { pat; type_ }
 
-and expand_head_pat : type a. a pat -> _ =
- fun pat ->
-  match pat with
-  | TP_typed { pat; annot = _ } -> expand_head_pat pat
-  | TP_hole { hole } as pat -> (
+let rec expand_head_term term =
+  tt_map_desc term @@ fun ~wrap:_ term desc ->
+  match desc with
+  | TT_subst { term; subst } ->
+      expand_head_term @@ expand_subst_term ~subst term
+  | TT_bound_var _ -> term
+  | TT_free_var { level = _; alias = Some alias } -> expand_head_term alias
+  | TT_free_var _ -> term
+  | TT_hole { hole } -> (
       (* TODO: path compression *)
       (* TODO: move this to machinery *)
-      let link = hole.link in
-      match is_tp_nil link with
-      | true -> pat
-      | false ->
+      match hole.link with
+      | None -> term
+      | Some link ->
           (* TODO: path compression *)
-          expand_head_pat link)
-  | TP_var _ as pat -> pat
+          expand_head_term link)
+  | TT_forall _ -> term
+  | TT_lambda _ -> term
+  | TT_apply { lambda; arg } -> (
+      (* TODO: use expanded lambda? *)
+      match tt_match (expand_head_term lambda) with
+      | TT_lambda { param = _; return } ->
+          (* TODO: param is not used here,
+             but it would be cool to check when in debug *)
+          (* TODO: this could be done in O(1) with context extending *)
+          let subst = TS_subst_bound { from = Index.zero; to_ = arg } in
+          expand_head_term @@ expand_subst_term ~subst return
+      | TT_native { native } -> expand_head_native native ~arg
+      | _lambda -> term)
+  | TT_self _ -> term
+  | TT_fix _ -> term
+  | TT_unroll _ -> term
+  | TT_unfold { term } -> expand_head_term term
+  | TT_let { bound = _; value; return } ->
+      (* TODO: param is not used here,
+         but it would be cool to check when in debug *)
+      let subst = TS_subst_bound { from = Index.zero; to_ = value } in
+      expand_head_term @@ expand_subst_term ~subst return
+  | TT_annot { term; annot = _ } -> expand_head_term term
+  | TT_string _ -> term
+  | TT_native _ -> term
+
+and expand_head_native native ~arg =
+  match native with TN_debug -> expand_head_term arg

--- a/teika/expand_head.mli
+++ b/teika/expand_head.mli
@@ -1,4 +1,4 @@
 open Ttree
 
-val expand_head_term : _ term -> core term
-val expand_head_pat : _ pat -> core pat
+val expand_subst_term : subst:subst -> term -> term
+val expand_head_term : term -> term

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -1,29 +1,25 @@
 open Ttree
+open Tprinter
 
 type error =
   (* TODO: why track nested locations?
          Probably because things like macros exists *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* unify *)
+  | TError_unify_subst_found of { expected : term; received : term }
+  | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }
   | TError_unify_free_var_clash of { expected : Level.t; received : Level.t }
-  | TError_unify_type_clash of {
-      expected : ex_term; [@printer Tprinter.pp_ex_term]
-      expected_norm : core term; [@printer Tprinter.pp_term]
-      received : ex_term; [@printer Tprinter.pp_ex_term]
-      received_norm : core term; [@printer Tprinter.pp_term]
-    }
+  | TError_unify_type_clash of { expected : term; received : term }
     (* TODO: lazy names for errors *)
   | TError_unify_var_occurs of {
-      hole : ex_term hole; [@printer Tprinter.pp_ex_term_hole]
-      in_ : ex_term hole; [@printer Tprinter.pp_ex_term_hole]
+      hole : term hole; [@printer Tprinter.pp_term_hole]
+      in_ : term hole; [@printer Tprinter.pp_term_hole]
     }
   | TError_unify_string_clash of { expected : string; received : string }
   (* typer *)
   | TError_typer_unknown_var of { name : Name.t }
-  | TError_typer_not_a_forall of {
-      type_ : ex_term; [@printer Tprinter.pp_ex_term]
-    }
+  | TError_typer_not_a_forall of { type_ : term }
   | TError_typer_pairs_not_implemented
   | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -4,19 +4,16 @@ type error =
   (* metadata *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* unify *)
+  | TError_unify_subst_found of { expected : term; received : term }
+  | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }
   | TError_unify_free_var_clash of { expected : Level.t; received : Level.t }
-  | TError_unify_type_clash of {
-      expected : ex_term;
-      expected_norm : core term;
-      received : ex_term;
-      received_norm : core term;
-    }
-  | TError_unify_var_occurs of { hole : ex_term hole; in_ : ex_term hole }
+  | TError_unify_type_clash of { expected : term; received : term }
+  | TError_unify_var_occurs of { hole : term hole; in_ : term hole }
   | TError_unify_string_clash of { expected : string; received : string }
   (* typer *)
   | TError_typer_unknown_var of { name : Name.t }
-  | TError_typer_not_a_forall of { type_ : ex_term }
+  | TError_typer_not_a_forall of { type_ : term }
   | TError_typer_pairs_not_implemented
   | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,5 +1,4 @@
 open Ttree
 
-val pp_term : Format.formatter -> _ term -> unit
-val pp_ex_term_hole : Format.formatter -> ex_term hole -> unit
-val pp_ex_term : Format.formatter -> ex_term -> unit
+val pp_term : Format.formatter -> term -> unit
+val pp_term_hole : Format.formatter -> term hole -> unit

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -3,82 +3,82 @@ type typed = Typed
 type core = Core
 type sugar = Sugar
 
-type _ term =
-  | TT_loc : { term : _ term; loc : Location.t } -> loc term
-  | TT_typed : { term : _ term; annot : _ term } -> typed term
+type term =
+  | TTerm of { desc : term_desc; type_ : term }
+  | TType of { desc : term_desc }
+
+and term_desc =
   (* M[S]*)
-  | TT_subst : { subst : subst; term : _ term } -> subst term
+  | TT_subst of { term : term; subst : subst }
   (* x/-n *)
-  | TT_bound_var : { index : Index.t } -> core term
+  | TT_bound_var of { index : Index.t }
   (* x/+n *)
   (* TODO: this alias is a hack *)
-  | TT_free_var : { level : Level.t; alias : _ term option } -> core term
+  | TT_free_var of { level : Level.t; alias : term option }
   (* TODO: I really don't like this ex_term *)
   (* _x/+n *)
-  | TT_hole : { hole : ex_term hole } -> core term
+  | TT_hole of { hole : term hole }
   (* (x : A) -> B *)
-  | TT_forall : { param : typed pat; return : _ term } -> core term
+  | TT_forall of { param : typed_pat; return : term }
   (* (x : A) => e *)
-  | TT_lambda : { param : typed pat; return : _ term } -> core term
+  | TT_lambda of { param : typed_pat; return : term }
   (* l a *)
-  | TT_apply : { lambda : _ term; arg : _ term } -> core term
+  | TT_apply of { lambda : term; arg : term }
   (* @self(x -> e)*)
   (* TODO: why core pat? *)
-  | TT_self : { var : core pat; body : _ term } -> core term
+  | TT_self of { var : core_pat; body : term }
   (* @fix(x => e)*)
   (* TODO: why core pat? *)
-  | TT_fix : { var : core pat; body : _ term } -> core term
+  | TT_fix of { var : core_pat; body : term }
   (* @unroll(e)*)
-  | TT_unroll : { term : _ term } -> core term
+  | TT_unroll of { term : term }
   (* @unfold(e)*)
   (* TODO: technically not sugar *)
-  | TT_unfold : { term : _ term } -> sugar term
+  | TT_unfold of { term : term }
   (* x = t; u *)
-  | TT_let : { bound : _ pat; value : _ term; return : _ term } -> sugar term
+  | TT_let of { bound : typed_pat; value : term; return : term }
   (* (v : T) *)
-  | TT_annot : { term : _ term; annot : _ term } -> sugar term
+  | TT_annot of { term : term; annot : term }
   (* ".." *)
-  | TT_string : { literal : string } -> core term
+  | TT_string of { literal : string }
   (* @native("debug") *)
-  | TT_native : { native : native } -> core term
+  | TT_native of { native : native }
 
-and _ pat =
-  | TP_typed : { pat : _ pat; annot : _ term } -> typed pat
-  | TP_hole : { hole : core pat hole } -> core pat
+(* TODO: this could probably be avoided if there were dependent types *)
+and typed_pat = TPat of { pat : core_pat; type_ : term }
+
+and core_pat =
+  | TP_hole of { hole : core_pat hole }
   (* x *)
-  | TP_var : { name : Name.t } -> core pat
+  | TP_var of { name : Name.t }
 
-and 'a hole = { mutable link : 'a }
+and 'a hole = { mutable link : 'a option }
 
 and subst =
   (* -f := N *)
-  | TS_subst_bound : { from : Index.t; to_ : _ term } -> subst
+  | TS_subst_bound of { from : Index.t; to_ : term }
   (* +f := N *)
-  | TS_subst_free : { from : Level.t; to_ : _ term } -> subst
+  | TS_subst_free of { from : Level.t; to_ : term }
   (* -f `open` +t *)
-  | TS_open_bound : { from : Index.t; to_ : Level.t } -> subst
+  | TS_open_bound of { from : Index.t; to_ : Level.t }
   (* +f `open` -t *)
-  | TS_close_free : { from : Level.t; to_ : Index.t } -> subst
+  | TS_close_free of { from : Level.t; to_ : Index.t }
 
 and native = TN_debug
-and ex_term = Ex_term : _ term -> ex_term [@@ocaml.unboxed]
-and ex_pat = Ex_pat : _ term -> ex_pat [@@ocaml.unboxed]
-and ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]
 
 val nil_level : Level.t
 val type_level : Level.t
 val string_level : Level.t
 
+(* utils *)
+val tt_match : term -> term_desc
+val tp_repr : core_pat -> core_pat
+
+val tt_map_desc :
+  term -> (wrap:(term_desc -> term) -> term -> term_desc -> term) -> term
+
 (* constructors *)
-val tt_subst_bound : from:Index.t -> to_:_ term -> _ term -> subst term
-val tt_subst_free : from:Level.t -> to_:_ term -> _ term -> subst term
-val tt_open_bound : from:Index.t -> to_:Level.t -> _ term -> subst term
-val tt_close_free : from:Level.t -> to_:Index.t -> _ term -> subst term
-val tt_nil : core term
-val tt_type : core term
-val string_type : core term
-val tt_hole : unit -> core term
-val is_tt_nil : _ term -> bool
-val tp_nil : core pat
-val tp_hole : unit -> core pat
-val is_tp_nil : _ pat -> bool
+val tt_type : term
+val string_type : term
+val tt_hole : unit -> term_desc
+val tp_hole : unit -> core_pat

--- a/teika/typer.mli
+++ b/teika/typer.mli
@@ -1,4 +1,4 @@
 open Context
 open Ttree
 
-val infer_term : Ltree.term -> typed term Typer_context.t
+val infer_term : Ltree.term -> term Typer_context.t

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -1,4 +1,4 @@
 open Ttree
 open Context
 
-val unify_term : expected:_ term -> received:_ term -> unit Unify_context.t
+val unify_term : expected:term -> received:term -> unit Unify_context.t


### PR DESCRIPTION
## Goals

Simplify the codebase and make generated code closer to source code.

## Context

Currently Teika relies heavily on GADTs for the typed tree, this helps to keep the codebase clean but it is hard to enforce and leads to some annoying behavior in different steps of the compilation process.

Additionally, currently Untype is using the normalized source of tree to generate the code, while this may be desirable as an opt-in at some point, it currently makes the generated completely different from the input code, which is not desirable for debugging reasons.