### PR TITLE
teika: only handle locally closed types

### DIFF
--- a/jsend/untype.ml
+++ b/jsend/untype.ml
@@ -44,11 +44,11 @@ end
 
 open Context
 
-let expand_subst_term = Expand_head.expand_subst_term
+let tt_expand_subst = Expand_head.tt_expand_subst
 
 let rec untype_term term =
   match tt_match term with
-  | TT_subst { term; subst } -> untype_term @@ expand_subst_term ~subst term
+  | TT_subst { term; subst } -> untype_term @@ tt_expand_subst ~subst term
   | TT_bound_var { index } ->
       let+ var = lookup index in
       UT_var { var }
@@ -89,8 +89,8 @@ let rec untype_term term =
   | TT_unfold { term } -> untype_term term
   | TT_let { bound = _; value; return } ->
       (* TODO: emit let *)
-      let subst = TS_subst_bound { from = Index.zero; to_ = value } in
-      untype_term @@ expand_subst_term ~subst return
+      let subst = TS_open { from = Index.zero; to_ = value } in
+      untype_term @@ tt_expand_subst ~subst return
   | TT_annot { term; annot = _ } -> untype_term term
   | TT_string { literal } -> return @@ UT_string { literal }
   | TT_native { native } -> erase_native native

--- a/teika/context.ml
+++ b/teika/context.ml
@@ -15,10 +15,16 @@ module Var_context = struct
     | Error _ as error -> error
 
   let error_subst_found term = fail @@ TError_misc_subst_found { term }
+  let error_bound_var_found term = fail @@ TError_misc_bound_var_found { term }
   let error_unfold_found term = fail @@ TError_misc_unfold_found { term }
   let error_annot_found term = fail @@ TError_misc_annot_found { term }
   let error_var_occurs ~hole ~in_ = fail @@ TError_misc_var_occurs { hole; in_ }
   let error_var_escape ~var = fail @@ TError_misc_var_escape { var }
+
+  let with_free_var f ~level =
+    let level = Level.next level in
+    f () ~level
+
   let level () ~level = Ok level
 end
 
@@ -36,6 +42,9 @@ module Unify_context = struct
 
   let error_subst_found ~expected ~received =
     fail @@ TError_unify_subst_found { expected; received }
+
+  let error_bound_var_found ~expected ~received =
+    fail @@ TError_unify_bound_var_found { expected; received }
 
   let error_unfold_found ~expected ~received =
     fail @@ TError_unify_unfold_found { expected; received }

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -11,12 +11,14 @@ module Var_context : sig
 
   (* errors *)
   val error_subst_found : term -> 'a var_context
+  val error_bound_var_found : term -> 'a var_context
   val error_unfold_found : term -> 'a var_context
   val error_annot_found : term -> 'a var_context
   val error_var_occurs : hole:term hole -> in_:term hole -> 'a var_context
   val error_var_escape : var:Level.t -> 'a var_context
 
   (* TODO: this should be removed *)
