### PR TITLE
syntax: split library

### DIFF
--- a/syntax/dune
+++ b/syntax/dune
@@ -1,0 +1,9 @@
+(library
+ (name syntax)
+ (libraries menhirLib compiler-libs.common)
+ (preprocess
+  (pps ppx_deriving.eq ppx_deriving.ord ppx_deriving.show sedlex.ppx)))
+
+(menhir
+ (modules sparser)
+ (flags --dump --explain))

--- a/syntax/lparser.ml
+++ b/syntax/lparser.ml
@@ -1,0 +1,83 @@
+open Stree
+open Ltree
+
+exception Invalid_notation of { loc : Location.t }
+
+let invalid_notation loc = raise (Invalid_notation { loc })
+
+let rec parse_term ~loc term =
+  match term with
+  | ST_loc { term; loc } ->
+      let term = parse_term ~loc term in
+      LT_loc { term; loc }
+  | ST_parens { content } -> parse_term ~loc content
+  | ST_var { var } -> LT_var { var }
+  | ST_extension _ -> invalid_notation loc
+  | ST_forall { param; return } ->
+      let param = parse_pat ~loc param in
+      let return = parse_term ~loc return in
+      LT_forall { param; return }
+  | ST_lambda { param; return } ->
+      let param = parse_pat ~loc param in
+      let return = parse_term ~loc return in
+      LT_lambda { param; return }
+  | ST_apply { lambda; arg } -> parse_apply ~loc ~lambda ~arg
+  | ST_pair { left = _; right = _ } ->
+      (* TODO: better error *)
+      invalid_notation loc
+  | ST_both _ -> invalid_notation loc
+  | ST_bind _ -> invalid_notation loc
+  | ST_semi { left; right } ->
+      let bound = parse_bind ~loc left in
+      let return = parse_term ~loc right in
+      LT_let { bound; return }
+  | ST_annot { value; annot } ->
+      let term = parse_term ~loc value in
+      let annot = parse_term ~loc annot in
+      LT_annot { term; annot }
+  | ST_string { literal } -> LT_string { literal }
+  | ST_braces _ -> invalid_notation loc
+
+and parse_bind ~loc term =
+  match term with
+  | ST_loc { term; loc } -> parse_bind ~loc term
+  | ST_bind { bound = pat; value } ->
+      let pat = parse_pat ~loc pat in
+      let value = parse_term ~loc value in
+      LBind { loc; pat; value }
+  | ST_var _ | ST_extension _ | ST_forall _ | ST_lambda _ | ST_apply _
+  | ST_pair _ | ST_both _ | ST_semi _ | ST_annot _ | ST_string _ | ST_parens _
+  | ST_braces _ ->
+      invalid_notation loc
+
+and parse_apply ~loc ~lambda ~arg =
+  (* TODO: is this fallback of locations okay? *)
+  match lambda with
+  | ST_loc { term = lambda; loc } -> parse_apply ~loc ~lambda ~arg
+  (* TODO: ST_parens? *)
+  | ST_extension { extension } ->
+      let payload = parse_term ~loc arg in
+      let term = LT_extension { extension; payload } in
+      (* TODO: this is not ideal *)
+      LT_loc { term; loc }
+  | _ ->
+      let lambda = parse_term ~loc lambda in
+      let arg = parse_term ~loc arg in
+      LT_apply { lambda; arg }
+
+and parse_pat ~loc term =
+  (* TODO: Stack of locs? *)
+  match term with
+  | ST_loc { term; loc } ->
+      let pat = parse_pat ~loc term in
+      LP_loc { pat; loc }
+  | ST_parens { content } -> parse_pat ~loc content
+  | ST_var { var } -> LP_var { var }
+  | ST_pair { left = _; right = _ } -> invalid_notation loc
+  | ST_annot { value = pat; annot } ->
+      let pat = parse_pat ~loc pat in
+      let annot = parse_term ~loc annot in
+      LP_annot { pat; annot }
+  | ST_extension _ | ST_forall _ | ST_lambda _ | ST_apply _ | ST_both _
+  | ST_bind _ | ST_semi _ | ST_string _ | ST_braces _ ->
+      invalid_notation loc

