### PR TITLE
{teija,jsend}: proper let handling

### DIFF
--- a/jsend/emit.ml
+++ b/jsend/emit.ml
@@ -8,16 +8,35 @@ let rec emit_term : Utree.term -> expression =
   | UT_loc { term; loc = _ } -> emit_term term
   | UT_var { var } -> JE_var { var }
   | UT_lambda { param; return } ->
-      let return = emit_term return in
-      JE_generator { param; return }
+      let params = [ param ] in
+      let block = emit_block ~consts:[] return in
+      JE_generator { params; block }
   | UT_apply { lambda; arg } ->
       let lambda = emit_term lambda in
-      let arg = emit_term arg in
-      let call = JE_call { lambda; arg } in
+      let args = [ emit_term arg ] in
+      let call = JE_call { lambda; args } in
       (* TODO: test optimization, if instanceof before yield *)
+      JE_yield { expression = call }
+  | UT_let _ ->
+      (* TODO: weird to ignore UT_let like this *)
+      let block = emit_block ~consts:[] term in
+      let wrapper = JE_generator { params = []; block } in
+      let call = JE_call { lambda = wrapper; args = [] } in
       JE_yield { expression = call }
   | UT_string { literal } -> JE_string { literal }
   | UT_external { external_ } -> translate_external external_
+
+and emit_block ~consts return =
+  match return with
+  | UT_loc { term = return; loc = _ } -> emit_block ~consts return
+  | UT_let { var; value; return } ->
+      let value = emit_term value in
+      let consts = (var, value) :: consts in
+      emit_block ~consts return
+  | UT_var _ | UT_lambda _ | UT_apply _ | UT_string _ | UT_external _ ->
+      let return = emit_term return in
+      let consts = List.rev consts in
+      JBlock { consts; return }
 
 and translate_external : external_ -> expression =
  fun external_ ->

--- a/jsend/jprinter.ml
+++ b/jsend/jprinter.ml
@@ -2,18 +2,40 @@ open Jtree
 open Format
 
 (* TODO: identation *)
-let rec pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom fmt expression =
+let pp_block_syntax ~pp_wrapped_expression fmt block =
+  let (JBlock { consts; return }) = block in
+  List.iter
+    (fun (var, value) ->
+      fprintf fmt "const %a = %a;" Var.pp var pp_wrapped_expression value)
+    consts;
+  fprintf fmt "return %a;" pp_wrapped_expression return
+
+let rec pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom ~pp_block fmt
+    expression =
   let pp_expression_syntax fmt expression =
-    pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom fmt expression
+    pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom ~pp_block fmt expression
   in
   match expression with
   | JE_loc { expression; loc = _ } -> pp_expression_syntax fmt expression
   | JE_var { var } -> Var.pp fmt var
-  | JE_generator { param; return } ->
+  | JE_generator { params; block } ->
       (* TODO: names on functions? *)
-      fprintf fmt "function* (%a) { return %a; }" Var.pp param pp_wrapped return
-  | JE_call { lambda; arg } ->
-      fprintf fmt "%a(%a)" pp_call lambda pp_wrapped arg
+      let rec pp_params fmt params =
+        match params with
+        | [] -> ()
+        | [ param ] -> fprintf fmt "%a" Var.pp param
+        | param :: params -> fprintf fmt "%a, %a" Var.pp param pp_params params
+      in
+      fprintf fmt "function* (%a) { %a }" pp_params params pp_block block
+  | JE_call { lambda; args } ->
+      (* TODO: almost duplicated from params *)
+      let rec pp_args fmt args =
+        match args with
+        | [] -> ()
+        | [ arg ] -> fprintf fmt "%a" pp_wrapped arg
+        | arg :: args -> fprintf fmt "%a, %a" pp_wrapped arg pp_args args
+      in
+      fprintf fmt "%a(%a)" pp_call lambda pp_args args
   | JE_yield { expression } -> fprintf fmt "yield %a" pp_call expression
   | JE_string { literal } ->
       (* TODO: proper JS escaping *)
@@ -25,12 +47,16 @@ let rec pp_expression prec fmt expression =
   let pp_wrapped fmt term = pp_expression Wrapped fmt term in
   let pp_call fmt term = pp_expression Call fmt term in
   let pp_atom fmt term = pp_expression Atom fmt term in
