### PR TITLE
teika: rename random functions

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -6,7 +6,7 @@ module Var_context = struct
   type 'a var_context = level:Level.t -> ('a, error) result
   type 'a t = 'a var_context
 
-  let return value ~level:_ = Ok value
+  let pure value ~level:_ = Ok value
   let fail desc ~level:_ = Error desc
 
   let ( let* ) context f ~level =
@@ -26,7 +26,7 @@ module Unify_context = struct
   type 'a unify_context = level:Level.t -> ('a, error) result
   type 'a t = 'a unify_context
 
-  let return value ~level:_ = Ok value
+  let pure value ~level:_ = Ok value
   let fail desc ~level:_ = Error desc
 
   let ( let* ) context f ~level =
@@ -86,17 +86,13 @@ module Typer_context = struct
     (* TODO: should Type be here? *)
     f () ~level ~vars
 
-  let return value ~level:_ ~vars:_ = Ok value
+  let pure value ~level:_ ~vars:_ = Ok value
   let fail desc ~level:_ ~vars:_ = Error desc
 
   let ( let* ) context f ~level ~vars =
     match context ~level ~vars with
     | Ok value -> f value ~level ~vars
     | Error _ as error -> error
-
-  let ( let+ ) context f =
-    let* value = context in
-    return (f value)
 
   let error_pairs_not_implemented () =
     fail @@ TError_typer_pairs_not_implemented

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -6,7 +6,7 @@ module Var_context : sig
   type 'a t = 'a var_context
 
   (* monad *)
-  val return : 'a -> 'a var_context
+  val pure : 'a -> 'a var_context
   val ( let* ) : 'a var_context -> ('a -> 'b var_context) -> 'b var_context
 
   (* errors *)
@@ -25,7 +25,7 @@ module Unify_context : sig
   type 'a t = 'a unify_context
 
   (* monad *)
-  val return : 'a -> 'a unify_context
+  val pure : 'a -> 'a unify_context
 
   val ( let* ) :
     'a unify_context -> ('a -> 'b unify_context) -> 'b unify_context
@@ -60,12 +60,10 @@ module Typer_context : sig
 
   (* monad *)
   val run : (unit -> 'a typer_context) -> ('a, error) result
-  val return : 'a -> 'a typer_context
+  val pure : 'a -> 'a typer_context
 
   val ( let* ) :
     'a typer_context -> ('a -> 'b typer_context) -> 'b typer_context
-
-  val ( let+ ) : 'a typer_context -> ('a -> 'b) -> 'b typer_context
 
   (* error *)
   val error_pairs_not_implemented : unit -> 'a typer_context

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -10,7 +10,7 @@ let rec tt_escape_check ~current term =
   (* TODO: check without expand_head? *)
   (* TODO: this should not be here *)
   match tt_match @@ expand_head_term term with
-  | TT_subst { term; subst } -> tt_escape_check @@ expand_subst_term ~subst term
+  | TT_subst { term; subst } -> tt_escape_check @@ tt_expand_subst ~subst term
   | TT_bound_var { index = _ } ->
       (* TODO: also check bound var *)
       (* TODO: very very important to check for bound vars, unification

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -9,7 +9,7 @@ let rec tt_escape_check ~current term =
 
   (* TODO: check without expand_head? *)
   (* TODO: this should not be here *)
-  match tt_match @@ expand_head_term term with
+  match tt_match @@ tt_expand_head term with
   | TT_subst { term; subst } -> tt_escape_check @@ tt_expand_subst ~subst term
   | TT_bound_var { index = _ } ->
       (* TODO: also check bound var *)

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -15,12 +15,12 @@ let rec tt_escape_check ~current term =
       (* TODO: also check bound var *)
       (* TODO: very very important to check for bound vars, unification
             may unify variables outside of their binders *)
-      return ()
+      pure ()
   | TT_free_var { level; alias = _ } -> (
       match Level.(current < level) with
       | true -> error_var_escape ~var:level
-      | false -> return ())
-  | TT_hole _hole -> return ()
+      | false -> pure ())
+  | TT_hole _hole -> pure ()
   | TT_forall { param; return } ->
       let* () = tpat_escape_check param in
       tt_escape_check return