--- a/syntax/lparser.mli
+++ b/syntax/lparser.mli
@@ -1,0 +1,1 @@
+val parse_term : loc:Warnings.loc -> Stree.term -> Ltree.term

--- a/syntax/ltree.ml
+++ b/syntax/ltree.ml
@@ -1,0 +1,22 @@
+type term =
+  | LT_loc of { term : term; loc : Location.t [@opaque] }
+  | LT_var of { var : Name.t }
+  | LT_extension of { extension : Name.t; payload : term }
+  | LT_forall of { param : pat; return : term }
+  | LT_lambda of { param : pat; return : term }
+  | LT_apply of { lambda : term; arg : term }
+  | LT_self of { bound : pat; body : term }
+  | LT_fix of { bound : pat; body : term }
+  | LT_unroll of { term : term }
+  | LT_let of { bound : bind; return : term }
+  | LT_annot of { term : term; annot : term }
+  | LT_string of { literal : string }
+
+and pat =
+  | LP_loc of { pat : pat; loc : Location.t [@opaque] }
+  | LP_var of { var : Name.t }
+  | LP_unroll of { pat : pat }
+  | LP_annot of { pat : pat; annot : term }
+
+and bind = LBind of { loc : Location.t; [@opaque] pat : pat; value : term }
+[@@deriving show { with_path = false }]

--- a/syntax/ltree.mli
+++ b/syntax/ltree.mli
@@ -1,0 +1,36 @@
+type term =
+  | LT_loc of { term : term; loc : Location.t }
+  (* x *)
+  | LT_var of { var : Name.t }
+  (* @x(e) *)
+  | LT_extension of { extension : Name.t; payload : term }
+  (* (x : A) -> (z : B) *)
+  | LT_forall of { param : pat; return : term }
+  (* (x : A) => e *)
+  | LT_lambda of { param : pat; return : term }
+  (* l a *)
+  | LT_apply of { lambda : term; arg : term }
+  (* P @-> m *)
+  | LT_self of { bound : pat; body : term }
+  (* P @=> m *)
+  | LT_fix of { bound : pat; body : term }
+  (* @m *)
+  | LT_unroll of { term : term }
+  (* p = v; r *)
+  | LT_let of { bound : bind; return : term }
+  (* (v : T) *)
+  | LT_annot of { term : term; annot : term }
+  (* ".." *)
+  | LT_string of { literal : string }
+
+and pat =
+  | LP_loc of { pat : pat; loc : Location.t }
+  (* x *)
+  | LP_var of { var : Name.t }
+  (* @p *)
+  | LP_unroll of { pat : pat }
+  (* (p : T) *)
+  | LP_annot of { pat : pat; annot : term }
+
+and bind = LBind of { loc : Location.t; pat : pat; value : term }
+[@@deriving show]

--- a/syntax/name.ml
+++ b/syntax/name.ml
@@ -1,0 +1,8 @@
+type name = string
+and t = name [@@deriving show, eq, ord]
+
+let make t = t
+let repr t = t
+
+module Map = Map.Make (String)
+module Tbl = Hashtbl.Make (String)

--- a/syntax/name.mli
+++ b/syntax/name.mli
@@ -1,0 +1,9 @@
+type name
+type t = name [@@deriving show, eq, ord]
+
+val make : string -> name
+val repr : name -> string
+
+(* TODO: stop exposing this? *)
+module Map : Map.S with type key = name
+module Tbl : Hashtbl.S with type key = name