+  let pp_block fmt block =
+    pp_block_syntax ~pp_wrapped_expression:pp_wrapped fmt block
+  in
   match (expression, prec) with
   | JE_loc { expression; loc = _ }, prec -> pp_expression prec fmt expression
   | (JE_var _ | JE_string _), (Wrapped | Call | Atom)
   | JE_call _, (Wrapped | Call)
   | (JE_generator _ | JE_yield _), Wrapped ->
-      pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom fmt expression
+      pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom ~pp_block fmt
+        expression
   | JE_call _, Atom | (JE_generator _ | JE_yield _), (Call | Atom) ->
       fprintf fmt "(%a)" pp_wrapped expression
 

--- a/jsend/jtree.ml
+++ b/jsend/jtree.ml
@@ -1,7 +1,10 @@
 type expression =
   | JE_loc of { expression : expression; loc : Location.t }
   | JE_var of { var : Var.t }
-  | JE_generator of { param : Var.t; return : expression }
-  | JE_call of { lambda : expression; arg : expression }
+  | JE_generator of { params : Var.t list; block : block }
+  | JE_call of { lambda : expression; args : expression list }
   | JE_yield of { expression : expression }
   | JE_string of { literal : string }
+
+and block =
+  | JBlock of { consts : (Var.t * expression) list; return : expression }

--- a/jsend/jtree.mli
+++ b/jsend/jtree.mli
@@ -1,8 +1,11 @@
 type expression =
   | JE_loc of { expression : expression; loc : Location.t }
   | JE_var of { var : Var.t }
-  | JE_generator of { param : Var.t; return : expression }
+  | JE_generator of { params : Var.t list; block : block }
   (* TODO: not really a lambda and arg *)
-  | JE_call of { lambda : expression; arg : expression }
+  | JE_call of { lambda : expression; args : expression list }
   | JE_yield of { expression : expression }
   | JE_string of { literal : string }
+
+and block =
+  | JBlock of { consts : (Var.t * expression) list; return : expression }

--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -48,5 +48,6 @@ let () =
         eight = mul two four;
         sixteen = mul two eight;
         byte = mul sixteen sixteen;
-        byte String "zero" (_ => @native("debug")("hello"))
+        short = mul byte byte;
+        short String "zero" (_ => @native("debug")("hello"))
       |}

--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -14,11 +14,39 @@ let compile code =
 
   let term = Untype.untype_term term in
   let term = Emit.emit_term term in
-  Format.printf "%a" Jprinter.pp_expression term
+  Format.printf "%a\n\n%!" Jprinter.pp_expression term
+
+let () =
+  compile
+    {|
+      Unit = (A : Type) -> (x : A) -> A;
+      (noop : (u : Unit) -> Unit) = u => u Unit u;
+      noop
+    |}
 
 let () =
   compile
     {|
       Bool = (A : Type) -> (t : A) -> (f : A) -> A;
-      @native("debug")(A => t => f => t : Bool)
+      (true : Bool) = A => x => y => x;
+      (false : Bool) = A => x => y => y;
+      f = (bool : Bool) => @native("debug")(bool String "!!true" "!!false");
+      f false
     |}
+
+let () =
+  compile
+    {|
+        Nat = (A : Type) -> (z : A) -> (s : (x : A) -> A) -> A;
+        (zero : Nat) = A => z => s => z;
+        (succ : (n : Nat) -> Nat) = n => A => z => s => s (n A z s);
+        (add : (n : Nat) -> (m : Nat) -> Nat) = n => m => n Nat m succ;
+        (mul : (n : Nat) -> (m : Nat) -> Nat) = n => m => n Nat zero (add m);
+        one = succ zero;
+        two = succ one;
+        four = mul two two;
+        eight = mul two four;
+        sixteen = mul two eight;
+        byte = mul sixteen sixteen;
+        byte String "zero" (_ => @native("debug")("hello"))
+      |}

--- a/jsend/untype.ml
+++ b/jsend/untype.ml
@@ -85,9 +85,17 @@ let rec untype_term term =
       let+ term = untype_term term in
       UT_apply { lambda = term; arg = unit_term }
   | TT_unfold { term } -> untype_term term
-  | TT_let { bound = _; value; return } ->
+  | TT_let { bound; value; return } ->
       (* TODO: emit let *)
