### PR TITLE
teika: multi context and more errors

### DIFF
--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -5,7 +5,7 @@ let compile code =
   let term = Option.get @@ Slexer.from_string Sparser.term_opt code in
   let term = Lparser.from_stree term in
   let term =
-    match Context.run @@ fun () -> Typer.infer_term term with
+    match Context.Typer_context.run @@ fun () -> Typer.infer_term term with
     | Ok ttree -> ttree
     | Error error ->
         Format.eprintf "%a\n%!" Terror.pp error;

--- a/teika/context.ml
+++ b/teika/context.ml
@@ -1,126 +1,134 @@
 open Ttree
 open Terror
 
-type ('a, 'b) result = { match_ : 'k. ok:('a -> 'k) -> error:('b -> 'k) -> 'k }
-[@@ocaml.unboxed]
+(* TODO: benchmark with @inline and continuations *)
+module Var_context = struct
+  type 'a var_context = level:Level.t -> ('a, error) result
+  type 'a t = 'a var_context
 
-let[@inline always] ok value = { match_ = (fun ~ok ~error:_ -> ok value) }
-let[@inline always] error desc = { match_ = (fun ~ok:_ ~error -> error desc) }
+  let return value ~level:_ = Ok value
+  let fail desc ~level:_ = Error desc
 
-type var_info = Free
+  let ( let* ) context f ~level =
+    match context ~level with
+    | Ok value -> f value ~level
+    | Error _ as error -> error
 
-type 'a context =
-  level:Level.t ->
-  (* TODO: Hashtbl *)
-  vars:(Level.t * term * term option) Name.Map.t ->
-  expected_vars:var_info list ->
-  received_vars:var_info list ->
-  ('a, error) result
+  let error_subst_found term = fail @@ TError_misc_subst_found { term }
+  let error_unfold_found term = fail @@ TError_misc_unfold_found { term }
+  let error_annot_found term = fail @@ TError_misc_annot_found { term }
+  let error_var_occurs ~hole ~in_ = fail @@ TError_misc_var_occurs { hole; in_ }
+  let error_var_escape ~var = fail @@ TError_misc_var_escape { var }
+  let level () ~level = Ok level
+end
 
-type 'a t = 'a context
+module Unify_context = struct
+  type 'a unify_context = level:Level.t -> ('a, error) result
+  type 'a t = 'a unify_context
 
-let[@inline always] run f =
-  let level = string_level in
-  let names = Name.Map.empty in
-  let vars =
-    (* TODO: better place for constants *)
-    names
-    |> Name.Map.add (Name.make "Type") (type_level, tt_type, None)
-    |> Name.Map.add (Name.make "String") (string_level, tt_type, None)
-  in
-  (* TODO: use proper stack *)
-  let received_vars = [ Free; Free ] in
-  let expected_vars = received_vars in
-  (* TODO: should Type be here? *)
-  (f () ~level ~vars ~expected_vars ~received_vars).match_
-    ~ok:(fun value -> Ok value)
-    ~error:(fun desc -> Error desc)
+  let return value ~level:_ = Ok value
+  let fail desc ~level:_ = Error desc
 
-let[@inline always] test ~level ~vars ~expected_vars ~received_vars f =
-  (f () ~level ~vars ~expected_vars ~received_vars).match_
-    ~ok:(fun value -> Ok value)
-    ~error:(fun desc -> Error desc)
+  let ( let* ) context f ~level =
+    match context ~level with
+    | Ok value -> f value ~level
+    | Error _ as error -> error
 
-let[@inline always] return_raw value ~level:_ ~vars:_ ~expected_vars:_
-    ~received_vars:_ =
-  value
+  let error_subst_found ~expected ~received =
+    fail @@ TError_unify_subst_found { expected; received }
 
-let[@inline always] return value = return_raw @@ ok value
-let[@inline always] fail desc = return_raw @@ error desc
+  let error_unfold_found ~expected ~received =
+    fail @@ TError_unify_unfold_found { expected; received }
 
-let[@inline always] bind context f ~level ~vars ~expected_vars ~received_vars =
-  (context ~level ~vars ~expected_vars ~received_vars).match_
-    ~ok:(fun value -> f value ~level ~vars ~expected_vars ~received_vars)
-    ~error
+  let error_annot_found ~expected ~received =
+    fail @@ TError_unify_annot_found { expected; received }
 
-let ( let* ) = bind
+  let error_bound_var_clash ~expected ~received =
+    fail @@ TError_unify_bound_var_clash { expected; received }
 
-let[@inline always] ( let+ ) context f =
-  let* value = context in
-  return @@ f value
+  let error_free_var_clash ~expected ~received =
+    fail @@ TError_unify_free_var_clash { expected; received }
 
-let[@inline always] error_subst_found ~expected ~received =
-  fail @@ TError_unify_subst_found { expected; received }
+  let error_type_clash ~expected ~received =
+    fail @@ TError_unify_type_clash { expected; received }
 
