### PR TITLE
teika: single typing context

### DIFF
--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -5,7 +5,7 @@ let compile code =
   let term = Option.get @@ Slexer.from_string Sparser.term_opt code in
   let term = Lparser.from_stree term in
   let term =
-    match Context.Typer_context.run @@ fun () -> Typer.infer_term term with
+    match Context.run @@ fun () -> Typer.infer_term term with
     | Ok ttree -> ttree
     | Error error ->
         Format.eprintf "%a\n%!" Terror.pp error;

--- a/teika/context.ml
+++ b/teika/context.ml
@@ -9,156 +9,118 @@ let[@inline always] error desc = { match_ = (fun ~ok:_ ~error -> error desc) }
 
 type var_info = Free
 
-module Unify_context = struct
-  type 'a unify_context =
-    expected_vars:var_info list ->
-    received_vars:var_info list ->
-    ('a, error) result
+type 'a context =
+  level:Level.t ->
+  (* TODO: Hashtbl *)
+  vars:(Level.t * term * term option) Name.Map.t ->
+  expected_vars:var_info list ->
+  received_vars:var_info list ->
+  ('a, error) result
 
-  type 'a t = 'a unify_context
+type 'a t = 'a context
 
-  let[@inline always] test ~expected_vars ~received_vars f =
-    (f () ~expected_vars ~received_vars).match_
-      ~ok:(fun value -> Ok value)
-      ~error:(fun desc -> Error desc)
+let[@inline always] run f =
+  let level = string_level in
+  let names = Name.Map.empty in
+  let vars =
+    (* TODO: better place for constants *)
+    names
+    |> Name.Map.add (Name.make "Type") (type_level, tt_type, None)
+    |> Name.Map.add (Name.make "String") (string_level, tt_type, None)
+  in
+  (* TODO: use proper stack *)
+  let received_vars = [ Free; Free ] in
+  let expected_vars = received_vars in
+  (* TODO: should Type be here? *)
+  (f () ~level ~vars ~expected_vars ~received_vars).match_
+    ~ok:(fun value -> Ok value)
+    ~error:(fun desc -> Error desc)
 
-  let[@inline always] return_raw value ~expected_vars:_ ~received_vars:_ = value
-  let[@inline always] return value = return_raw @@ ok value
-  let[@inline always] fail desc = return_raw @@ error desc
+let[@inline always] test ~level ~vars ~expected_vars ~received_vars f =
+  (f () ~level ~vars ~expected_vars ~received_vars).match_
+    ~ok:(fun value -> Ok value)
+    ~error:(fun desc -> Error desc)
 
-  let[@inline always] bind context f ~expected_vars ~received_vars =
-    (context ~expected_vars ~received_vars).match_
-      ~ok:(fun value -> f value ~expected_vars ~received_vars)
-      ~error
+let[@inline always] return_raw value ~level:_ ~vars:_ ~expected_vars:_
+    ~received_vars:_ =
+  value
 
-  let ( let* ) = bind
+let[@inline always] return value = return_raw @@ ok value
+let[@inline always] fail desc = return_raw @@ error desc
 
-  let[@inline always] ( let+ ) context f =
-    let* value = context in
-    return @@ f value
+let[@inline always] bind context f ~level ~vars ~expected_vars ~received_vars =
+  (context ~level ~vars ~expected_vars ~received_vars).match_
+    ~ok:(fun value -> f value ~level ~vars ~expected_vars ~received_vars)
+    ~error
 
-  let[@inline always] error_subst_found ~expected ~received =
-    fail @@ TError_unify_subst_found { expected; received }
+let ( let* ) = bind
 
-  let[@inline always] error_annot_found ~expected ~received =
-    fail @@ TError_unify_annot_found { expected; received }
+let[@inline always] ( let+ ) context f =
+  let* value = context in
+  return @@ f value
 
-  let[@inline always] error_bound_var_clash ~expected ~received =
-    fail @@ TError_unify_bound_var_clash { expected; received }
+let[@inline always] error_subst_found ~expected ~received =
+  fail @@ TError_unify_subst_found { expected; received }
 
-  let[@inline always] error_free_var_clash ~expected ~received =
-    fail @@ TError_unify_free_var_clash { expected; received }
+let[@inline always] error_annot_found ~expected ~received =
+  fail @@ TError_unify_annot_found { expected; received }
 
-  let[@inline always] error_type_clash ~expected ~received =
-    fail @@ TError_unify_type_clash { expected; received }
+let[@inline always] error_bound_var_clash ~expected ~received =
+  fail @@ TError_unify_bound_var_clash { expected; received }
 
-  let[@inline always] error_var_occurs ~hole ~in_ =
-    fail @@ TError_unify_var_occurs { hole; in_ }
+let[@inline always] error_free_var_clash ~expected ~received =
+  fail @@ TError_unify_free_var_clash { expected; received }
 
-  let[@inline always] error_string_clash ~expected ~received =
-    fail @@ TError_unify_string_clash { expected; received }
-end
+let[@inline always] error_type_clash ~expected ~received =
+  fail @@ TError_unify_type_clash { expected; received }
 
-module Typer_context = struct
-  type 'a typer_context =
-    level:Level.t ->
-    (* TODO: Hashtbl *)
-    vars:(Level.t * term * term option) Name.Map.t ->
-    expected_vars:var_info list ->
-    received_vars:var_info list ->
-    ('a, error) result
+let[@inline always] error_var_occurs ~hole ~in_ =
+  fail @@ TError_unify_var_occurs { hole; in_ }
 
-  type 'a t = 'a typer_context
+let[@inline always] error_string_clash ~expected ~received =
+  fail @@ TError_unify_string_clash { expected; received }
 
-  let[@inline always] run f =
-    let level = string_level in
-    let names = Name.Map.empty in
-    let vars =
-      (* TODO: better place for constants *)
-      names
-      |> Name.Map.add (Name.make "Type") (type_level, tt_type, None)
-      |> Name.Map.add (Name.make "String") (string_level, tt_type, None)
-    in
-    (* TODO: use proper stack *)
-    let received_vars = [ Free ] in
-    let expected_vars = received_vars in
-    (* TODO: should Type be here? *)
-    (f () ~level ~vars ~expected_vars ~received_vars).match_
-      ~ok:(fun value -> Ok value)
-      ~error:(fun desc -> Error desc)
+let[@inline always] error_pairs_not_implemented () =
+  fail @@ TError_typer_pairs_not_implemented
 
-  let[@inline always] test ~level ~vars ~expected_vars ~received_vars f =
-    (f () ~level ~vars ~expected_vars ~received_vars).match_
-      ~ok:(fun value -> Ok value)
-      ~error:(fun desc -> Error desc)
+let[@inline always] error_not_a_forall ~type_ =
+  fail @@ TError_typer_not_a_forall { type_ }
 
-  let[@inline always] return_raw value ~level:_ ~vars:_ ~expected_vars:_
-      ~received_vars:_ =
-    value
+let[@inline always] error_var_escape ~var =
+  fail @@ TError_typer_var_escape { var }
 
-  let[@inline always] return value = return_raw @@ ok value
-  let[@inline always] fail desc = return_raw @@ error desc
+let[@inline always] error_typer_unknown_extension ~extension ~payload =
+  fail @@ TError_typer_unknown_extension { extension; payload }
 
-  let[@inline always] bind context f ~level ~vars ~expected_vars ~received_vars
-      =
-    (context ~level ~vars ~expected_vars ~received_vars).match_
-      ~ok:(fun value -> f value ~level ~vars ~expected_vars ~received_vars)
-      ~error
+let[@inline always] error_typer_unknown_native ~native =
+  fail @@ TError_typer_unknown_native { native }
 
-  let ( let* ) = bind
+let[@inline always] lookup_var ~name ~level:_ ~vars ~expected_vars:_
+    ~received_vars:_ =
+  match Name.Map.find_opt name vars with
+  | Some (var, type_, alias) -> ok @@ (var, type_, alias)
+  | None -> error @@ TError_typer_unknown_var { name }
 
-  let[@inline always] ( let+ ) context f =
-    let* value = context in
-    return @@ f value
+let[@inline always] with_expected_var f ~level ~vars ~expected_vars
+    ~received_vars =
+  let expected_vars = Free :: expected_vars in
+  f () ~level ~vars ~expected_vars ~received_vars
 
-  let[@inline always] error_pairs_not_implemented () =
-    fail @@ TError_typer_pairs_not_implemented
+let[@inline always] with_received_var ~name ~type_ ~alias f ~level ~vars
+    ~expected_vars ~received_vars =
+  let level = Level.next level in
+  let alias = match alias with Some alias -> Some alias | None -> None in
+  let vars = Name.Map.add name (level, type_, alias) vars in
+  let received_vars = Free :: received_vars in
+  f () ~level ~vars ~expected_vars ~received_vars
 
-  let[@inline always] error_not_a_forall ~type_ =
-    fail @@ TError_typer_not_a_forall { type_ }
+let[@inline always] level () ~level ~vars:_ ~expected_vars:_ ~received_vars:_ =
+  ok level
 
-  let[@inline always] error_var_escape ~var =
-    fail @@ TError_typer_var_escape { var }
+let[@inline always] enter_level f ~level ~vars ~expected_vars ~received_vars =
+  let level = Level.next level in
+  f () ~level ~vars ~expected_vars ~received_vars
 
-  let[@inline always] error_typer_unknown_extension ~extension ~payload =
-    fail @@ TError_typer_unknown_extension { extension; payload }
-
-  let[@inline always] error_typer_unknown_native ~native =
-    fail @@ TError_typer_unknown_native { native }
-
-  let[@inline always] lookup_var ~name ~level:_ ~vars ~expected_vars:_
-      ~received_vars:_ =
-    match Name.Map.find_opt name vars with
-    | Some (var, type_, alias) -> ok @@ (var, type_, alias)
-    | None -> error @@ TError_typer_unknown_var { name }
-
-  let[@inline always] with_expected_var f ~level ~vars ~expected_vars
-      ~received_vars =
-    let expected_vars = Free :: expected_vars in
-    f () ~level ~vars ~expected_vars ~received_vars
-
-  let[@inline always] with_received_var ~name ~type_ ~alias f ~level ~vars
-      ~expected_vars ~received_vars =
-    let level = Level.next level in
-    let alias = match alias with Some alias -> Some alias | None -> None in
-    let vars = Name.Map.add name (level, type_, alias) vars in
-    let received_vars = Free :: received_vars in
-    f () ~level ~vars ~expected_vars ~received_vars
-
-  let[@inline always] level () ~level ~vars:_ ~expected_vars:_ ~received_vars:_
-      =
-    ok level
-
-  let[@inline always] enter_level f ~level ~vars ~expected_vars ~received_vars =
-    let level = Level.next level in
-    f () ~level ~vars ~expected_vars ~received_vars
-
-  let[@inline always] with_unify_context f ~level:_ ~vars:_ ~expected_vars
-      ~received_vars =
-    f () ~expected_vars ~received_vars
-
-  let[@inline always] with_loc ~loc f ~level ~vars ~expected_vars ~received_vars
-      =
-    (f () ~level ~vars ~expected_vars ~received_vars).match_ ~ok
-      ~error:(fun desc -> error @@ TError_loc { error = desc; loc })
-end
+let[@inline always] with_loc ~loc f ~level ~vars ~expected_vars ~received_vars =
+  (f () ~level ~vars ~expected_vars ~received_vars).match_ ~ok
+    ~error:(fun desc -> error @@ TError_loc { error = desc; loc })

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -2,97 +2,60 @@ open Ttree
 open Terror
 
 type var_info = Free
+type 'a context
+type 'a t = 'a context
 
-(* TODO: this is bad *)
-module Unify_context : sig
-  type 'a unify_context
-  type 'a t = 'a unify_context
+(* monad *)
+val run : (unit -> 'a context) -> ('a, error) result
 
-  (* monad *)
-  val test :
-    expected_vars:var_info list ->
-    received_vars:var_info list ->
-    (unit -> 'a unify_context) ->
-    ('a, error) result
+(* TODO: next_var must be bigger than type_of_types *)
+val test :
+  level:Level.t ->
+  vars:(Level.t * term * term option) Name.Map.t ->
+  expected_vars:var_info list ->
+  received_vars:var_info list ->
+  (unit -> 'a context) ->
+  ('a, error) result
 
-  val return : 'a -> 'a unify_context
-  val bind : 'a unify_context -> ('a -> 'b unify_context) -> 'b unify_context
+val return : 'a -> 'a context
+val bind : 'a context -> ('a -> 'b context) -> 'b context
+val ( let* ) : 'a context -> ('a -> 'b context) -> 'b context
+val ( let+ ) : 'a context -> ('a -> 'b) -> 'b context
 
-  val ( let* ) :
-    'a unify_context -> ('a -> 'b unify_context) -> 'b unify_context
+(* errors *)
+(* unify *)
+val error_subst_found : expected:term -> received:term -> 'a context
+val error_annot_found : expected:term -> received:term -> 'a context
+val error_bound_var_clash : expected:Index.t -> received:Index.t -> 'a context
+val error_free_var_clash : expected:Level.t -> received:Level.t -> 'a context
+val error_type_clash : expected:term -> received:term -> 'a context
+val error_var_occurs : hole:term hole -> in_:term hole -> 'a context
+val error_string_clash : expected:string -> received:string -> 'a context
 
-  val ( let+ ) : 'a unify_context -> ('a -> 'b) -> 'b unify_context
+(* typer *)
+val error_pairs_not_implemented : unit -> 'a context
+val error_not_a_forall : type_:term -> 'a context
+val error_var_escape : var:Level.t -> 'a context
 
-  (* errors *)
-  val error_subst_found : expected:term -> received:term -> 'a unify_context
-  val error_annot_found : expected:term -> received:term -> 'a unify_context
+val error_typer_unknown_extension :
+  extension:Name.t -> payload:Ltree.term -> 'a context
 
-  val error_bound_var_clash :
-    expected:Index.t -> received:Index.t -> 'a unify_context
+val error_typer_unknown_native : native:string -> 'a context
 
-  val error_free_var_clash :
-    expected:Level.t -> received:Level.t -> 'a unify_context
+(* level *)
+val level : unit -> Level.t context
+val enter_level : (unit -> 'a context) -> 'a context
 
-  val error_type_clash : expected:term -> received:term -> 'a unify_context
-  val error_var_occurs : hole:term hole -> in_:term hole -> 'a unify_context
+(* vars *)
+val lookup_var : name:Name.t -> (Level.t * term * term option) context
+val with_expected_var : (unit -> 'a context) -> 'a context
 
-  val error_string_clash :
-    expected:string -> received:string -> 'a unify_context
-end
+val with_received_var :
+  name:Name.t ->
+  type_:term ->
+  alias:term option ->
+  (unit -> 'a context) ->
+  'a context
 
-module Typer_context : sig
-  type 'a typer_context
-  type 'a t = 'a typer_context
-
-  (* monad *)
-  val run : (unit -> 'a typer_context) -> ('a, error) result
-
-  (* TODO: next_var must be bigger than type_of_types *)
-  val test :
-    level:Level.t ->
-    vars:(Level.t * term * term option) Name.Map.t ->
-    expected_vars:var_info list ->
-    received_vars:var_info list ->
-    (unit -> 'a typer_context) ->
-    ('a, error) result
-
-  val return : 'a -> 'a typer_context
-  val bind : 'a typer_context -> ('a -> 'b typer_context) -> 'b typer_context
-
-  val ( let* ) :
-    'a typer_context -> ('a -> 'b typer_context) -> 'b typer_context
-
-  val ( let+ ) : 'a typer_context -> ('a -> 'b) -> 'b typer_context
-
-  (* errors *)
-  val error_pairs_not_implemented : unit -> 'a typer_context
-  val error_not_a_forall : type_:term -> 'a typer_context
-  val error_var_escape : var:Level.t -> 'a typer_context
-
-  val error_typer_unknown_extension :
-    extension:Name.t -> payload:Ltree.term -> 'a typer_context
-
-  val error_typer_unknown_native : native:string -> 'a typer_context
-
-  (* level *)
-  val level : unit -> Level.t typer_context
-  val enter_level : (unit -> 'a typer_context) -> 'a typer_context
-
-  (* vars *)
-  val lookup_var : name:Name.t -> (Level.t * term * term option) typer_context
-  val with_expected_var : (unit -> 'a typer_context) -> 'a typer_context
-
-  val with_received_var :
-    name:Name.t ->
-    type_:term ->
-    alias:term option ->
-    (unit -> 'a typer_context) ->
-    'a typer_context
-
-  (* unify *)
-  val with_unify_context : (unit -> 'a Unify_context.t) -> 'a typer_context
-
-  (* locs *)
-  val with_loc :
-    loc:Location.t -> (unit -> 'a typer_context) -> 'a typer_context
-end
+(* locs *)
+val with_loc : loc:Location.t -> (unit -> 'a context) -> 'a context

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -1,5 +1,5 @@
-open Context.Typer_context
 open Ttree
+open Context
 open Expand_head
 
 let rec escape_check_term ~current term =

--- a/teika/escape_check.mli
+++ b/teika/escape_check.mli
@@ -1,4 +1,4 @@
-open Context.Typer_context
 open Ttree
+open Context
 
-val escape_check_term : term -> unit typer_context
+val escape_check_term : term -> unit context

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -267,9 +267,7 @@ module Ttree_utils = struct
   open Teika
   open Context
 
-  let infer_term term =
-    let open Typer_context in
-    run @@ fun () -> Typer.infer_term term
+  let infer_term term = run @@ fun () -> Typer.infer_term term
 
   (* let dump code =
        let stree = Slexer.from_string Sparser.term_opt code |> Option.get in

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -1,11 +1,8 @@
 open Ltree
 open Ttree
 open Context
-open Typer_context
 open Escape_check
-
-let unify_term ~expected ~received =
-  with_unify_context @@ fun () -> Unify.unify_term ~expected ~received
+open Unify
 
 let open_term term =
   (* TODO: this opening is weird *)

--- a/teika/typer.mli
+++ b/teika/typer.mli
@@ -1,4 +1,4 @@
-open Context
 open Ttree
+open Context
 
-val infer_term : Ltree.term -> term Typer_context.t
+val infer_term : Ltree.term -> term context

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -1,6 +1,5 @@
 open Ttree
 open Context
-open Unify_context
 open Expand_head
 
 (* TODO: ensure this is eliminated *)

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -1,4 +1,4 @@
 open Ttree
 open Context
 
-val unify_term : expected:term -> received:term -> unit Unify_context.t
+val unify_term : expected:term -> received:term -> unit context


### PR DESCRIPTION
## Goals

Prepare to integrate substitutions in the context.

## Context

Currently Teika has two different monadic context, Unify_context and Typer_context, while there is some advantages in this approach, they're currently minor and make it harder to change the context.