-      untype_term @@ tt_open return ~to_:value
+      (* TODO: param first *)
+      let* value = untype_term value in
+      let+ param, return =
+        erase_typed_pat bound @@ fun var ->
+        let+ return = untype_term return in
+        (var, return)
+      in
+      let lambda = UT_lambda { param; return } in
+      UT_apply { lambda; arg = value }
   | TT_annot { term; annot = _ } -> untype_term term
   | TT_string { literal } -> return @@ UT_string { literal }
   | TT_native { native } -> erase_native native

--- a/jsend/untype.ml
+++ b/jsend/untype.ml
@@ -86,16 +86,14 @@ let rec untype_term term =
       UT_apply { lambda = term; arg = unit_term }
   | TT_unfold { term } -> untype_term term
   | TT_let { bound; value; return } ->
-      (* TODO: emit let *)
       (* TODO: param first *)
       let* value = untype_term value in
-      let+ param, return =
+      let+ var, return =
         erase_typed_pat bound @@ fun var ->
         let+ return = untype_term return in
         (var, return)
       in
-      let lambda = UT_lambda { param; return } in
-      UT_apply { lambda; arg = value }
+      UT_let { var; value; return }
   | TT_annot { term; annot = _ } -> untype_term term
   | TT_string { literal } -> return @@ UT_string { literal }
   | TT_native { native } -> erase_native native

--- a/jsend/utree.ml
+++ b/jsend/utree.ml
@@ -3,6 +3,7 @@ type term =
   | UT_var of { var : Var.t }
   | UT_lambda of { param : Var.t; return : term }
   | UT_apply of { lambda : term; arg : term }
+  | UT_let of { var : Var.t; value : term; return : term }
   | UT_string of { literal : string }
   | UT_external of { external_ : external_ }
 

--- a/jsend/utree.mli
+++ b/jsend/utree.mli
@@ -5,7 +5,7 @@ type term =
   (* TODO: patterns in the Itree? *)
   | UT_lambda of { param : Var.t; return : term }
   | UT_apply of { lambda : term; arg : term }
-  (* TODO: let here? *)
+  | UT_let of { var : Var.t; value : term; return : term }
   | UT_string of { literal : string }
   | UT_external of { external_ : external_ }
 

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -74,6 +74,7 @@ module Typer_context : sig
 
   (* TODO: this should be removed *)
   val level : unit -> Level.t typer_context