-let[@inline always] error_annot_found ~expected ~received =
-  fail @@ TError_unify_annot_found { expected; received }
+  let error_string_clash ~expected ~received =
+    fail @@ TError_unify_string_clash { expected; received }
 
-let[@inline always] error_bound_var_clash ~expected ~received =
-  fail @@ TError_unify_bound_var_clash { expected; received }
+  let with_free_vars f ~level =
+    let level = Level.next level in
+    f () ~level
 
-let[@inline always] error_free_var_clash ~expected ~received =
-  fail @@ TError_unify_free_var_clash { expected; received }
+  (* context *)
+  let with_expected_var_context f ~level = f () ~level
+  let with_received_var_context f ~level = f () ~level
+end
 
-let[@inline always] error_type_clash ~expected ~received =
-  fail @@ TError_unify_type_clash { expected; received }
+module Typer_context = struct
+  type 'a typer_context =
+    level:Level.t ->
+    (* TODO: Hashtbl *)
+    (* TODO: also think about word table as an optimization *)
+    vars:(Level.t * term * term option) Name.Map.t ->
+    ('a, error) result
 
-let[@inline always] error_var_occurs ~hole ~in_ =
-  fail @@ TError_unify_var_occurs { hole; in_ }
+  type 'a t = 'a typer_context
 
-let[@inline always] error_string_clash ~expected ~received =
-  fail @@ TError_unify_string_clash { expected; received }
+  let run f =
+    let level = string_level in
+    let names = Name.Map.empty in
+    let vars =
+      (* TODO: better place for constants *)
+      names
+      |> Name.Map.add (Name.make "Type") (type_level, tt_type, None)
+      |> Name.Map.add (Name.make "String") (string_level, tt_type, None)
+    in
+    (* TODO: should Type be here? *)
+    f () ~level ~vars
 
-let[@inline always] error_pairs_not_implemented () =
-  fail @@ TError_typer_pairs_not_implemented
+  let return value ~level:_ ~vars:_ = Ok value
+  let fail desc ~level:_ ~vars:_ = Error desc
 
-let[@inline always] error_not_a_forall ~type_ =
-  fail @@ TError_typer_not_a_forall { type_ }
+  let ( let* ) context f ~level ~vars =
+    match context ~level ~vars with
+    | Ok value -> f value ~level ~vars
+    | Error _ as error -> error
 
-let[@inline always] error_var_escape ~var =
-  fail @@ TError_typer_var_escape { var }
+  let ( let+ ) context f =
+    let* value = context in
+    return (f value)
 
-let[@inline always] error_typer_unknown_extension ~extension ~payload =
-  fail @@ TError_typer_unknown_extension { extension; payload }
+  let error_pairs_not_implemented () =
+    fail @@ TError_typer_pairs_not_implemented
 
-let[@inline always] error_typer_unknown_native ~native =
-  fail @@ TError_typer_unknown_native { native }
+  let error_unknown_extension ~extension ~payload =
+    fail @@ TError_typer_unknown_extension { extension; payload }
 
-let[@inline always] lookup_var ~name ~level:_ ~vars ~expected_vars:_
-    ~received_vars:_ =
-  match Name.Map.find_opt name vars with
-  | Some (var, type_, alias) -> ok @@ (var, type_, alias)
-  | None -> error @@ TError_typer_unknown_var { name }
+  let error_unknown_native ~native =
+    fail @@ TError_typer_unknown_native { native }
 
-let[@inline always] with_expected_var f ~level ~vars ~expected_vars
-    ~received_vars =
-  let expected_vars = Free :: expected_vars in
-  f () ~level ~vars ~expected_vars ~received_vars
+  let level () ~level ~vars:_ = Ok level
 
-let[@inline always] with_received_var ~name ~type_ ~alias f ~level ~vars
-    ~expected_vars ~received_vars =
-  let level = Level.next level in
-  let alias = match alias with Some alias -> Some alias | None -> None in
-  let vars = Name.Map.add name (level, type_, alias) vars in
-  let received_vars = Free :: received_vars in
-  f () ~level ~vars ~expected_vars ~received_vars
+  let enter_level f ~level ~vars =
+    let level = Level.next level in
+    f () ~level ~vars
 
-let[@inline always] level () ~level ~vars:_ ~expected_vars:_ ~received_vars:_ =
-  ok level
+  let with_free_vars ~name ~type_ ~alias f ~level ~vars =
+    let level = Level.next level in
+    let alias = match alias with Some alias -> Some alias | None -> None in
+    let vars = Name.Map.add name (level, type_, alias) vars in
+    f () ~level ~vars
 
-let[@inline always] enter_level f ~level ~vars ~expected_vars ~received_vars =
-  let level = Level.next level in
-  f () ~level ~vars ~expected_vars ~received_vars
+  let lookup_var ~name ~level:_ ~vars =
+    match Name.Map.find_opt name vars with
+    | Some (var, type_, alias) -> Ok (var, type_, alias)
+    | None -> Error (TError_typer_unknown_var { name })
 
-let[@inline always] with_loc ~loc f ~level ~vars ~expected_vars ~received_vars =
-  (f () ~level ~vars ~expected_vars ~received_vars).match_ ~ok
-    ~error:(fun desc -> error @@ TError_loc { error = desc; loc })
+  let with_loc ~loc f ~level ~vars =
+    match f () ~level ~vars with
+    | Ok _value as ok -> ok
+    | Error desc -> Error (TError_loc { error = desc; loc })
+
+  let with_var_context f ~level ~vars:_ = f () ~level
+  let with_unify_context f ~level ~vars:_ = f () ~level
+end

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -1,5 +1,6 @@
 open Ttree
 open Context
+open Var_context
 open Expand_head
 
 let rec escape_check_term ~current term =

--- a/teika/escape_check.mli
+++ b/teika/escape_check.mli
@@ -1,4 +1,5 @@
 open Ttree
 open Context
+open Var_context
 
-val escape_check_term : term -> unit context
+val escape_check_term : term -> unit var_context

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -5,23 +5,28 @@ type error =
   (* TODO: why track nested locations?
          Probably because things like macros exists *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
+  (* misc *)
+  | TError_misc_subst_found of { term : term }
+  | TError_misc_unfold_found of { term : term }
+  | TError_misc_annot_found of { term : term }
+  (* TODO: lazy names for errors *)
+  | TError_misc_var_occurs of {
+      hole : term hole; [@printer Tprinter.pp_term_hole]
+      in_ : term hole; [@printer Tprinter.pp_term_hole]
+    }
+  | TError_misc_var_escape of { var : Level.t }
   (* unify *)
   | TError_unify_subst_found of { expected : term; received : term }
+  | TError_unify_unfold_found of { expected : term; received : term }
   | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }
   | TError_unify_free_var_clash of { expected : Level.t; received : Level.t }
   | TError_unify_type_clash of { expected : term; received : term }
-    (* TODO: lazy names for errors *)
-  | TError_unify_var_occurs of {
-      hole : term hole; [@printer Tprinter.pp_term_hole]
-      in_ : term hole; [@printer Tprinter.pp_term_hole]
-    }
   | TError_unify_string_clash of { expected : string; received : string }
   (* typer *)
   | TError_typer_unknown_var of { name : Name.t }
   | TError_typer_not_a_forall of { type_ : term }
   | TError_typer_pairs_not_implemented
-  | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {
       extension : Name.t;
       payload : Ltree.term;

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -3,19 +3,28 @@ open Ttree
 type error =
   (* metadata *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
+  (* misc *)
+  | TError_misc_subst_found of { term : term }
+  | TError_misc_unfold_found of { term : term }
+  | TError_misc_annot_found of { term : term }
+  (* TODO: lazy names for errors *)
+  | TError_misc_var_occurs of {
+      hole : term hole; [@printer Tprinter.pp_term_hole]
+      in_ : term hole; [@printer Tprinter.pp_term_hole]
+    }
+  | TError_misc_var_escape of { var : Level.t }
   (* unify *)
   | TError_unify_subst_found of { expected : term; received : term }
+  | TError_unify_unfold_found of { expected : term; received : term }
   | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }
   | TError_unify_free_var_clash of { expected : Level.t; received : Level.t }
   | TError_unify_type_clash of { expected : term; received : term }
-  | TError_unify_var_occurs of { hole : term hole; in_ : term hole }
   | TError_unify_string_clash of { expected : string; received : string }
   (* typer *)
   | TError_typer_unknown_var of { name : Name.t }
   | TError_typer_not_a_forall of { type_ : term }
   | TError_typer_pairs_not_implemented
-  | TError_typer_var_escape of { var : Level.t }
   | TError_typer_unknown_extension of {
       extension : Name.t;
       payload : Ltree.term;

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -267,7 +267,7 @@ module Ttree_utils = struct
   open Teika
   open Context
 
-  let infer_term term = run @@ fun () -> Typer.infer_term term
+  let infer_term term = Typer_context.run @@ fun () -> Typer.infer_term term
 
   (* let dump code =
        let stree = Slexer.from_string Sparser.term_opt code |> Option.get in

--- a/teika/typer.mli
+++ b/teika/typer.mli
@@ -1,4 +1,5 @@
 open Ttree
 open Context
+open Typer_context
 
-val infer_term : Ltree.term -> term context
+val infer_term : Ltree.term -> term typer_context

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -1,4 +1,5 @@
 open Ttree
 open Context
+open Unify_context
 
-val unify_term : expected:term -> received:term -> unit context
+val unify_term : expected:term -> received:term -> unit unify_context


### PR DESCRIPTION
## Goals

Prepare for a context with substitutions.

## Context

I'm currently working on moving substitutions to the context, as described by #165. And due to that in the future more operations will require a context, like expand_head and printing, so this PR essentially reverses #164 and make a smaller context.