@@ -41,8 +41,8 @@ let rec tt_escape_check ~current term =
   | TT_annot { term; annot } ->
       let* () = tt_escape_check term in
       tt_escape_check annot
-  | TT_string { literal = _ } -> return ()
-  | TT_native { native = _ } -> return ()
+  | TT_string { literal = _ } -> pure ()
+  | TT_native { native = _ } -> pure ()
 
 and tpat_escape_check ~current term =
   (* TODO: check pat? *)

--- a/teika/escape_check.mli
+++ b/teika/escape_check.mli
@@ -2,4 +2,4 @@ open Ttree
 open Context
 open Var_context
 
-val escape_check_term : term -> unit var_context
+val tt_escape_check : term -> unit var_context

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -1,6 +1,6 @@
 open Ttree
 
-let rec expand_subst_term ~subst term =
+let rec tt_expand_subst ~subst term =
   (* TODO: check if term has same type as subst *)
   tt_map_desc term @@ fun ~wrap term desc ->
   let tt_subst term subst = wrap @@ TT_subst { term; subst } in
@@ -21,8 +21,8 @@ let rec expand_subst_term ~subst term =
   in
   match desc with
   | TT_subst { term; subst = subst' } ->
-      let term = expand_subst_term ~subst:subst' term in
-      expand_subst_term ~subst term
+      let term = tt_expand_subst ~subst:subst' term in
+      tt_expand_subst ~subst term
   | TT_bound_var { index } -> (
       match subst with
       | TS_subst_bound { from; to_ } -> (
@@ -46,11 +46,11 @@ let rec expand_subst_term ~subst term =
   (* TODO: subst and hole *)
   | TT_hole { hole = _ } -> term
   | TT_forall { param; return } ->
-      let param = expand_subst_typed_pat ~subst param in
+      let param = tpat_expand_subst ~subst param in
       let return = tt_subst return @@ with_var subst in
       wrap @@ TT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = expand_subst_typed_pat ~subst param in
+      let param = tpat_expand_subst ~subst param in
       let return = tt_subst return @@ with_var subst in
       wrap @@ TT_lambda { param; return }
   | TT_apply { lambda; arg } ->
@@ -70,7 +70,7 @@ let rec expand_subst_term ~subst term =
       let term = tt_subst term subst in
       wrap @@ TT_unfold { term }
   | TT_let { bound; value; return } ->
-      let bound = expand_subst_typed_pat ~subst bound in
+      let bound = tpat_expand_subst ~subst bound in
       let value = tt_subst value subst in
       let return = tt_subst return @@ with_var subst in
       wrap @@ TT_let { bound; value; return }
@@ -81,17 +81,16 @@ let rec expand_subst_term ~subst term =
   | TT_string _ -> term
   | TT_native _ -> term
 
-and expand_subst_typed_pat : subst:subst -> _ -> _ =
+and tpat_expand_subst : subst:subst -> _ -> _ =
  fun ~subst pat ->
   let (TPat { pat; type_ }) = pat in
-  let type_ = expand_subst_term ~subst type_ in
+  let type_ = tt_expand_subst ~subst type_ in
   TPat { pat; type_ }
 
 let rec expand_head_term term =
   tt_map_desc term @@ fun ~wrap:_ term desc ->
   match desc with
-  | TT_subst { term; subst } ->
-      expand_head_term @@ expand_subst_term ~subst term
+  | TT_subst { term; subst } -> expand_head_term @@ tt_expand_subst ~subst term
   | TT_bound_var _ -> term
   | TT_free_var { level = _; alias = Some alias } -> expand_head_term alias
   | TT_free_var _ -> term
@@ -113,7 +112,7 @@ let rec expand_head_term term =
              but it would be cool to check when in debug *)
           (* TODO: this could be done in O(1) with context extending *)
           let subst = TS_subst_bound { from = Index.zero; to_ = arg } in
-          expand_head_term @@ expand_subst_term ~subst return
+          expand_head_term @@ tt_expand_subst ~subst return
       | TT_native { native } -> expand_head_native native ~arg
       | _lambda -> term)
   | TT_self _ -> term
@@ -124,7 +123,7 @@ let rec expand_head_term term =
       (* TODO: param is not used here,
          but it would be cool to check when in debug *)
       let subst = TS_subst_bound { from = Index.zero; to_ = value } in
-      expand_head_term @@ expand_subst_term ~subst return
+      expand_head_term @@ tt_expand_subst ~subst return
   | TT_annot { term; annot = _ } -> expand_head_term term
   | TT_string _ -> term
   | TT_native _ -> term

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -87,12 +87,12 @@ and tpat_expand_subst : subst:subst -> _ -> _ =
   let type_ = tt_expand_subst ~subst type_ in
   TPat { pat; type_ }
 
-let rec expand_head_term term =
+let rec tt_expand_head term =
   tt_map_desc term @@ fun ~wrap:_ term desc ->
   match desc with
-  | TT_subst { term; subst } -> expand_head_term @@ tt_expand_subst ~subst term
+  | TT_subst { term; subst } -> tt_expand_head @@ tt_expand_subst ~subst term
   | TT_bound_var _ -> term
-  | TT_free_var { level = _; alias = Some alias } -> expand_head_term alias
+  | TT_free_var { level = _; alias = Some alias } -> tt_expand_head alias
   | TT_free_var _ -> term
   | TT_hole { hole } -> (
       (* TODO: path compression *)
@@ -101,32 +101,32 @@ let rec expand_head_term term =
       | None -> term
       | Some link ->
           (* TODO: path compression *)
-          expand_head_term link)
+          tt_expand_head link)
   | TT_forall _ -> term
   | TT_lambda _ -> term
   | TT_apply { lambda; arg } -> (
       (* TODO: use expanded lambda? *)
-      match tt_match (expand_head_term lambda) with
+      match tt_match (tt_expand_head lambda) with
       | TT_lambda { param = _; return } ->
           (* TODO: param is not used here,
              but it would be cool to check when in debug *)
           (* TODO: this could be done in O(1) with context extending *)
           let subst = TS_subst_bound { from = Index.zero; to_ = arg } in
-          expand_head_term @@ tt_expand_subst ~subst return
+          tt_expand_head @@ tt_expand_subst ~subst return
       | TT_native { native } -> expand_head_native native ~arg
       | _lambda -> term)
   | TT_self _ -> term
   | TT_fix _ -> term
   | TT_unroll _ -> term
