### PR TITLE
teika: move substitutions to context

### DIFF
--- a/jsend/untype.ml
+++ b/jsend/untype.ml
@@ -53,10 +53,10 @@ let rec untype_term term =
       let+ var = lookup index in
       UT_var { var }
   (* TODO: those should definitely not be hard coded here  *)
-  | TT_free_var { level; alias = None } when Level.equal level type_level ->
+  | TT_free_var { level } when Level.equal level type_level ->
       let var = Var.type_ in
       return @@ UT_var { var }
-  | TT_free_var { level; alias = None } when Level.equal level string_level ->
+  | TT_free_var { level } when Level.equal level string_level ->
       (* TODO: is it okay for string to be this? *)
       let var = Var.type_ in
       return @@ UT_var { var }
@@ -89,7 +89,7 @@ let rec untype_term term =
   | TT_unfold { term } -> untype_term term
   | TT_let { bound = _; value; return } ->
       (* TODO: emit let *)
-      let subst = TS_open { from = Index.zero; to_ = value } in
+      let subst = TS_open { to_ = value } in
       untype_term @@ tt_expand_subst ~subst return
   | TT_annot { term; annot = _ } -> untype_term term
   | TT_string { literal } -> return @@ UT_string { literal }

--- a/teika/context.ml
+++ b/teika/context.ml
@@ -94,12 +94,8 @@ module Typer_context = struct
       |> Name.Map.add (Name.make "String") (string_level, tt_type)
     in
     let subst =
-      let type_ =
-        TType { desc = TT_free_var { level = type_level; alias = None } }
-      in
-      let string =
-        TType { desc = TT_free_var { level = string_level; alias = None } }
-      in
+      let type_ = TType { desc = TT_free_var { level = type_level } } in
+      let string = TType { desc = TT_free_var { level = string_level } } in
       let subst = TS_open { to_ = type_ } in
       TS_cons { subst = TS_open { to_ = string }; next = TS_lift { subst } }
     in
@@ -142,7 +138,11 @@ module Typer_context = struct
     let level = Level.next level in
     let vars = Name.Map.add name (level, type_) vars in
     let subst =