+  val with_free_var : (unit -> 'a var_context) -> 'a var_context
   val level : unit -> Level.t var_context
 end
 
@@ -32,6 +34,7 @@ module Unify_context : sig
 
   (* error *)
   val error_subst_found : expected:term -> received:term -> 'a unify_context
+  val error_bound_var_found : expected:term -> received:term -> 'a unify_context
   val error_unfold_found : expected:term -> received:term -> 'a unify_context
   val error_annot_found : expected:term -> received:term -> 'a unify_context
 

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -3,52 +3,55 @@ open Context
 open Var_context
 open Expand_head
 
-let rec tt_escape_check ~current term =
-  let tt_escape_check term = tt_escape_check ~current term in
-  let tpat_escape_check pat = tpat_escape_check ~current pat in
+(* TODO: duplicated *)
+let open_term term =
+  let open Var_context in
+  tt_map_desc term @@ fun ~wrap term _desc ->
+  let* level = level () in
+  let to_ = wrap @@ TT_free_var { level; alias = None } in
+  let subst = TS_open { from = Index.zero; to_ } in
+  pure @@ wrap @@ TT_subst { term; subst }
 
+let rec tt_escape_check term =
+  let* current = level () in
   (* TODO: check without expand_head? *)
   (* TODO: this should not be here *)
   match tt_match @@ tt_expand_head term with
-  | TT_subst { term; subst } -> tt_escape_check @@ tt_expand_subst ~subst term
-  | TT_bound_var { index = _ } ->
-      (* TODO: also check bound var *)
-      (* TODO: very very important to check for bound vars, unification
-            may unify variables outside of their binders *)
-      pure ()
+  | TT_subst _ -> error_subst_found term
+  (* TODO: also check bound var *)
+  (* TODO: very very important to check for bound vars, unification
+        may unify variables outside of their binders *)
+  | TT_bound_var _ -> error_bound_var_found term
+  | TT_unfold _ -> error_unfold_found term
+  | TT_annot _ -> error_annot_found term
   | TT_free_var { level; alias = _ } -> (
       match Level.(current < level) with
       | true -> error_var_escape ~var:level
       | false -> pure ())
   | TT_hole _hole -> pure ()
-  | TT_forall { param; return } ->
+  | TT_forall { param; return } | TT_lambda { param; return } ->
       let* () = tpat_escape_check param in
-      tt_escape_check return
-  | TT_lambda { param; return } ->
-      let* () = tpat_escape_check param in
+      with_free_var @@ fun () ->
+      let* return = open_term return in
       tt_escape_check return
   | TT_apply { lambda; arg } ->
       let* () = tt_escape_check lambda in
       tt_escape_check arg
-  | TT_self { var = _; body } -> tt_escape_check body
-  | TT_fix { var = _; body } -> tt_escape_check body
+  | TT_self { var = _; body } | TT_fix { var = _; body } ->
+      with_free_var @@ fun () ->
+      let* body = open_term body in
+      tt_escape_check body
   | TT_unroll { term } -> tt_escape_check term
-  | TT_unfold { term } -> tt_escape_check term
   | TT_let { bound; value; return } ->
       let* () = tpat_escape_check bound in
       let* () = tt_escape_check value in
+      with_free_var @@ fun () ->
+      let* return = open_term return in
       tt_escape_check return
-  | TT_annot { term; annot } ->
-      let* () = tt_escape_check term in
-      tt_escape_check annot
   | TT_string { literal = _ } -> pure ()
   | TT_native { native = _ } -> pure ()
 
-and tpat_escape_check ~current term =
+and tpat_escape_check term =
   (* TODO: check pat? *)
   let (TPat { pat = _; type_ }) = term in
-  tt_escape_check ~current type_
-
-let tt_escape_check term =
-  let* current = level () in
-  tt_escape_check ~current term
+  tt_escape_check type_

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -7,16 +7,15 @@ type error =
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* misc *)
   | TError_misc_subst_found of { term : term }
+  | TError_misc_bound_var_found of { term : term }
   | TError_misc_unfold_found of { term : term }
   | TError_misc_annot_found of { term : term }
   (* TODO: lazy names for errors *)
-  | TError_misc_var_occurs of {
-      hole : term hole; [@printer Tprinter.pp_term_hole]
-      in_ : term hole; [@printer Tprinter.pp_term_hole]
-    }
+  | TError_misc_var_occurs of { hole : term hole; in_ : term hole }
   | TError_misc_var_escape of { var : Level.t }
   (* unify *)
   | TError_unify_subst_found of { expected : term; received : term }
+  | TError_unify_bound_var_found of { expected : term; received : term }
   | TError_unify_unfold_found of { expected : term; received : term }
   | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -5,16 +5,15 @@ type error =
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* misc *)
   | TError_misc_subst_found of { term : term }
+  | TError_misc_bound_var_found of { term : term }
   | TError_misc_unfold_found of { term : term }
   | TError_misc_annot_found of { term : term }
   (* TODO: lazy names for errors *)
-  | TError_misc_var_occurs of {
-      hole : term hole; [@printer Tprinter.pp_term_hole]
-      in_ : term hole; [@printer Tprinter.pp_term_hole]
-    }
+  | TError_misc_var_occurs of { hole : term hole; in_ : term hole }
   | TError_misc_var_escape of { var : Level.t }
   (* unify *)
   | TError_unify_subst_found of { expected : term; received : term }
+  | TError_unify_bound_var_found of { expected : term; received : term }
   | TError_unify_unfold_found of { expected : term; received : term }
   | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -298,6 +298,9 @@ module Typer = struct
 
   (* TODO: write tests for locations and names / offset *)
   (* TODO: write tests for escape check *)