-  | TT_unfold { term } -> expand_head_term term
+  | TT_unfold { term } -> tt_expand_head term
   | TT_let { bound = _; value; return } ->
       (* TODO: param is not used here,
          but it would be cool to check when in debug *)
       let subst = TS_subst_bound { from = Index.zero; to_ = value } in
-      expand_head_term @@ tt_expand_subst ~subst return
-  | TT_annot { term; annot = _ } -> expand_head_term term
+      tt_expand_head @@ tt_expand_subst ~subst return
+  | TT_annot { term; annot = _ } -> tt_expand_head term
   | TT_string _ -> term
   | TT_native _ -> term
 
 and expand_head_native native ~arg =
-  match native with TN_debug -> expand_head_term arg
+  match native with TN_debug -> tt_expand_head arg

--- a/teika/expand_head.mli
+++ b/teika/expand_head.mli
@@ -1,4 +1,4 @@
 open Ttree
 
 val tt_expand_subst : subst:subst -> term -> term
-val expand_head_term : term -> term
+val tt_expand_head : term -> term

--- a/teika/expand_head.mli
+++ b/teika/expand_head.mli
@@ -1,4 +1,4 @@
 open Ttree
 
-val expand_subst_term : subst:subst -> term -> term
+val tt_expand_subst : subst:subst -> term -> term
 val expand_head_term : term -> term

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -147,7 +147,7 @@ let rec ptree_of_term config next holes term =
   let ptree_of_hole hole = ptree_of_hole config next holes hole in
   (* TODO: print details *)
   match tt_match term with
