### PR TITLE
jsend: better functions

### DIFF
--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -48,6 +48,5 @@ let () =
         eight = mul two four;
         sixteen = mul two eight;
         byte = mul sixteen sixteen;
-        short = mul byte byte;
-        short String "zero" (_ => @native("debug")("hello"))
+        byte String "zero" (_ => @native("debug")("hello"))
       |}

--- a/jsend/var.ml
+++ b/jsend/var.ml
@@ -58,6 +58,7 @@ let type_ = predef "$type"
 let fix = predef "$fix"
 let unit = predef "$unit"
 let debug = predef "$debug"
+let curry = predef "$curry"
 
 module Map = Map.Make (struct
   type t = var

--- a/jsend/var.mli
+++ b/jsend/var.mli
@@ -13,5 +13,6 @@ val type_ : var
 val fix : var
 val unit : var
 val debug : var
+val curry : var
 
 module Map : Map.S with type key = t


### PR DESCRIPTION
## Goals

More legible output and hopefully faster.

## Context

All Teika functions have a single parameter and right now Teika doesn't have pairs, so the generated code is quite hard to read, additionally it allocates too many closures.

This changes addresses that by grouping nested functions and using a magic $curry helper in JS, this hopefully improves performance but it also makes the generated code much more readable.