+  let univ_type = check "Type" ~wrapper:false {|(Type : Type)|}
+  let string_type = check "String" ~wrapper:false {|(String : Type)|}
+
   let id =
     check "id" ~wrapper:false
       {|(((A : Type) => (x : A) => x)
@@ -399,6 +402,8 @@ module Typer = struct
 
   let tests =
     [
+      univ_type;
+      string_type;
       id;
       id_propagate;
       id_unify;
@@ -416,10 +421,6 @@ module Typer = struct
       unfold_false;
       let_alias;
       simple_string;
-      (*
-          pair;
-          left_unpair;
-          right_unpair; *)
     ]
 
   (* alcotest *)

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -75,10 +75,10 @@ module Ptree = struct
         fprintf fmt "%a : %a" pp_funct term pp_wrapped annot
     | PT_string { literal } ->
         (* TODO: is this correct *)
-        fprintf fmt {|"%S"|} literal
+        fprintf fmt {|%S|} literal
     | PT_native { native } ->
         (* TODO: this is clearly not the best way*)
-        fprintf fmt {|@native("%S")|} native
+        fprintf fmt {|@native(%S)|} native
 
   type prec = Wrapped | Let | Funct | Apply | Atom
 
@@ -142,6 +142,7 @@ let rec ptree_of_term config next holes term =
   (* TODO: print details *)
   match tt_match term with
   | TT_subst { term; subst } -> ptree_of_term @@ tt_expand_subst ~subst term
+  (* TODO: bound var should not be reachable  *)
   | TT_bound_var { index } -> PT_var_index { index }
   | TT_free_var { level; alias = _ } -> PT_var_level { level }
   | TT_hole { hole } -> ptree_of_hole @@ Ex_hole hole

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -49,7 +49,7 @@ and subst =
   (* +f `open` -t *)
   | TS_close of { from : Level.t; to_ : Index.t }
 
-and native = TN_debug
+and native = TN_debug [@@deriving show { with_path = true }]
 
 let nil_level = Level.zero
 let type_level = Level.next nil_level

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -60,7 +60,7 @@ and subst =
   (* +f `open` -t *)
   | TS_close of { from : Level.t; to_ : Index.t }
 
-and native = TN_debug
+and native = TN_debug [@@deriving show]
 
 val nil_level : Level.t
 val type_level : Level.t

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -23,6 +23,15 @@ open Expand_head
 
 (* TODO: diff is a bad name *)
 
+(* TODO: duplicated *)
+let open_term term =
+  let open Var_context in
+  tt_map_desc term @@ fun ~wrap term _desc ->
+  let* level = level () in
+  let to_ = wrap @@ TT_free_var { level; alias = None } in
+  let subst = TS_open { from = Index.zero; to_ } in
+  pure @@ wrap @@ TT_subst { term; subst }
+
 let rec tt_occurs hole ~in_ =
   let open Var_context in
   (* TODO: this is needed because of non injective functions
@@ -35,30 +44,34 @@ let rec tt_occurs hole ~in_ =
   match tt_match @@ tt_expand_head in_ with
   (* TODO: frozen and subst *)
   | TT_subst _ -> error_subst_found in_
+  | TT_bound_var _ -> error_bound_var_found in_
   | TT_unfold _ -> error_unfold_found in_
   | TT_annot _ -> error_annot_found in_
-  | TT_bound_var { index = _ } -> pure ()
+  (* TODO: escape check *)
   | TT_free_var { level = _; alias = _ } -> pure ()
   (* TODO: use this substs? *)
   | TT_hole { hole = in_ } -> (
       match hole == in_ with
       | true -> error_var_occurs ~hole ~in_
       | false -> pure ())
-  | TT_forall { param; return } ->
+  | TT_forall { param; return } | TT_lambda { param; return } ->
       let* () = tpat_occurs ~in_:param in
-      tt_occurs ~in_:return
-  | TT_lambda { param; return } ->
-      let* () = tpat_occurs ~in_:param in
+      with_free_var @@ fun () ->
+      let* return = open_term return in
       tt_occurs ~in_:return
   | TT_apply { lambda; arg } ->
       let* () = tt_occurs ~in_:lambda in
       tt_occurs ~in_:arg
-  | TT_self { var = _; body } -> tt_occurs ~in_:body
-  | TT_fix { var = _; body } -> tt_occurs ~in_:body
+  | TT_self { var = _; body } | TT_fix { var = _; body } ->
+      with_free_var @@ fun () ->
+      let* body = open_term body in
+      tt_occurs ~in_:body
   | TT_unroll { term } -> tt_occurs ~in_:term
   | TT_let { bound; value; return } ->
       let* () = tpat_occurs ~in_:bound in
       let* () = tt_occurs ~in_:value in
+      with_free_var @@ fun () ->
+      let* return = open_term return in
       tt_occurs ~in_:return
   | TT_string { literal = _ } -> pure ()
   | TT_native { native = _ } -> pure ()
@@ -80,19 +93,25 @@ let unify_term_hole hole ~to_ =
 
 open Unify_context
 
+let open_term_expected term =
+  with_expected_var_context @@ fun () -> open_term term
+
+let open_term_received term =
+  with_received_var_context @@ fun () -> open_term term
+
+(* TODO: for complete terms, there is no need to open during equality *)
 let rec tt_unify ~expected ~received =
   (* TODO: short circuit physical equality *)
   match
     (tt_match @@ tt_expand_head expected, tt_match @@ tt_expand_head received)
   with
+  (* TODO: frozen and subst? *)
   (* TODO: annot and subst equality?  *)
   | TT_subst _, _ | _, TT_subst _ -> error_subst_found ~expected ~received
+  | TT_bound_var _, _ | _, TT_bound_var _ ->
+      error_bound_var_found ~expected ~received
+  | TT_unfold _, _ | _, TT_unfold _ -> error_unfold_found ~expected ~received
   | TT_annot _, _ | _, TT_annot _ -> error_annot_found ~expected ~received
-  (* TODO: frozen and subst? *)
-  | TT_bound_var { index = expected }, TT_bound_var { index = received } -> (
-      match Index.equal expected received with
-      | true -> pure ()
-      | false -> error_bound_var_clash ~expected ~received)
   | ( TT_free_var { level = expected; alias = _ },
       TT_free_var { level = received; alias = _ } ) -> (
       match Level.equal expected received with
@@ -105,29 +124,28 @@ let rec tt_unify ~expected ~received =
       with_expected_var_context @@ fun () -> unify_term_hole hole ~to_:expected
   (* TODO: track whenever it is unified and locations, visualizing inference *)
   | ( TT_forall { param = expected_param; return = expected_return },
-      TT_forall { param = received_param; return = received_return } ) ->
-      (* TODO: contravariance *)
-      let* () = tpat_unify ~expected:expected_param ~received:received_param in
-      tt_unify ~expected:expected_return ~received:received_return
+      TT_forall { param = received_param; return = received_return } )
   | ( TT_lambda { param = expected_param; return = expected_return },
       TT_lambda { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
       let* () = tpat_unify ~expected:expected_param ~received:received_param in
+      with_free_vars @@ fun () ->
+      let* expected_return = open_term_expected expected_return in
+      let* received_return = open_term_received received_return in
       tt_unify ~expected:expected_return ~received:received_return
   | ( TT_apply { lambda = expected_lambda; arg = expected_arg },
       TT_apply { lambda = received_lambda; arg = received_arg } ) ->
       let* () = tt_unify ~expected:expected_lambda ~received:received_lambda in
       tt_unify ~expected:expected_arg ~received:received_arg
   | ( TT_self { var = _; body = expected_body },
-      TT_self { var = _; body = received_body } ) ->
-      tt_unify ~expected:expected_body ~received:received_body
+      TT_self { var = _; body = received_body } )
   | ( TT_fix { var = _; body = expected_body },
       TT_fix { var = _; body = received_body } ) ->
+      with_free_vars @@ fun () ->
+      let* expected_body = open_term_expected expected_body in
+      let* received_body = open_term_received received_body in
       tt_unify ~expected:expected_body ~received:received_body
   | TT_unroll { term = expected }, TT_unroll { term = received } ->
-      tt_unify ~expected ~received
-  | TT_unfold { term = expected }, TT_unfold { term = received } ->
-      (* TODO: does unfold equality makes sense? *)
       tt_unify ~expected ~received
   | ( TT_let
         {
@@ -151,12 +169,10 @@ let rec tt_unify ~expected ~received =
       | false -> error_string_clash ~expected ~received)
   | TT_native { native = expected }, TT_native { native = received } ->
       unify_native ~expected ~received
-  | ( ( TT_bound_var _ | TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _
-      | TT_self _ | TT_fix _ | TT_unroll _ | TT_unfold _ | TT_let _
-      | TT_string _ | TT_native _ ),
-      ( TT_bound_var _ | TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _
-      | TT_self _ | TT_fix _ | TT_unroll _ | TT_unfold _ | TT_let _
-      | TT_string _ | TT_native _ ) ) ->
+  | ( ( TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_self _
+      | TT_fix _ | TT_unroll _ | TT_let _ | TT_string _ | TT_native _ ),
+      ( TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_self _
+      | TT_fix _ | TT_unroll _ | TT_let _ | TT_string _ | TT_native _ ) ) ->
       error_type_clash ~expected ~received
 
 and tpat_unify ~expected ~received =


### PR DESCRIPTION
## Goals

Simpler inference algorithm.

## Context

Currently Teika handles in many places both locally closed types and non locally closed ones. This makes so that whenever a unification variable is created the compiler needs to "guess" which kind of variable it will be. Additionally some substitutions cannot compose due to that.

While this may be desirable in the future for performance reasons it drastically increases the complexity of the typer, so in this PR, I make sure that every typed term is in the locally closed form.

This breaks typing for self types, but those will be restored very soon.