-      let to_ = TTerm { desc = TT_free_var { level; alias }; type_ } in
+      let to_ =
+        match alias with
+        | Some alias -> alias
+        | None -> TTerm { desc = TT_free_var { level }; type_ }
+      in
       TS_cons { subst = TS_open { to_ }; next = TS_lift { subst } }
     in
     f () ~level ~vars ~subst

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -90,13 +90,13 @@ module Typer_context : sig
     (unit -> 'a typer_context) ->
     'a typer_context
 
-  val lookup_var : name:Name.t -> (Level.t * term * term option) typer_context
+  val lookup_var : name:Name.t -> (Index.t * term) typer_context
 
   (* locs *)
   val with_loc :
     loc:Location.t -> (unit -> 'a typer_context) -> 'a typer_context
 
   (* context *)
-  val with_var_context : (unit -> 'a Var_context.t) -> 'a typer_context
-  val with_unify_context : (unit -> 'a Unify_context.t) -> 'a typer_context
+  val with_var_context : (subst -> 'a Var_context.t) -> 'a typer_context
+  val with_unify_context : (subst -> 'a Unify_context.t) -> 'a typer_context
 end

--- a/teika/escape_check.ml
+++ b/teika/escape_check.ml
@@ -8,7 +8,7 @@ let open_term term =
   let open Var_context in
   tt_map_desc term @@ fun ~wrap term _desc ->
   let* level = level () in
-  let to_ = wrap @@ TT_free_var { level; alias = None } in
+  let to_ = wrap @@ TT_free_var { level } in
   let subst = TS_open { to_ } in
   pure @@ wrap @@ TT_subst { term; subst }
 
@@ -24,7 +24,7 @@ let rec tt_escape_check term =
   | TT_bound_var _ -> error_bound_var_found term
   | TT_unfold _ -> error_unfold_found term
   | TT_annot _ -> error_annot_found term
-  | TT_free_var { level; alias = _ } -> (
+  | TT_free_var { level } -> (
       match Level.(current < level) with
       | true -> error_var_escape ~var:level
       | false -> pure ())

--- a/teika/expand_head.ml
+++ b/teika/expand_head.ml
@@ -57,7 +57,7 @@ let rec tt_expand_subst ~subst term =
       match repr_bound_var index subst with
       | Some (to_, subst) -> tt_expand_subst ~subst to_
       | None -> term)
-  | TT_free_var { level; alias = _ } -> (
+  | TT_free_var { level } -> (
       match repr_free_var level subst with
       | Some (index, subst) ->
           let to_ = wrap @@ TT_bound_var { index } in
@@ -112,7 +112,6 @@ let rec tt_expand_head term =
   match desc with
   | TT_subst { term; subst } -> tt_expand_head @@ tt_expand_subst ~subst term
   | TT_bound_var _ -> term
-  | TT_free_var { level = _; alias = Some alias } -> tt_expand_head alias
   | TT_free_var _ -> term
   | TT_hole { hole } -> (
       (* TODO: path compression *)

--- a/teika/level.ml
+++ b/teika/level.ml
@@ -5,4 +5,5 @@ let zero = 0
 
 (* TODO: check for overflows *)
 let next n = n + 1
+let offset ~from ~to_ = Index.of_int (to_ - from)
 let ( < ) : level -> level -> bool = ( < )

--- a/teika/level.mli
+++ b/teika/level.mli
@@ -3,4 +3,5 @@ type t = level [@@deriving show, eq]
 
 val zero : level
 val next : level -> level
+val offset : from:level -> to_:level -> Index.t
 val ( < ) : level -> level -> bool

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -133,7 +133,7 @@ let rec ptree_of_term config next holes term =
   | TT_subst { term; subst } -> ptree_of_term @@ tt_expand_subst ~subst term
   (* TODO: bound var should not be reachable  *)
   | TT_bound_var { index } -> PT_var_index { index }
-  | TT_free_var { level; alias = _ } -> PT_var_level { level }
+  | TT_free_var { level } -> PT_var_level { level }
   | TT_hole { hole } -> ptree_of_hole @@ Ex_hole hole
   | TT_forall { param; return } ->
       let param = ptree_of_typed_pat param in

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -20,7 +20,7 @@ type term =
 and term_desc =
   | TT_subst of { term : term; subst : subst }
   | TT_bound_var of { index : Index.t }
-  | TT_free_var of { level : Level.t; alias : term option }
+  | TT_free_var of { level : Level.t }
   | TT_hole of { hole : term hole }
   | TT_forall of { param : typed_pat; return : term }
   | TT_lambda of { param : typed_pat; return : term }
@@ -100,11 +100,11 @@ let tt_map_desc term f =
 (* TODO: loc *)
 let tt_type =
   (* TODO: why types have locations? *)
-  let desc = TT_free_var { level = type_level; alias = None } in
+  let desc = TT_free_var { level = type_level } in
   TType { desc }
 
 let string_type =
-  let desc = TT_free_var { level = string_level; alias = None } in
+  let desc = TT_free_var { level = string_level } in
   TType { desc }
 
 let tt_hole () =

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -44,6 +44,7 @@ and core_pat =
 and 'a hole = { mutable link : 'a option }
 
 and subst =
+  | TS_id
   (* open *)
   | TS_open of { to_ : term }
   (* close +l *)

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -55,6 +55,8 @@ and core_pat =
 and 'a hole = { mutable link : 'a option }
 
 and subst =
+  (* id *)
+  | TS_id
   (* open *)
   | TS_open of { to_ : term }
   (* close +l *)

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -13,8 +13,7 @@ and term_desc =
   (* x/-n *)
   | TT_bound_var of { index : Index.t }
   (* x/+n *)
-  (* TODO: this alias is a hack *)
-  | TT_free_var of { level : Level.t; alias : term option }
+  | TT_free_var of { level : Level.t }
   (* TODO: I really don't like this ex_term *)
   (* _x/+n *)
   | TT_hole of { hole : term hole }

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -28,7 +28,7 @@ let open_term term =
   let open Var_context in
   tt_map_desc term @@ fun ~wrap term _desc ->
   let* level = level () in
-  let to_ = wrap @@ TT_free_var { level; alias = None } in
+  let to_ = wrap @@ TT_free_var { level } in
   let subst = TS_open { to_ } in
   pure @@ wrap @@ TT_subst { term; subst }
 
@@ -48,7 +48,7 @@ let rec tt_occurs hole ~in_ =
   | TT_unfold _ -> error_unfold_found in_
   | TT_annot _ -> error_annot_found in_
   (* TODO: escape check *)
-  | TT_free_var { level = _; alias = _ } -> pure ()
+  | TT_free_var { level = _ } -> pure ()
   (* TODO: use this substs? *)
   | TT_hole { hole = in_ } -> (
       match hole == in_ with
@@ -112,8 +112,7 @@ let rec tt_unify ~expected ~received =
       error_bound_var_found ~expected ~received
   | TT_unfold _, _ | _, TT_unfold _ -> error_unfold_found ~expected ~received
   | TT_annot _, _ | _, TT_annot _ -> error_annot_found ~expected ~received
-  | ( TT_free_var { level = expected; alias = _ },
-      TT_free_var { level = received; alias = _ } ) -> (
+  | TT_free_var { level = expected }, TT_free_var { level = received } -> (
       match Level.equal expected received with
       | true -> pure ()
       | false -> error_free_var_clash ~expected ~received)


### PR DESCRIPTION
## Goals

Prepare for higher-order unification and clear the typing substitution pipeline.

## Context

My current design for doing higher order substitution will be to accumulate all the substitutions in the context, then invert them before unifying.

Currently the typer first emit open terms and then close them later, while this works, a possibly more interesting approach is to emit the closed terms and register a substitution to keep them open while typing, due to that terms are automatically closed when it is over.

This is probably slower due to accumulating too many substitutions but this can be mitigated with better data structures easily in the future. Additionally it makes let aliasing quite straightforward(just one open).