### PR TITLE
teika: add better printer for error mesages

### DIFF
--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -24,6 +24,7 @@ type error =
       extension : Name.t;
       payload : Ltree.term;
     }
+  (* TODO: native should not be a string *)
   | TError_typer_unknown_native of { native : string }
 
 type t = error [@@deriving show]

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -393,6 +393,22 @@ module Typer = struct
       |}
 
   let simple_string = check "simple_string" {|("simple string" : String)|}
+
+  let rank_2_propagate =
+    check "rank_2_propagate"
+      {|
+        Unit = (A : Type) -> (x : A) -> A;
+        (u => u Unit u : (u : Unit) -> Unit)
+      |}
+
+  let rank_2_propagate_let =
+    check "rank_2_propagate"
+      {|
+        Unit = (A : Type) -> (x : A) -> A;
+        (noop : (u : Unit) -> Unit) = u => u Unit u;
+        noop
+      |}
+
   let invalid_annotation = fail "invalid_annotation" {|(String : "A")|}
   let simplest_escape_check = fail "simplest_escape_check" "x => A => (x : A)"
 
@@ -417,6 +433,8 @@ module Typer = struct
       unfold_false;
       let_alias;
       simple_string;
+      rank_2_propagate;
+      rank_2_propagate_let;
       invalid_annotation;
       simplest_escape_check;
     ]
@@ -434,7 +452,8 @@ module Typer = struct
               Format.eprintf "%a\n%!" Tprinter.pp_term _ttree;
               ()
           | Error error ->
-              failwith @@ Format.asprintf "error: %a\n%!" Terror.pp error)
+              failwith
+              @@ Format.asprintf "error: %a\n%!" Tprinter.pp_error error)
       | None -> failwith "failed to parse"
     in
     let fail ~name ~annotated_term =

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,5 +1,7 @@
 open Ttree
+open Terror
 
 val pp_term : Format.formatter -> term -> unit
 val pp_term_hole : Format.formatter -> term hole -> unit
 val pp_subst : Format.formatter -> subst -> unit
+val pp_error : Format.formatter -> error -> unit


### PR DESCRIPTION
## Goals

Make debugging compiler bugs easier.

## Context

Currently the printer for error messages is really bad, leading to huge error blocks, this PR aims to reduce that a bit. **WARNING** those are not meant to be end-user errors yet, this is just an internal tool for now.