### PR TITLE
teika: integrates escape check on occurs check

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -108,9 +108,13 @@ module Typer_context = struct
   let level () ~level ~vars:_ ~aliases:_ = Ok level
   let aliases () ~level:_ ~vars:_ ~aliases = Ok aliases
 
-  let enter_level f ~level ~vars =
+  let enter_level f ~level ~vars ~aliases =
     let level = Level.next level in
-    f () ~level ~vars
+    f () ~level ~vars ~aliases
+
+  let tt_hole () ~level ~vars:_ ~aliases:_ =
+    let hole = { link = None } in
+    Ok (TT_hole { hole; level; subst = TS_id })
 
   let with_free_vars ~name ~type_ ~alias f ~level ~vars ~aliases =
     let level = Level.next level in

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -76,6 +76,7 @@ module Typer_context : sig
   val level : unit -> Level.t typer_context
   val aliases : unit -> term Level.Map.t typer_context
   val enter_level : (unit -> 'a typer_context) -> 'a typer_context
+  val tt_hole : unit -> term typer_context
 
   (* vars *)
 

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -404,13 +404,20 @@ module Typer = struct
   let rank_2_propagate_let =
     check "rank_2_propagate"
       {|
-        Unit = (A : Type) -> (x : A) -> A;
-        (noop : (u : Unit) -> Unit) = u => u Unit u;
-        noop
-      |}
+            Unit = (A : Type) -> (x : A) -> A;
+            (noop : (u : Unit) -> Unit) = u => u Unit u;
+            noop
+          |}
 
   let invalid_annotation = fail "invalid_annotation" {|(String : "A")|}
   let simplest_escape_check = fail "simplest_escape_check" "x => A => (x : A)"
+
+  let bound_var_escape_check =
+    fail "bound_var_escape_check"
+      {|
+        call = f => v => f v;
+        (never : (A : Type) -> A) => call never
+      |}
 
   let tests =
     [
@@ -437,6 +444,7 @@ module Typer = struct
       rank_2_propagate_let;
       invalid_annotation;
       simplest_escape_check;
+      bound_var_escape_check;
     ]
 
   (* alcotest *)

--- a/teika/tmachinery.mli
+++ b/teika/tmachinery.mli
@@ -1,5 +1,4 @@
 open Ttree
-open Context
 
 val tt_repr : term -> term
 val tt_match : term -> term
@@ -7,6 +6,5 @@ val tt_apply_subst : term -> subst -> term
 val tt_open : term -> to_:term -> term
 val tt_close : term -> from:Level.t -> term
 val tt_expand_head : aliases:term Level.Map.t -> term -> term
-val tt_escape_check : aliases:term Level.Map.t -> term -> unit Var_context.t
 val tt_unfold_fix : aliases:term Level.Map.t -> term -> term
 val ts_inverse : subst -> subst

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -216,8 +216,8 @@ let rec ptree_of_term config next holes term =
   (* TODO: bound var should not be reachable  *)
   | TT_bound_var { index } -> PT_var_index { index }
   | TT_free_var { level } -> PT_var_level { level }
-  | TT_hole { hole; subst } ->
-      (* TODO: print hole substs *)
+  | TT_hole { hole; level = _; subst } ->
+      (* TODO: print hole level *)
       ptree_of_tt_hole ~subst @@ Ex_hole hole
   | TT_forall { param; return } ->
       let param = ptree_of_typed_pat param in

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -16,7 +16,7 @@ type sugar = Sugar
 type term =
   | TT_bound_var of { index : Index.t }
   | TT_free_var of { level : Level.t }
-  | TT_hole of { hole : term hole; subst : subst }
+  | TT_hole of { hole : term hole; level : Level.t; subst : subst }
   | TT_forall of { param : typed_pat; return : term }
   | TT_lambda of { param : typed_pat; return : term }
   | TT_apply of { lambda : term; arg : term }
@@ -66,10 +66,6 @@ let rec tp_repr pat =
 (* TODO: loc *)
 let tt_type = TT_free_var { level = type_level }
 let string_type = TT_free_var { level = string_level }
-
-let tt_hole () =
-  let hole = { link = None } in
-  TT_hole { hole; subst = TS_id }
 
 let tp_hole () =
   let hole = { link = None } in

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -9,8 +9,8 @@ type term =
   (* x/+n *)
   | TT_free_var of { level : Level.t }
   (* TODO: I really don't like this ex_term *)
-  (* _x/+n *)
-  | TT_hole of { hole : term hole; subst : subst }
+  (* _x/+n[s] *)
+  | TT_hole of { hole : term hole; level : Level.t; subst : subst }
   (* (x : A) -> B *)
   | TT_forall of { param : typed_pat; return : term }
   (* (x : A) => e *)
@@ -71,5 +71,4 @@ val tp_repr : core_pat -> core_pat
 (* constructors *)
 val tt_type : term
 val string_type : term
-val tt_hole : unit -> term
 val tp_hole : unit -> core_pat


### PR DESCRIPTION
## Goals

Faster escape checking and more precise error messages.

## Context

Currently Teika does escape checking in the most naive way possible, by checking nothing escaped when returning a term, this is slow and will lead to error messages at the declaration site instead of where it actually happened.

So I'm switching to a level based approach where meta variables contain the lowest level where they're referenced, using this it should be possible to detect at occurs time when a variable would escape.