--- a/syntax/slexer.ml
+++ b/syntax/slexer.ml
@@ -1,0 +1,47 @@
+open Sparser
+open Sedlexing.Utf8
+
+(* TODO: more information *)
+exception Lexer_unknown_token
+
+let whitespace = [%sedlex.regexp? Plus (' ' | '\t' | '\n')]
+let alphabet = [%sedlex.regexp? 'a' .. 'z' | 'A' .. 'Z']
+let digit = [%sedlex.regexp? '0' .. '9']
+let variable = [%sedlex.regexp? (alphabet | '_'), Star (alphabet | digit | '_')]
+let extension = [%sedlex.regexp? '%', variable]
+let string = [%sedlex.regexp? '"', Star (Sub (any, '"')), '"']
+
+let rec tokenizer buf =
+  match%sedlex buf with
+  | whitespace -> tokenizer buf
+  | variable -> VAR (lexeme buf)
+  | extension -> EXTENSION (lexeme buf)
+  | ":" -> COLON
+  | "->" -> ARROW
+  | "=>" -> FAT_ARROW
+  | "=" -> EQUAL
+  | "," -> COMMA
+  | "&" -> AMPERSAND
+  | ";" -> SEMICOLON
+  | string ->
+      (* TODO: this should probably be somewhere else *)
+      let literal = lexeme buf in
+      (* TODO: this is dangerous *)
+      let literal = String.sub literal 1 (String.length literal - 2) in
+      STRING literal
+  | "(" -> LEFT_PARENS
+  | ")" -> RIGHT_PARENS
+  | "{" -> LEFT_BRACE
+  | "}" -> RIGHT_BRACE
+  | eof -> EOF
+  | _ -> raise Lexer_unknown_token
+
+let provider buf () =
+  let token = tokenizer buf in
+  let start, stop = Sedlexing.lexing_positions buf in
+  (token, start, stop)
+
+let from_string parser string =
+  let buf = from_string string in
+  let provider = provider buf in
+  MenhirLib.Convert.Simplified.traditional2revised parser provider