+  val aliases : unit -> term Level.Map.t typer_context
   val enter_level : (unit -> 'a typer_context) -> 'a typer_context
 
   (* vars *)
@@ -87,13 +88,16 @@ module Typer_context : sig
     'a typer_context
 
   (* TODO: this is a hack *)
-  val lookup_var : name:Name.t -> (term * term) typer_context
+  val lookup_var : name:Name.t -> (Level.t * term) typer_context
 
   (* locs *)
   val with_loc :
     loc:Location.t -> (unit -> 'a typer_context) -> 'a typer_context
 
   (* context *)
-  val with_var_context : (unit -> 'a Var_context.t) -> 'a typer_context
-  val with_unify_context : (unit -> 'a Unify_context.t) -> 'a typer_context
+  val with_var_context :
+    (aliases:term Level.Map.t -> 'a Var_context.t) -> 'a typer_context
+
+  val with_unify_context :
+    (aliases:term Level.Map.t -> 'a Unify_context.t) -> 'a typer_context
 end

--- a/teika/tmachinery.mli
+++ b/teika/tmachinery.mli
@@ -6,7 +6,7 @@ val tt_match : term -> term
 val tt_apply_subst : term -> subst -> term
 val tt_open : term -> to_:term -> term
 val tt_close : term -> from:Level.t -> term
-val tt_expand_head : term -> term
-val tt_escape_check : term -> unit Var_context.t
-val tt_unfold_fix : term -> term
+val tt_expand_head : aliases:term Level.Map.t -> term -> term
+val tt_escape_check : aliases:term Level.Map.t -> term -> unit Var_context.t
+val tt_unfold_fix : aliases:term Level.Map.t -> term -> term
 val ts_inverse : subst -> subst

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -23,16 +23,16 @@ open Tmachinery
 
 (* TODO: diff is a bad name *)
 
-let rec tt_occurs hole ~in_ =
+let rec tt_occurs ~aliases hole ~in_ =
   let open Var_context in
   (* TODO: this is needed because of non injective functions
        the unification could succeed only if expand_head happened
 
      maybe should fail anyway ?
   *)
-  let tt_occurs ~in_ = tt_occurs hole ~in_ in
-  let tpat_occurs ~in_ = tpat_occurs hole ~in_ in
-  match tt_match @@ tt_expand_head in_ with
+  let tt_occurs ~in_ = tt_occurs ~aliases hole ~in_ in
+  let tpat_occurs ~in_ = tpat_occurs ~aliases hole ~in_ in
+  match tt_match @@ tt_expand_head ~aliases in_ with
   (* TODO: frozen and subst *)
   | TT_unfold _ -> error_unfold_found in_
   | TT_annot _ -> error_annot_found in_ (* TODO: escape check *)
@@ -42,6 +42,7 @@ let rec tt_occurs hole ~in_ =
   | TT_hole { hole = in_; subst = _ } -> (
       (* TODO: is it the same hole if substs are different? *)
       match hole == in_ with
+      (* TODO: better error *)
       | true -> error_var_occurs ~hole ~in_
       | false -> pure ())
   | TT_forall { param; return } | TT_lambda { param; return } ->
@@ -66,7 +67,7 @@ and tpat_occurs hole ~in_ =
   let (TPat { pat = _; type_ }) = in_ in
   tt_occurs hole ~in_:type_
 
-let unify_term_hole hole ~subst ~to_ =
+let unify_term_hole ~aliases hole ~subst ~to_ =
   let open Var_context in
   match tt_match to_ with
   (* TODO: what if subst is different *)
@@ -74,17 +75,25 @@ let unify_term_hole hole ~subst ~to_ =
   | _ ->
       let to_ = tt_apply_subst to_ @@ ts_inverse subst in
       (* TODO: prefer a direction when both are holes? *)
-      let* () = tt_occurs hole ~in_:to_ in
+      let* () = tt_occurs ~aliases hole ~in_:to_ in
       hole.link <- Some to_;
       pure ()
 
 open Unify_context
 
 (* TODO: for complete terms, there is no need to open during equality *)
-let rec tt_unify ~expected ~received =
+let rec tt_unify ~aliases ~expected ~received =
+  let tt_unify ~expected ~received = tt_unify ~aliases ~expected ~received in
+  let tpat_unify ~expected ~received =
+    tpat_unify ~aliases ~expected ~received
+  in
+  let unify_term_hole hole ~subst ~to_ =
+    unify_term_hole ~aliases hole ~subst ~to_
+  in
   (* TODO: short circuit physical equality *)
   match
-    (tt_match @@ tt_expand_head expected, tt_match @@ tt_expand_head received)
+    ( tt_match @@ tt_expand_head ~aliases expected,
+      tt_match @@ tt_expand_head ~aliases received )
   with
   (* TODO: annot and unfold equality?  *)
   | TT_unfold _, _ | _, TT_unfold _ -> error_unfold_found ~expected ~received
@@ -155,12 +164,12 @@ let rec tt_unify ~expected ~received =
       | TT_native _ ) ) ->
       error_type_clash ~expected ~received
 
-and tpat_unify ~expected ~received =
+and tpat_unify ~aliases ~expected ~received =
   (* TODO: pat? *)
   let (TPat { pat = expected_pat; type_ = expected_type }) = expected in
   let (TPat { pat = received_pat; type_ = received_type }) = received in
   let* () = tp_unify ~expected:expected_pat ~received:received_pat in
-  tt_unify ~expected:expected_type ~received:received_type
+  tt_unify ~aliases ~expected:expected_type ~received:received_type
 
 and tp_unify ~expected ~received =
   match (tp_repr expected, tp_repr received) with

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -2,4 +2,8 @@ open Ttree
 open Context
 open Unify_context
 
-val tt_unify : expected:term -> received:term -> unit unify_context
+val tt_unify :
+  aliases:term Level.Map.t ->
+  expected:term ->
+  received:term ->
+  unit unify_context


### PR DESCRIPTION
## Goals

Faster, smaller and closer to source code, let generation.

## Context

Currently `let` is erased in Teika during typing, this is the case just because at the time(yesterday) this was the simplest implementation. This leads to bigger and slower code in general as let will multiply the value, removing sharing.

Here the implementation of let is hackish but should work, by passing an aliases parameter to every function involved.

Additionally JSEnd was improved to properly generate blocks containing const definitions. Making the let code gen reasonable.