### PR TITLE
teika: use context during printing

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -132,6 +132,22 @@ module Typer_context = struct
     | Some (level, type_) -> Ok (level, type_)
     | None -> Error (TError_typer_unknown_var { name })
 
+  let free_vars ~vars =
+    (* TODO: this is hackish *)
+    Name.Map.fold
+      (fun name (level, _type) free_vars -> Level.Map.add level name free_vars)
+      vars Level.Map.empty
+
+  let pp_term () ~level:_ ~vars ~aliases:_ =
+    let bound_vars = [] in
+    let free_vars = free_vars ~vars in
+    Ok (Tprinter.raw_pp_term ~bound_vars ~free_vars)
+
+  let pp_error () ~level:_ ~vars ~aliases:_ =
+    let bound_vars = [] in
+    let free_vars = free_vars ~vars in
+    Ok (Tprinter.raw_pp_error ~bound_vars ~free_vars)
+
   let with_loc ~loc f ~level ~vars ~aliases =
     match f () ~level ~vars ~aliases with
     | Ok _value as ok -> ok

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -88,12 +88,15 @@ module Typer_context : sig
     (unit -> 'a typer_context) ->
     'a typer_context
 
-  (* TODO: this is a hack *)
   val lookup_var : name:Name.t -> (Level.t * term) typer_context
 
   (* locs *)
   val with_loc :
     loc:Location.t -> (unit -> 'a typer_context) -> 'a typer_context
+
+  (* tools *)
+  val pp_term : unit -> (Format.formatter -> term -> unit) typer_context
+  val pp_error : unit -> (Format.formatter -> error -> unit) typer_context
 
   (* context *)
   val with_var_context :

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -1,5 +1,3 @@
-[@@@ocaml.warning "-unused-constructor"]
-
 open Ttree
 open Terror
 open Tmachinery
@@ -8,11 +6,8 @@ module Ptree = struct
   open Format
 
   type term =
-    | PT_subst of { term : term; subst : subst }
-    | PT_var_name of { name : Name.t }
-    | PT_var_index of { index : Index.t }
-    | PT_var_level of { level : Level.t }
-    | PT_hole_var_full of { id : int }
+    | PT_var of { name : Name.t }
+    | PT_hole of { name : Name.t }
     | PT_forall of { param : term; return : term }
     | PT_lambda of { param : term; return : term }
     | PT_apply of { lambda : term; arg : term }
@@ -25,6 +20,13 @@ module Ptree = struct
     | PT_string of { literal : string }
     (* TODO: very weird for native to be a string *)
     | PT_native of { native : string }
+    (* low level *)
+    (* TODO: weird to use string *)
+    | PT_subst of { term : term; subst : subst }
+    | PT_var_index of { name : Name.t option; index : Index.t }
+    | PT_var_level of { name : Name.t option; level : Level.t }
+    (* TODO: also print id of hole *)
+    | PT_hole_level of { name : Name.t; level : Level.t }
 
   and subst =
     | PS_id
@@ -39,13 +41,8 @@ module Ptree = struct
   let pp_term_syntax ~pp_wrapped ~pp_let ~pp_funct ~pp_apply ~pp_atom
       ~pp_subst_wrapped fmt term =
     match term with
-    | PT_subst { term; subst } ->
-        (* TODO: better notation *)
-        fprintf fmt "%a[%a]" pp_atom term pp_subst_wrapped subst
-    | PT_var_name { name } -> fprintf fmt "%s" (Name.repr name)
-    | PT_var_index { index } -> fprintf fmt "\\-%a" Index.pp index
-    | PT_var_level { level } -> fprintf fmt "\\+%a" Level.pp level
-    | PT_hole_var_full { id } -> fprintf fmt "_x%d" id
+    | PT_var { name } -> fprintf fmt "%s" (Name.repr name)
+    | PT_hole { name } -> fprintf fmt "_%s" (Name.repr name)
     | PT_forall { param; return } ->
         fprintf fmt "%a -> %a" pp_atom param pp_funct return
     | PT_lambda { param; return } ->
@@ -68,6 +65,21 @@ module Ptree = struct
     | PT_native { native } ->
         (* TODO: this is clearly not the best way*)
         fprintf fmt {|@native(%S)|} native
+    | PT_subst { term; subst } ->
+        (* TODO: better notation *)
+        fprintf fmt "%a[%a]" pp_atom term pp_subst_wrapped subst
+    | PT_var_index { name; index } -> (
+        match name with
+        | Some name -> fprintf fmt "%s\\-%a" (Name.repr name) Index.pp index
+        (* TODO: should this syntax be supported? Maybe as extension *)
+        | None -> fprintf fmt "\\-%a" Index.pp index)
+    | PT_var_level { name; level } -> (
+        match name with
+        | Some name -> fprintf fmt "%s\\-%a" (Name.repr name) Level.pp level
+        (* TODO: should this syntax be supported? Maybe as extension *)
+        | None -> fprintf fmt "\\+%a" Level.pp level)
+    | PT_hole_level { name; level } ->
+        fprintf fmt "_%s\\+%a" (Name.repr name) Level.pp level
 
   let pp_subst_syntax ~pp_wrapped ~pp_atom fmt term =
     match term with
@@ -87,8 +99,8 @@ module Ptree = struct
     let pp_subst_wrapped fmt subst = pp_subst S_wrapped fmt subst in
     match (term, prec) with
     (* TODO: subst as atom is weird *)
-    | ( ( PT_subst _ | PT_var_name _ | PT_var_index _ | PT_var_level _
-        | PT_hole_var_full _ | PT_string _ ),
+    | ( ( PT_var _ | PT_hole _ | PT_string _ | PT_subst _ | PT_var_index _
+        | PT_var_level _ | PT_hole_level _ ),
         (T_wrapped | T_let | T_funct | T_apply | T_atom) )
     | ( ( PT_apply _ | PT_self _ | PT_fix _ | PT_unroll _ | PT_unfold _
         | PT_native _ ),
@@ -179,161 +191,229 @@ module Perror = struct
         fprintf fmt "unknown extension : %a" Name.pp extension
     | PE_unknown_native { native } -> fprintf fmt "unknown native : %S" native
 end
-(* TODO: probably make printer tree *)
-
-type typed_mode = Typed_default | Typed_force
-type loc_mode = Loc_default | Loc_meaningful | Loc_force
-type var_mode = Var_name | Var_full
-
-type config = {
-  typed_mode : typed_mode;
-  loc_mode : loc_mode;
-  var_mode : var_mode;
-}
-
-let _should_print_typed config =
-  match config.typed_mode with Typed_default -> false | Typed_force -> true
-
-let _should_print_loc config ~loc =
-  match config.loc_mode with
-  | Loc_default -> false
-  | Loc_force -> true
-  | Loc_meaningful -> not (Location.is_none loc)
 
 (* TODO: this is hackish *)
 type ex_hole = Ex_hole : _ hole -> ex_hole [@@ocaml.unboxed]
 
-let rec ptree_of_term config next holes term =
+(* TODO: move this into the context *)
+let debug = ref false
+
+module Printer_context : sig
+  type printer_context
+
+  val create :
+    bound_vars:Name.t list -> free_vars:Name.t Level.Map.t -> printer_context
+
+  val name_of_hole : printer_context -> ex_hole -> Name.t
+  val name_of_bound : printer_context -> Index.t -> Name.t option
+  val name_of_free : printer_context -> Level.t -> Name.t option
+  val with_var_bound : printer_context -> name:Name.t -> (unit -> 'a) -> 'a
+end = struct
+  (* TODO: aliases? *)
+  type printer_context = {
+    mutable next : int;
+    (* not locally closed terms *)
+    (* TODO: reuse names *)
+    holes : (ex_hole, Name.t) Hashtbl.t;
+    (* TODO: use stack *)
+    (* TODO: free bound vars *)
+    mutable bound_vars : Name.t list;
+    (* TODO: use stack *)
+    (* TODO: shadowing *)
+    free_vars : Name.t Level.Map.t;
+  }
+
+  let create ~bound_vars ~free_vars =
+    (* TODO: better magic numbers *)
+    (* TODO: reuse tables *)
+    let holes = Hashtbl.create 2 in
+    { next = 0; holes; bound_vars; free_vars }
+
+  let var_name n =
+    let rec letters acc n =
+      (* TODO : make this fast *)
+      let alphabet = 26 in
+      let base = Char.code 'a' in
+      let letter = Char.chr @@ (base + (n mod alphabet)) in
+      let acc = letter :: acc in
+      match n < 26 with true -> acc | false -> letters acc ((n - 26) / 26)
+    in
+    let letters = letters [] n in
+    String.of_seq @@ List.to_seq letters
+
+  let next_var ctx =
+    let var = ctx.next in
+    ctx.next <- var + 1;
+    Name.make (var_name var)
+
+  let name_of_hole ctx hole =
+    match Hashtbl.find_opt ctx.holes hole with
+    | Some var -> var
+    | None ->
+        let var = next_var ctx in
+        Hashtbl.add ctx.holes hole var;
+        var
+
+  let name_of_bound ctx index = List.nth_opt ctx.bound_vars (Index.repr index)
+  let name_of_free ctx level = Level.Map.find_opt level ctx.free_vars
+
+  let with_var_bound ctx ~name k =
+    let snapshot = ctx.bound_vars in
+    ctx.bound_vars <- name :: ctx.bound_vars;
+    let value = k () in
+    ctx.bound_vars <- snapshot;
+    value
+end
+
+open Ptree
+open Perror
+open Printer_context
+
+(* TODO: this is hackish *)
+let name_of_core_pat ctx pat =
+  match pat with
+  | TP_var { name } -> name
+  | TP_hole { hole } -> name_of_hole ctx @@ Ex_hole hole
+
+let name_of_typed_pat ctx pat =
+  let (TPat { pat; type_ = _ }) = pat in
+  name_of_core_pat ctx pat
+
+let with_var_core_bound ctx bound k =
+  let name = name_of_core_pat ctx bound in
+  with_var_bound ctx ~name k
+
+let with_var_typed_bound ctx param k =
+  let name = name_of_typed_pat ctx param in
+  with_var_bound ctx ~name k
+
+let rec ptree_of_term ctx term =
   let open Ptree in
-  let ptree_of_term term = ptree_of_term config next holes term in
-  let ptree_of_core_pat pat = ptree_of_core_pat config next holes pat in
-  let ptree_of_typed_pat pat = ptree_of_typed_pat config next holes pat in
-  let ptree_of_tt_hole hole ~subst =
-    ptree_of_tt_hole config next holes hole ~subst
-  in
   (* TODO: print details *)
+  (* TODO: handle aliases *)
   match tt_match term with
-  (* TODO: bound var should not be reachable  *)
-  | TT_bound_var { index } -> PT_var_index { index }
-  | TT_free_var { level } -> PT_var_level { level }
-  | TT_hole { hole; level = _; subst } ->
-      (* TODO: print hole level *)
-      ptree_of_tt_hole ~subst @@ Ex_hole hole
+  | TT_bound_var { index } -> (
+      let name = name_of_bound ctx index in
+      match (name, !debug) with
+      | None, _ | _, true -> PT_var_index { name; index }
+      | Some name, false -> PT_var { name })
+  | TT_free_var { level } -> (
+      let name = name_of_free ctx level in
+      match (name, !debug) with
+      | None, _ | _, true -> PT_var_level { name; level }
+      | Some name, false -> PT_var { name })
+  | TT_hole { hole; level; subst } ->
+      ptree_of_tt_hole ctx ~level ~subst @@ Ex_hole hole
   | TT_forall { param; return } ->
-      let param = ptree_of_typed_pat param in
-      let return = ptree_of_term return in
+      let return =
+        with_var_typed_bound ctx param @@ fun () -> ptree_of_term ctx return
+      in
+      (* TODO: weird order *)
+      let param = ptree_of_typed_pat ctx param in
       PT_forall { param; return }
   | TT_lambda { param; return } ->
-      let param = ptree_of_typed_pat param in
-      let return = ptree_of_term return in
+      let return =
+        with_var_typed_bound ctx param @@ fun () -> ptree_of_term ctx return
+      in
+      let param = ptree_of_typed_pat ctx param in
+      (* TODO: weird order *)
       PT_lambda { param; return }
   | TT_apply { lambda; arg } ->
-      let lambda = ptree_of_term lambda in
-      let arg = ptree_of_term arg in
+      let lambda = ptree_of_term ctx lambda in
+      let arg = ptree_of_term ctx arg in
       PT_apply { lambda; arg }
   | TT_self { var; body } ->
-      let bound = ptree_of_core_pat var in
-      let body = ptree_of_term body in
+      let body =
+        with_var_core_bound ctx var @@ fun () -> ptree_of_term ctx body
+      in
+      (* TODO: weird order *)
+      let bound = ptree_of_core_pat ctx var in
       PT_self { bound; body }
   | TT_fix { var; body } ->
-      let bound = ptree_of_core_pat var in
-      let body = ptree_of_term body in
+      let body =
+        with_var_core_bound ctx var @@ fun () -> ptree_of_term ctx body
+      in
+      (* TODO: weird order *)
+      let bound = ptree_of_core_pat ctx var in
       PT_fix { bound; body }
   | TT_unroll { term } ->
-      let term = ptree_of_term term in
+      let term = ptree_of_term ctx term in
       PT_unroll { term }
   | TT_unfold { term } ->
-      let term = ptree_of_term term in
+      let term = ptree_of_term ctx term in
       PT_unfold { term }
   | TT_let { bound; value; return } ->
-      let bound = ptree_of_typed_pat bound in
-      let value = ptree_of_term value in
-      let return = ptree_of_term return in
+      let value = ptree_of_term ctx value in
+      let return =
+        with_var_typed_bound ctx bound @@ fun () -> ptree_of_term ctx return
+      in
+      let bound = ptree_of_typed_pat ctx bound in
+      (* TODO: weird order *)
       PT_let { bound; value; return }
   | TT_annot { term; annot } ->
-      let term = ptree_of_term term in
-      let annot = ptree_of_term annot in
+      let term = ptree_of_term ctx term in
+      let annot = ptree_of_term ctx annot in
       PT_annot { term; annot }
   | TT_string { literal } -> PT_string { literal }
   | TT_native { native } ->
       let native = match native with TN_debug -> "debug" in
       PT_native { native }
 
-and ptree_of_subst config next holes subst =
+and ptree_of_subst ctx subst =
   let open Ptree in
-  let ptree_of_subst subst = ptree_of_subst config next holes subst in
   (* TODO: print details *)
   match subst with
   | TS_id -> PS_id
   | TS_open { to_ } -> PS_open { to_ }
   | TS_close { from } -> PS_close { from }
   | TS_lift { subst } ->
-      let subst = ptree_of_subst subst in
+      let subst = ptree_of_subst ctx subst in
       PS_lift { subst }
   | TS_cons { subst; next } ->
-      let subst = ptree_of_subst subst in
-      let next = ptree_of_subst next in
+      let subst = ptree_of_subst ctx subst in
+      let next = ptree_of_subst ctx next in
       PS_cons { subst; next }
 
-and ptree_of_typed_pat config next holes pat =
+and ptree_of_typed_pat ctx pat =
   let open Ptree in
-  let ptree_of_term term = ptree_of_term config next holes term in
-  let ptree_of_core_pat term = ptree_of_core_pat config next holes term in
   let (TPat { pat; type_ }) = pat in
   (* TODO: calling this term is weird *)
-  let term = ptree_of_core_pat pat in
-  let type_ = ptree_of_term type_ in
+  let term = ptree_of_core_pat ctx pat in
+  let type_ = ptree_of_term ctx type_ in
   PT_annot { term; annot = type_ }
 
-and ptree_of_core_pat config next holes pat =
+and ptree_of_core_pat ctx pat =
   let open Ptree in
-  let ptree_of_tpat_hole hole = ptree_of_tpat_hole config next holes hole in
   (* TODO: expand head here? *)
   match tp_repr pat with
-  | TP_hole { hole } -> ptree_of_tpat_hole @@ Ex_hole hole
-  | TP_var { name } -> PT_var_name { name }
+  | TP_hole { hole } -> ptree_of_tpat_hole ctx @@ Ex_hole hole
+  | TP_var { name } -> PT_var { name }
 
-and ptree_of_tt_hole config next holes hole ~subst =
-  let open Ptree in
-  let ptree_of_subst subst = ptree_of_subst config next holes subst in
-  (* TODO: extract this into machinery tooling *)
+and ptree_of_tt_hole ctx hole ~level ~subst =
   (* TODO: allow to print link *)
-  match Hashtbl.find_opt holes hole with
-  | Some term -> term
-  | None ->
-      let id = !next in
-      let term = PT_hole_var_full { id } in
-      let term =
-        match subst with
-        | TS_id -> term
-        | subst ->
-            let subst = ptree_of_subst subst in
-            PT_subst { term; subst }
-      in
-      next := id + 1;
-      Hashtbl.add holes hole term;
-      term
-
-and ptree_of_tpat_hole _config next holes hole =
-  let open Ptree in
-  (* TODO: extract this into machinery tooling *)
-  (* TODO: allow to print link *)
-  match Hashtbl.find_opt holes hole with
-  | Some term -> term
-  | None ->
-      let id = !next in
-      let term = PT_hole_var_full { id } in
-      next := id + 1;
-      Hashtbl.add holes hole term;
-      term
-
-and perror_of_error config next holes error =
-  let open Perror in
-  let ptree_of_term term = ptree_of_term config next holes term in
-  let ptree_of_tt_hole hole ~subst =
-    ptree_of_tt_hole config next holes hole ~subst
+  let name = name_of_hole ctx hole in
+  let term =
+    match !debug with
+    | false -> PT_hole { name }
+    | true -> PT_hole_level { name; level }
   in
-  let perror_of_error error = perror_of_error config next holes error in
+  (* TODO: print subst *)
+  let _ =
+    match subst with
+    | TS_id -> term
+    | subst ->
+        let subst = ptree_of_subst ctx subst in
+        PT_subst { term; subst }
+  in
+
+  term
+
+and ptree_of_tpat_hole ctx hole =
+  (* TODO: allow to print link *)
+  let name = name_of_hole ctx hole in
+  PT_hole { name }
+
+and perror_of_error ctx error =
   match error with
   | TError_loc { error; loc } ->
       let rec loop loc error =
@@ -345,7 +425,7 @@ and perror_of_error config next holes error =
             in
             loop loc error
         | error ->
-            let error = perror_of_error error in
+            let error = perror_of_error ctx error in
             PE_loc { loc; error }
       in
       loop loc error
@@ -356,8 +436,13 @@ and perror_of_error config next holes error =
   (* TODO: print hole *)
   | TError_misc_var_occurs { hole; in_ } ->
       (* TODO: subst *)
-      let hole = ptree_of_tt_hole ~subst:TS_id @@ Ex_hole hole in
-      let in_ = ptree_of_tt_hole ~subst:TS_id @@ Ex_hole in_ in
+      (* TODO: Level.zero here is hackish *)
+      let hole =
+        ptree_of_tt_hole ctx ~level:Level.zero ~subst:TS_id @@ Ex_hole hole
+      in
+      let in_ =
+        ptree_of_tt_hole ctx ~level:Level.zero ~subst:TS_id @@ Ex_hole in_
+      in
       PE_var_occurs { hole; in_ }
   | TError_misc_var_escape { var } -> PE_var_escape { var }
   | TError_unify_unfold_found _ -> PE_fallback { error }
@@ -367,14 +452,14 @@ and perror_of_error config next holes error =
   | TError_unify_free_var_clash { expected; received } ->
       PE_free_var_clash { expected; received }
   | TError_unify_type_clash { expected; received } ->
-      let expected = ptree_of_term expected in
-      let received = ptree_of_term received in
+      let expected = ptree_of_term ctx expected in
+      let received = ptree_of_term ctx received in
       PE_type_clash { expected; received }
   | TError_unify_string_clash { expected; received } ->
       PE_string_clash { expected; received }
   | TError_typer_unknown_var { name } -> PE_unknown_var { name }
   | TError_typer_not_a_forall { type_ } ->
-      let type_ = ptree_of_term type_ in
+      let type_ = ptree_of_term ctx type_ in
       PE_not_a_forall { type_ }
   | TError_typer_pairs_not_implemented ->
       PE_pairs_not_implemented (* TODO: print payload *)
@@ -382,30 +467,37 @@ and perror_of_error config next holes error =
       PE_unknown_extension { extension }
   | TError_typer_unknown_native { native } -> PE_unknown_native { native }
 
-let config =
-  { typed_mode = Typed_default; loc_mode = Loc_default; var_mode = Var_name }
-
-let pp_term fmt term =
-  let next = ref 0 in
-  let holes = Hashtbl.create 8 in
-  let pterm = ptree_of_term config next holes term in
+let raw_pp_term ~bound_vars ~free_vars fmt term =
+  let ctx = Printer_context.create ~bound_vars ~free_vars in
+  let pterm = ptree_of_term ctx term in
   Ptree.pp_term fmt pterm
 
-let pp_term_hole fmt hole =
-  let next = ref 0 in
-  let holes = Hashtbl.create 8 in
-  (* TODO: this is weird *)
-  let pterm = ptree_of_tt_hole config next holes ~subst:TS_id @@ Ex_hole hole in
+let raw_pp_term_hole ~bound_vars ~free_vars fmt hole =
+  let ctx = Printer_context.create ~bound_vars ~free_vars in
+  (* TODO: subst and level *)
+  let pterm =
+    ptree_of_tt_hole ctx ~level:Level.zero ~subst:TS_id @@ Ex_hole hole
+  in
   Ptree.pp_term fmt pterm
 
-let pp_subst fmt subst =
-  let next = ref 0 in
-  let holes = Hashtbl.create 8 in
-  let psubst = ptree_of_subst config next holes subst in
+let raw_pp_subst ~bound_vars ~free_vars fmt subst =
+  let ctx = Printer_context.create ~bound_vars ~free_vars in
+  let psubst = ptree_of_subst ctx subst in
   Ptree.pp_subst fmt psubst
 
-let pp_error fmt error =
-  let next = ref 0 in
-  let holes = Hashtbl.create 8 in
-  let perror = perror_of_error config next holes error in
+let raw_pp_error ~bound_vars ~free_vars fmt error =
+  let ctx = Printer_context.create ~bound_vars ~free_vars in
+  let perror = perror_of_error ctx error in
   Perror.pp_error fmt perror
+
+let pp_term fmt term =
+  raw_pp_term ~bound_vars:[] ~free_vars:Level.Map.empty fmt term
+
+let pp_term_hole fmt hole =
+  raw_pp_term_hole ~bound_vars:[] ~free_vars:Level.Map.empty fmt hole
+
+let pp_subst fmt subst =
+  raw_pp_subst ~bound_vars:[] ~free_vars:Level.Map.empty fmt subst
+
+let pp_error fmt error =
+  raw_pp_error ~bound_vars:[] ~free_vars:Level.Map.empty fmt error

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -1,6 +1,37 @@
 open Ttree
 open Terror
 
+val debug : bool ref
+
+(* TODO: bad API *)
+val raw_pp_term :
+  bound_vars:Name.t list ->
+  free_vars:Name.t Level.Map.t ->
+  Format.formatter ->
+  term ->
+  unit
+
+val raw_pp_term_hole :
+  bound_vars:Name.t list ->
+  free_vars:Name.t Level.Map.t ->
+  Format.formatter ->
+  term hole ->
+  unit
+
+val raw_pp_subst :
+  bound_vars:Name.t list ->
+  free_vars:Name.t Level.Map.t ->
+  Format.formatter ->
+  subst ->
+  unit
+
+val raw_pp_error :
+  bound_vars:Name.t list ->
+  free_vars:Name.t Level.Map.t ->
+  Format.formatter ->
+  error ->
+  unit
+
 val pp_term : Format.formatter -> term -> unit
 val pp_term_hole : Format.formatter -> term hole -> unit
 val pp_subst : Format.formatter -> subst -> unit


### PR DESCRIPTION
## Goals

Improve error and terms printing.

## Context

Due to Teika version of locally nameless names are not available at all in the typed tree, and currently even the ones that are(in binders) are ignored. This patch improves on both dimensions, by having a context for printing where names can be accumulated and by also reading the data available in the typed tree.