--- a/syntax/slexer.mli
+++ b/syntax/slexer.mli
@@ -1,0 +1,2 @@
+val from_string :
+  (Sparser.token, 'a) MenhirLib.Convert.traditional -> string -> 'a

--- a/syntax/sparser.mly
+++ b/syntax/sparser.mly
@@ -1,0 +1,113 @@
+%{
+open Stree
+
+let mk (loc_start, loc_end) =
+  Location.{ loc_start; loc_end; loc_ghost = false }
+
+%}
+%token <string> VAR (* x *)
+%token COLON (* : *)
+%token ARROW (* -> *)
+%token FAT_ARROW (* => *)
+%token EQUAL (* = *)
+%token COMMA (* , *)
+%token AMPERSAND (* & *)
+%token SEMICOLON (* ; *)
+%token <string> STRING (* ".." *)
+%token LEFT_PARENS (* ( *)
+%token RIGHT_PARENS (* ) *)
+%token LEFT_BRACE (* { *)
+%token RIGHT_BRACE (* } *)
+%token <string> EXTENSION (* @x *)
+
+%token EOF
+
+%start <Stree.term option> term_opt
+
+%%
+
+let term_opt :=
+  | EOF;
+    { None }
+  | term = term; EOF;
+    { Some term }
+
+let term := term_rec_semi
+
+let term_rec_semi :=
+  | term_rec_bind
+  | term_semi(term_rec_semi, term_rec_bind)
+
+let term_rec_bind :=
+  | term_rec_funct
+  | term_bind(term_rec_funct, term_rec_funct)
+
+let term_rec_funct :=
+  | term_rec_apply
+  | term_forall(term_rec_funct, term_rec_apply)
+  | term_lambda(term_rec_funct, term_rec_apply)
+
+let term_rec_apply :=
+  | term_atom
+  | term_apply(term_rec_apply, term_atom)
+
+let term_atom :=
+  | term_var
+  | term_extension
+  | term_string
+  | term_parens(term_wrapped)
+  | term_braces(term_wrapped)
+
+let term_wrapped := term_rec_pair
+
+let term_rec_pair :=
+  | term_rec_both
+  | term_pair(term_rec_pair, term_rec_both)
+
+let term_rec_both :=
+  | term_rec_annot
+  | term_both(term_rec_both, term_rec_annot)
+
+let term_rec_annot :=
+  | term
+  | term_annot(term_rec_annot, term_rec_funct)
+
+let term_var ==
+  | var = VAR;
+    { st_var (mk $loc) ~var:(Name.make var) }
+let term_extension ==
+  | extension = EXTENSION;
+    { st_extension (mk $loc) ~extension:(Name.make extension) }
+let term_forall(self, lower) ==
+  | param = lower; ARROW; return = self;
+    { st_forall (mk $loc) ~param ~return }
+let term_lambda(self, lower) ==
+  | param = lower; FAT_ARROW; return = self;
+    { st_lambda (mk $loc) ~param ~return }
+let term_apply(self, lower) ==
+  | lambda = self; arg = lower;
+    { st_apply (mk $loc) ~lambda ~arg }
+let term_pair(self, lower) ==
+  | left = lower; COMMA; right = self;
+    { st_pair (mk $loc) ~left ~right }
+let term_both(self, lower) ==
+  | left = lower; AMPERSAND; right = self;
+    { st_both (mk $loc) ~left ~right }
+let term_bind(self, lower) ==
+  | bound = lower; EQUAL; value = lower;
+    { st_bind (mk $loc) ~bound ~value }
+let term_semi(self, lower) ==
+  | left = lower; SEMICOLON; right = self;
+    { st_semi (mk $loc) ~left ~right }
+let term_annot(self, lower) ==
+  | value = lower; COLON; annot = self;
+    { st_annot (mk $loc) ~value ~annot }
+let term_string ==
+  | literal = STRING;
+    { st_string (mk $loc) ~literal }
+let term_parens(content) ==
+  | LEFT_PARENS; content = content; RIGHT_PARENS;
+    { st_parens (mk $loc) ~content }
+let term_braces(content) ==
+  | LEFT_BRACE; content = content; RIGHT_BRACE;
+    { st_braces (mk $loc) ~content }

--- a/syntax/sparser.mly
+++ b/syntax/sparser.mly
@@ -13,12 +13,12 @@ let mk (loc_start, loc_end) =
 %token COMMA (* , *)
 %token AMPERSAND (* & *)
 %token SEMICOLON (* ; *)
-%token <string> STRING (* ".." *)
+%token <string> STRING (* "abc" *)
 %token LEFT_PARENS (* ( *)
 %token RIGHT_PARENS (* ) *)
 %token LEFT_BRACE (* { *)
 %token RIGHT_BRACE (* } *)
-%token <string> EXTENSION (* @x *)
+%token <string> EXTENSION (* %x *)
 
 %token EOF
 
@@ -32,7 +32,19 @@ let term_opt :=
   | term = term; EOF;
     { Some term }
 
-let term := term_rec_semi
+let term := term_rec_pair
+
+let term_rec_pair :=
+  | term_rec_both
+  | term_pair(term_rec_pair, term_rec_both)
+
+let term_rec_both :=
+  | term_rec_annot
+  | term_both(term_rec_both, term_rec_annot)
+
+let term_rec_annot :=
+  | term_rec_semi
+  | term_annot(term_rec_annot, term_rec_funct)
 
 let term_rec_semi :=
   | term_rec_bind
@@ -55,22 +67,8 @@ let term_atom :=
   | term_var
   | term_extension
   | term_string
-  | term_parens(term_wrapped)
-  | term_braces(term_wrapped)
-
-let term_wrapped := term_rec_pair
-
-let term_rec_pair :=
-  | term_rec_both
-  | term_pair(term_rec_pair, term_rec_both)
-
-let term_rec_both :=
-  | term_rec_annot
-  | term_both(term_rec_both, term_rec_annot)
-
-let term_rec_annot :=
-  | term
-  | term_annot(term_rec_annot, term_rec_funct)
+  | term_parens(term)
+  | term_braces(term)
 
 let term_var ==
   | var = VAR;

--- a/syntax/stree.ml
+++ b/syntax/stree.ml
@@ -1,6 +1,6 @@
 type term =
   (* TODO: printer location *)
-  | ST_loc of { loc : Location.t; [@opaque] term : term }
+  | ST_loc of { term : term; loc : Location.t [@opaque] }
   | ST_var of { var : Name.t }
   | ST_extension of { extension : Name.t }
   | ST_forall of { param : term; return : term }

--- a/syntax/stree.ml
+++ b/syntax/stree.ml
@@ -1,0 +1,32 @@
+type term =
+  (* TODO: printer location *)
+  | ST_loc of { loc : Location.t; [@opaque] term : term }
+  | ST_var of { var : Name.t }
+  | ST_extension of { extension : Name.t }
+  | ST_forall of { param : term; return : term }
+  | ST_lambda of { param : term; return : term }
+  | ST_apply of { lambda : term; arg : term }
+  | ST_pair of { left : term; right : term }
+  | ST_both of { left : term; right : term }
+  | ST_bind of { bound : term; value : term }
+  | ST_semi of { left : term; right : term }
+  | ST_annot of { value : term; annot : term }
+  | ST_string of { literal : string }
+  | ST_parens of { content : term }
+  | ST_braces of { content : term }
+[@@deriving show { with_path = false }]
+
+let st_loc loc term = ST_loc { loc; term }
+let st_var loc ~var = st_loc loc (ST_var { var })
+let st_extension loc ~extension = st_loc loc (ST_extension { extension })
+let st_forall loc ~param ~return = st_loc loc (ST_forall { param; return })
+let st_lambda loc ~param ~return = st_loc loc (ST_lambda { param; return })
+let st_apply loc ~lambda ~arg = st_loc loc (ST_apply { lambda; arg })
+let st_pair loc ~left ~right = st_loc loc (ST_pair { left; right })
+let st_both loc ~left ~right = st_loc loc (ST_both { left; right })
+let st_bind loc ~bound ~value = st_loc loc (ST_bind { bound; value })
+let st_semi loc ~left ~right = st_loc loc (ST_semi { left; right })
+let st_annot loc ~value ~annot = st_loc loc (ST_annot { value; annot })
+let st_string loc ~literal = st_loc loc (ST_string { literal })
+let st_parens loc ~content = st_loc loc (ST_parens { content })
+let st_braces loc ~content = st_loc loc (ST_braces { content })

--- a/syntax/stree.mli
+++ b/syntax/stree.mli
@@ -1,0 +1,30 @@
+type term =
+  | ST_loc of { loc : Location.t; term : term }
+  | ST_var of { var : Name.t }
+  | ST_extension of { extension : Name.t }
+  | ST_forall of { param : term; return : term }
+  | ST_lambda of { param : term; return : term }
+  | ST_apply of { lambda : term; arg : term }
+  | ST_pair of { left : term; right : term }
+  | ST_both of { left : term; right : term }
+  | ST_bind of { bound : term; value : term }
+  | ST_semi of { left : term; right : term }
+  | ST_annot of { value : term; annot : term }
+  | ST_string of { literal : string }
+  | ST_parens of { content : term }
+  | ST_braces of { content : term }
+[@@deriving show]
+
+val st_var : Location.t -> var:Name.t -> term
+val st_extension : Location.t -> extension:Name.t -> term
+val st_forall : Location.t -> param:term -> return:term -> term
+val st_lambda : Location.t -> param:term -> return:term -> term
+val st_apply : Location.t -> lambda:term -> arg:term -> term
+val st_pair : Location.t -> left:term -> right:term -> term
+val st_both : Location.t -> left:term -> right:term -> term
+val st_bind : Location.t -> bound:term -> value:term -> term
+val st_semi : Location.t -> left:term -> right:term -> term
+val st_annot : Location.t -> value:term -> annot:term -> term
+val st_string : Location.t -> literal:string -> term
+val st_parens : Location.t -> content:term -> term
+val st_braces : Location.t -> content:term -> term

--- a/syntax/stree.mli
+++ b/syntax/stree.mli
@@ -1,5 +1,5 @@
 type term =
-  | ST_loc of { loc : Location.t; term : term }
+  | ST_loc of { term : term; loc : Location.t }
   | ST_var of { var : Name.t }
   | ST_extension of { extension : Name.t }
   | ST_forall of { param : term; return : term }


### PR DESCRIPTION
## Goals

As part of #184 both Teika and Smol should share the same syntax / parser.

## Context

The syntax used by Teika and Smol should not be different as such this PR extracts the parser and lexer in a separate dune library. This also does some parser cleaning.