-  | TT_subst { term; subst } -> ptree_of_term @@ expand_subst_term ~subst term
+  | TT_subst { term; subst } -> ptree_of_term @@ tt_expand_subst ~subst term
   | TT_bound_var { index } -> PT_var_index { index }
   | TT_free_var { level; alias = _ } -> PT_var_level { level }
   | TT_hole { hole } -> ptree_of_hole @@ Ex_hole hole

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -62,7 +62,7 @@ let rec unfold_fix term =
   (* TODO: not ideal to expand head *)
   tt_map_desc term @@ fun ~wrap term desc ->
   match desc with
-  | TT_subst { term; subst } -> unfold_fix @@ expand_subst_term ~subst term
+  | TT_subst { term; subst } -> unfold_fix @@ tt_expand_subst ~subst term
   | TT_bound_var _ -> term
   | TT_free_var _ -> term
   | TT_hole _ -> term
@@ -78,7 +78,7 @@ let rec unfold_fix term =
       match tt_match @@ expand_head_term fix with
       | TT_fix { var = _; body } ->
           let subst = TS_subst_bound { from = Index.zero; to_ = fix } in
-          expand_head_term @@ expand_subst_term ~subst body
+          expand_head_term @@ tt_expand_subst ~subst body
       | _ -> term)
   | TT_unfold { term } ->
       let term = unfold_fix term in

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -9,7 +9,7 @@ let escape_check_term term =
   with_var_context @@ fun () -> escape_check_term term
 
 let unify_term ~expected ~received =
-  with_unify_context @@ fun () -> unify_term ~expected ~received
+  with_unify_context @@ fun () -> tt_unify ~expected ~received
 
 let open_term term =
   (* TODO: this opening is weird *)

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -5,8 +5,7 @@ open Typer_context
 open Escape_check
 open Unify
 
-let escape_check_term term =
-  with_var_context @@ fun () -> escape_check_term term
+let escape_check_term term = with_var_context @@ fun () -> tt_escape_check term
 
 let unify_term ~expected ~received =
   with_unify_context @@ fun () -> tt_unify ~expected ~received

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -75,10 +75,10 @@ let rec unfold_fix term =
   | TT_self _ -> term
   | TT_fix _ -> term
   | TT_unroll { term = fix } -> (
-      match tt_match @@ expand_head_term fix with
+      match tt_match @@ tt_expand_head fix with
       | TT_fix { var = _; body } ->
           let subst = TS_subst_bound { from = Index.zero; to_ = fix } in
-          expand_head_term @@ tt_expand_subst ~subst body
+          tt_expand_head @@ tt_expand_subst ~subst body
       | _ -> term)
   | TT_unfold { term } ->
       let term = unfold_fix term in

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -23,15 +23,15 @@ open Expand_head
 
 (* TODO: diff is a bad name *)
 
-let rec occurs_term hole ~in_ =
+let rec tt_occurs hole ~in_ =
   let open Var_context in
   (* TODO: this is needed because of non injective functions
        the unification could succeed only if expand_head happened
 
      maybe should fail anyway ?
   *)
-  let occurs_term ~in_ = occurs_term hole ~in_ in
-  let occurs_typed_pat ~in_ = occurs_typed_pat hole ~in_ in
+  let tt_occurs ~in_ = tt_occurs hole ~in_ in
+  let tpat_occurs ~in_ = tpat_occurs hole ~in_ in
   match tt_match @@ expand_head_term in_ with
   (* TODO: frozen and subst *)
   | TT_subst _ -> error_subst_found in_
