### PR TITLE
jsend: implement tail call optimization

### DIFF
--- a/jsend/emit.ml
+++ b/jsend/emit.ml
@@ -60,7 +60,18 @@ and emit_block ~consts return =
       let value = emit_term value in
       let consts = (var, value) :: consts in
       emit_block ~consts return
-  | UT_var _ | UT_lambda _ | UT_apply _ | UT_string _ | UT_external _ ->
+  | UT_apply _ ->
+      (* tco *)
+      let return =
+        let return = emit_call ~args:[] return in
+        let constructor =
+          JE_call { lambda = JE_var { var = Var.jmp }; args = [ return ] }
+        in
+        JE_new { constructor }
+      in
+      let consts = List.rev consts in
+      JBlock { consts; return }
+  | UT_var _ | UT_lambda _ | UT_string _ | UT_external _ ->
       let return = emit_term return in
       let consts = List.rev consts in
       JBlock { consts; return }

--- a/jsend/jprinter.ml
+++ b/jsend/jprinter.ml
@@ -27,6 +27,8 @@ let rec pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom ~pp_block fmt
         | param :: params -> fprintf fmt "%a, %a" Var.pp param pp_params params
       in
       fprintf fmt "function* (%a) { %a }" pp_params params pp_block block
+  (* TODO: new precedence is the same as call? *)
+  | JE_new { constructor } -> fprintf fmt "new %a" pp_call constructor
   | JE_call { lambda; args } ->
       (* TODO: almost duplicated from params *)
       let rec pp_args fmt args =
@@ -53,11 +55,12 @@ let rec pp_expression prec fmt expression =
   match (expression, prec) with
   | JE_loc { expression; loc = _ }, prec -> pp_expression prec fmt expression
   | (JE_var _ | JE_string _), (Wrapped | Call | Atom)
-  | JE_call _, (Wrapped | Call)
+  | (JE_new _ | JE_call _), (Wrapped | Call)
   | (JE_generator _ | JE_yield _), Wrapped ->
       pp_expression_syntax ~pp_wrapped ~pp_call ~pp_atom ~pp_block fmt
         expression
-  | JE_call _, Atom | (JE_generator _ | JE_yield _), (Call | Atom) ->
+  | (JE_new _ | JE_call _), Atom | (JE_generator _ | JE_yield _), (Call | Atom)
+    ->
       fprintf fmt "(%a)" pp_wrapped expression
 
 let pp_expression fmt expression = pp_expression Wrapped fmt expression

--- a/jsend/jtree.ml
+++ b/jsend/jtree.ml
@@ -2,6 +2,7 @@ type expression =
   | JE_loc of { expression : expression; loc : Location.t }
   | JE_var of { var : Var.t }
   | JE_generator of { params : Var.t list; block : block }
+  | JE_new of { constructor : expression }
   | JE_call of { lambda : expression; args : expression list }
   | JE_yield of { expression : expression }
   | JE_string of { literal : string }

--- a/jsend/jtree.mli
+++ b/jsend/jtree.mli
@@ -3,6 +3,7 @@ type expression =
   | JE_var of { var : Var.t }
   | JE_generator of { params : Var.t list; block : block }
   (* TODO: not really a lambda and arg *)
+  | JE_new of { constructor : expression }
   | JE_call of { lambda : expression; args : expression list }
   | JE_yield of { expression : expression }
   | JE_string of { literal : string }

--- a/jsend/test.ml
+++ b/jsend/test.ml
@@ -37,16 +37,21 @@ let () =
 let () =
   compile
     {|
-        Nat = (A : Type) -> (z : A) -> (s : (x : A) -> A) -> A;
-        (zero : Nat) = A => z => s => z;
-        (succ : (n : Nat) -> Nat) = n => A => z => s => s (n A z s);
-        (add : (n : Nat) -> (m : Nat) -> Nat) = n => m => n Nat m succ;
-        (mul : (n : Nat) -> (m : Nat) -> Nat) = n => m => n Nat zero (add m);
+        Nat = (A : Type) -> (z : A) ->
+          (s : (x : A) -> A) -> (k : (x : A) -> A) -> A;
+        (zero : Nat) = A => z => s => k => k z;
+        (succ : (n : Nat) -> Nat) =
+          n => A => z => s => k => n A z s (x => k (s x));
+        (add : (n : Nat) -> (m : Nat) -> Nat) =
+          n => m => n Nat m succ (x => x);
+        (mul : (n : Nat) -> (m : Nat) -> Nat) =
+          n => m => n Nat zero (add m) (x => x);
         one = succ zero;
         two = succ one;
         four = mul two two;
         eight = mul two four;
         sixteen = mul two eight;
         byte = mul sixteen sixteen;
-        byte String "zero" (_ => @native("debug")("hello"))
+        short = mul byte byte;
+        short String "zero" (_ => @native("debug")("hello")) (x => x)
       |}

--- a/jsend/var.ml
+++ b/jsend/var.ml
@@ -59,6 +59,7 @@ let fix = predef "$fix"
 let unit = predef "$unit"
 let debug = predef "$debug"
 let curry = predef "$curry"
+let jmp = predef "$jmp"
 
 module Map = Map.Make (struct
   type t = var

--- a/jsend/var.mli
+++ b/jsend/var.mli
@@ -14,5 +14,6 @@ val fix : var
 val unit : var
 val debug : var
 val curry : var
+val jmp : var
 
 module Map : Map.S with type key = t


### PR DESCRIPTION
## Goals

Allow constant memory recursion by reusing stack frame when doing tail-call.

## Context

A crucial part of making real software in Teika is to do recursive functions, but every function call adds an entry to the stack, while the Teika runtime supports a shadow stack to avoid stack overflow, it will still lead to a lot memory being used.

But it is well-known that function calls at a tail call position can reuse the previous stack frame, so this is what this PR does. By having a wrapper `$jmp` where the runtime can do `instanceof $jmp` to know when to reuse the frame.

**NOTE** this works for any tail-call not only recursive ones.