### PR TITLE
teika: internalize substitution transformations

### DIFF
--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -9,7 +9,7 @@ let open_term term =
   tt_map_desc term @@ fun ~wrap term _desc ->
   let* level = level () in
   let to_ = wrap @@ TT_free_var { level; alias = None } in
-  let subst = TS_open { from = Index.zero; to_ } in
+  let subst = TS_open { to_ } in
   pure @@ wrap @@ TT_subst { term; subst }
 
 let rec tt_escape_check term =

--- a/teika/index.ml
+++ b/teika/index.ml
@@ -3,9 +3,16 @@ and t = index [@@deriving show, eq]
 
 let zero = 0
 let one = 1
-let of_int x = x
+let previous x = match x > 0 with true -> Some (x - 1) | false -> None
+(* TODO: overflow detection *)
+
+let next x = x + 1
+
+let of_int x =
+  match x >= 0 with
+  | true -> x
+  | false -> raise (Invalid_argument "index must be bigger than zero")
+
 let repr x = x
-let ( + ) a b = a + b
-let ( - ) a b = a - b
 let ( < ) (a : index) (b : index) = a < b
 let ( > ) (a : index) (b : index) = a > b

--- a/teika/index.mli
+++ b/teika/index.mli
@@ -3,6 +3,8 @@ type t = index [@@deriving show, eq]
 
 val zero : index
 val one : index
+val previous : index -> index option
+val next : index -> index
 
 (* repr *)
 (* TODO: this API is non ideal *)
@@ -10,7 +12,5 @@ val of_int : int -> index
 val repr : index -> int
 
 (* operations *)
-val ( + ) : index -> index -> index
-val ( - ) : index -> index -> index
 val ( < ) : index -> index -> bool
 val ( > ) : index -> index -> bool

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -26,10 +26,6 @@ module Ptree = struct
     (* TODO: very weird for native to be a string *)
     | PT_native of { native : string }
 
-  and subst =
-    | PS_open : { from : Index.t; to_ : term } -> subst
-    | PS_close : { from : Level.t; to_ : Index.t } -> subst
-
   let pp_loc fmt loc =
     let pp_pos fmt pos =
       let Lexing.{ pos_fname; pos_lnum; pos_bol; pos_cnum = _ } = pos in
@@ -40,13 +36,6 @@ module Ptree = struct
     match Location.is_none loc with
     | true -> fprintf fmt "[%a .. %a]" pp_pos loc_start pp_pos loc_end
     | false -> fprintf fmt "[__NONE__]"
-
-  let _pp_subst_syntax ~pp_wrapped fmt subst =
-    match subst with
-    | PS_open { from; to_ } ->
-        fprintf fmt "\\-%a := %a" Index.pp from pp_wrapped to_
-    | PS_close { from; to_ } ->
-        fprintf fmt "\\+%a `close` \\-%a" Level.pp from Index.pp to_
 
   let pp_term_syntax ~pp_wrapped ~pp_let ~pp_funct ~pp_apply ~pp_atom fmt term =
     match term with
@@ -216,15 +205,6 @@ and ptree_of_hole _config next holes hole =
       next := id + 1;
       Hashtbl.add holes hole term;
       term
-
-and _ptree_of_subst config next holes subst =
-  let open Ptree in
-  let ptree_of_term term = ptree_of_term config next holes term in
-  match subst with
-  | TS_open { from; to_ } ->
-      let to_ = ptree_of_term to_ in
-      PS_open { from; to_ }
-  | TS_close { from; to_ } -> PS_close { from; to_ }
 
 let config =
   { typed_mode = Typed_default; loc_mode = Loc_default; var_mode = Var_name }

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -44,10 +44,14 @@ and core_pat =
 and 'a hole = { mutable link : 'a option }
 
 and subst =
-  (* -f := N *)
-  | TS_open of { from : Index.t; to_ : term }
-  (* +f `open` -t *)
-  | TS_close of { from : Level.t; to_ : Index.t }
+  (* open *)
+  | TS_open of { to_ : term }
+  (* close +l *)
+  | TS_close of { from : Level.t }
+  (* lift s *)
+  | TS_lift of { subst : subst }
+  (* s :: n *)
+  | TS_cons of { subst : subst; next : subst }
 
 and native = TN_debug [@@deriving show { with_path = true }]
 

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -55,10 +55,14 @@ and core_pat =
 and 'a hole = { mutable link : 'a option }
 
 and subst =
-  (* -f := N *)
-  | TS_open of { from : Index.t; to_ : term }
-  (* +f `open` -t *)
-  | TS_close of { from : Level.t; to_ : Index.t }
+  (* open *)
+  | TS_open of { to_ : term }
+  (* close +l *)
+  | TS_close of { from : Level.t }
+  (* lift s *)
+  | TS_lift of { subst : subst }
+  (* s :: n *)
+  | TS_cons of { subst : subst; next : subst }
 
 and native = TN_debug [@@deriving show]
 

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -14,15 +14,15 @@ let subst_free term ~to_ =
   (* TODO: this could be done waaay better *)
   let* level = level () in
   tt_map_desc term @@ fun ~wrap term _desc ->
-  let subst = TS_close { from = level; to_ = Index.zero } in
+  let subst = TS_close { from = level } in
   let term = wrap @@ TT_subst { term; subst } in
-  let subst = TS_open { from = Index.zero; to_ } in
+  let subst = TS_open { to_ } in
   pure @@ wrap @@ TT_subst { term; subst }
 
 let close_term term =
   (* TODO: this closing is weird *)
   let* from = level () in
-  let subst = TS_close { from; to_ = Index.zero } in
+  let subst = TS_close { from } in
   pure @@ tt_map_desc term
   @@ fun ~wrap term _desc -> wrap @@ TT_subst { term; subst }
 
@@ -74,7 +74,7 @@ let rec unfold_fix term =
   | TT_unroll { term = fix } -> (
       match tt_match @@ tt_expand_head fix with
       | TT_fix { var = _; body } ->
-          let subst = TS_open { from = Index.zero; to_ = fix } in
+          let subst = TS_open { to_ = fix } in
           tt_expand_head @@ tt_expand_subst ~subst body
       | _ -> term)
   | TT_unfold { term } ->

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -29,7 +29,7 @@ let open_term term =
   tt_map_desc term @@ fun ~wrap term _desc ->
   let* level = level () in
   let to_ = wrap @@ TT_free_var { level; alias = None } in
-  let subst = TS_open { from = Index.zero; to_ } in
+  let subst = TS_open { to_ } in
   pure @@ wrap @@ TT_subst { term; subst }
 
 let rec tt_occurs hole ~in_ =


### PR DESCRIPTION
## Goals

Use more standard techniques for substitutions.

## Context

Currently instead of using lifting, like used traditionally in explicit substitutions with de-bruijin indices, when entering every binder it changes the substitution itself, which is a bit slower but also more ad-hoc.

Additionally this accumulates substitutions before applying them, note that they're not composed, so this should be the same as propagating one at the time.

Those changes improves the code quality a bit and hopefully can be used to more easily reduce the overhead of ES.