@@ -45,28 +45,28 @@ let rec occurs_term hole ~in_ =
       | true -> error_var_occurs ~hole ~in_
       | false -> return ())
   | TT_forall { param; return } ->
-      let* () = occurs_typed_pat ~in_:param in
-      occurs_term ~in_:return
+      let* () = tpat_occurs ~in_:param in
+      tt_occurs ~in_:return
   | TT_lambda { param; return } ->
-      let* () = occurs_typed_pat ~in_:param in
-      occurs_term ~in_:return
+      let* () = tpat_occurs ~in_:param in
+      tt_occurs ~in_:return
   | TT_apply { lambda; arg } ->
-      let* () = occurs_term ~in_:lambda in
-      occurs_term ~in_:arg
-  | TT_self { var = _; body } -> occurs_term ~in_:body
-  | TT_fix { var = _; body } -> occurs_term ~in_:body
-  | TT_unroll { term } -> occurs_term ~in_:term
+      let* () = tt_occurs ~in_:lambda in
+      tt_occurs ~in_:arg
+  | TT_self { var = _; body } -> tt_occurs ~in_:body
+  | TT_fix { var = _; body } -> tt_occurs ~in_:body
+  | TT_unroll { term } -> tt_occurs ~in_:term
   | TT_let { bound; value; return } ->
-      let* () = occurs_typed_pat ~in_:bound in
-      let* () = occurs_term ~in_:value in
-      occurs_term ~in_:return
+      let* () = tpat_occurs ~in_:bound in
+      let* () = tt_occurs ~in_:value in
+      tt_occurs ~in_:return
   | TT_string { literal = _ } -> return ()
   | TT_native { native = _ } -> return ()
 
-and occurs_typed_pat hole ~in_ =
+and tpat_occurs hole ~in_ =
   (* TODO: occurs inside of TP_hole *)
   let (TPat { pat = _; type_ }) = in_ in
-  occurs_term hole ~in_:type_
+  tt_occurs hole ~in_:type_
 
 let unify_term_hole hole ~to_ =
   let open Var_context in
@@ -74,13 +74,13 @@ let unify_term_hole hole ~to_ =
   | TT_hole { hole = to_ } when hole == to_ -> return ()
   | _ ->
       (* TODO: prefer a direction when both are holes? *)
-      let* () = occurs_term hole ~in_:to_ in
+      let* () = tt_occurs hole ~in_:to_ in
       hole.link <- Some to_;
       return ()
 
 open Unify_context
 
-let rec unify_term ~expected ~received =
+let rec tt_unify ~expected ~received =
   (* TODO: short circuit physical equality *)
   match
     ( tt_match @@ expand_head_term expected,
@@ -108,34 +108,28 @@ let rec unify_term ~expected ~received =
   | ( TT_forall { param = expected_param; return = expected_return },
       TT_forall { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
-      let* () =
-        unify_typed_pat ~expected:expected_param ~received:received_param
-      in
-      unify_term ~expected:expected_return ~received:received_return
+      let* () = tpat_unify ~expected:expected_param ~received:received_param in
+      tt_unify ~expected:expected_return ~received:received_return
   | ( TT_lambda { param = expected_param; return = expected_return },
       TT_lambda { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
-      let* () =
-        unify_typed_pat ~expected:expected_param ~received:received_param
-      in
-      unify_term ~expected:expected_return ~received:received_return
+      let* () = tpat_unify ~expected:expected_param ~received:received_param in
+      tt_unify ~expected:expected_return ~received:received_return
   | ( TT_apply { lambda = expected_lambda; arg = expected_arg },
       TT_apply { lambda = received_lambda; arg = received_arg } ) ->
-      let* () =
-        unify_term ~expected:expected_lambda ~received:received_lambda
-      in
-      unify_term ~expected:expected_arg ~received:received_arg
+      let* () = tt_unify ~expected:expected_lambda ~received:received_lambda in
+      tt_unify ~expected:expected_arg ~received:received_arg
   | ( TT_self { var = _; body = expected_body },
       TT_self { var = _; body = received_body } ) ->
-      unify_term ~expected:expected_body ~received:received_body
+      tt_unify ~expected:expected_body ~received:received_body
   | ( TT_fix { var = _; body = expected_body },
       TT_fix { var = _; body = received_body } ) ->
-      unify_term ~expected:expected_body ~received:received_body
+      tt_unify ~expected:expected_body ~received:received_body
   | TT_unroll { term = expected }, TT_unroll { term = received } ->
-      unify_term ~expected ~received
+      tt_unify ~expected ~received
   | TT_unfold { term = expected }, TT_unfold { term = received } ->
       (* TODO: does unfold equality makes sense? *)
-      unify_term ~expected ~received
+      tt_unify ~expected ~received
   | ( TT_let
         {
           bound = expected_bound;
@@ -149,11 +143,9 @@ let rec unify_term ~expected ~received =
           return = received_return;
         } ) ->
       (* TODO: contravariance *)
-      let* () =
-        unify_typed_pat ~expected:expected_bound ~received:received_bound
-      in
-      let* () = unify_term ~expected:expected_value ~received:received_value in
-      unify_term ~expected:expected_return ~received:received_return
+      let* () = tpat_unify ~expected:expected_bound ~received:received_bound in
+      let* () = tt_unify ~expected:expected_value ~received:received_value in
+      tt_unify ~expected:expected_return ~received:received_return
   | TT_string { literal = expected }, TT_string { literal = received } -> (
       match String.equal expected received with
       | true -> return ()
@@ -168,14 +160,14 @@ let rec unify_term ~expected ~received =
       | TT_string _ | TT_native _ ) ) ->
       error_type_clash ~expected ~received
 
-and unify_typed_pat ~expected ~received =
+and tpat_unify ~expected ~received =
   (* TODO: pat? *)
   let (TPat { pat = expected_pat; type_ = expected_type }) = expected in
   let (TPat { pat = received_pat; type_ = received_type }) = received in
-  let* () = unify_core_pat ~expected:expected_pat ~received:received_pat in
-  unify_term ~expected:expected_type ~received:received_type
+  let* () = tp_unify ~expected:expected_pat ~received:received_pat in
+  tt_unify ~expected:expected_type ~received:received_type
 
-and unify_core_pat ~expected ~received =
+and tp_unify ~expected ~received =
   match (tp_repr expected, tp_repr received) with
   | TP_hole { hole }, pat | pat, TP_hole { hole } ->
       unify_pat_hole hole ~to_:pat

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -32,7 +32,7 @@ let rec tt_occurs hole ~in_ =
   *)
   let tt_occurs ~in_ = tt_occurs hole ~in_ in
   let tpat_occurs ~in_ = tpat_occurs hole ~in_ in
-  match tt_match @@ expand_head_term in_ with
+  match tt_match @@ tt_expand_head in_ with
   (* TODO: frozen and subst *)
   | TT_subst _ -> error_subst_found in_
   | TT_unfold _ -> error_unfold_found in_
@@ -83,8 +83,7 @@ open Unify_context
 let rec tt_unify ~expected ~received =
   (* TODO: short circuit physical equality *)
   match
-    ( tt_match @@ expand_head_term expected,
-      tt_match @@ expand_head_term received )
+    (tt_match @@ tt_expand_head expected, tt_match @@ tt_expand_head received)
   with
   (* TODO: annot and subst equality?  *)
   | TT_subst _, _ | _, TT_subst _ -> error_subst_found ~expected ~received

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -2,4 +2,4 @@ open Ttree
 open Context
 open Unify_context
 
-val unify_term : expected:term -> received:term -> unit unify_context
+val tt_unify : expected:term -> received:term -> unit unify_context


### PR DESCRIPTION
## Goals

Avoid name conflicts and follow a convention.

## Context

The first four commits were made to enforce the naming convention of prefixing names to disambiguate between two different types. Here `tt_` for term, `tpat_` for typed_pat and `tp_` for core_pat.