### PR TITLE
syntax: add support for self, fix and unroll

### DIFF
--- a/syntax/ltree.ml
+++ b/syntax/ltree.ml
@@ -5,8 +5,8 @@ type term =
   | LT_forall of { param : pat; return : term }
   | LT_lambda of { param : pat; return : term }
   | LT_apply of { lambda : term; arg : term }
-  | LT_self of { bound : pat; body : term }
-  | LT_fix of { bound : pat; body : term }
+  | LT_self of { self : pat; body : term }
+  | LT_fix of { self : pat; body : term }
   | LT_unroll of { term : term }
   | LT_let of { bound : bind; return : term }
   | LT_annot of { term : term; annot : term }

--- a/syntax/ltree.mli
+++ b/syntax/ltree.mli
@@ -10,10 +10,10 @@ type term =
   | LT_lambda of { param : pat; return : term }
   (* l a *)
   | LT_apply of { lambda : term; arg : term }
-  (* P @-> m *)
-  | LT_self of { bound : pat; body : term }
-  (* P @=> m *)
-  | LT_fix of { bound : pat; body : term }
+  (* x @-> m *)
+  | LT_self of { self : pat; body : term }
+  (* (@T : A) @=> m *)
+  | LT_fix of { self : pat; body : term }
   (* @m *)
   | LT_unroll of { term : term }
   (* p = v; r *)

--- a/syntax/slexer.ml
+++ b/syntax/slexer.ml
@@ -19,6 +19,9 @@ let rec tokenizer buf =
   | ":" -> COLON
   | "->" -> ARROW
   | "=>" -> FAT_ARROW
+  | "@->" -> SELF_ARROW
+  | "@=>" -> FIX_ARROW
+  | "@" -> UNROLL
   | "=" -> EQUAL
   | "," -> COMMA
   | "&" -> AMPERSAND

--- a/syntax/sparser.mly
+++ b/syntax/sparser.mly
@@ -9,6 +9,9 @@ let mk (loc_start, loc_end) =
 %token COLON (* : *)
 %token ARROW (* -> *)
 %token FAT_ARROW (* => *)
+%token SELF_ARROW (* @-> *)
+%token FIX_ARROW (* @=> *)
+%token UNROLL (* @ *)
 %token EQUAL (* = *)
 %token COMMA (* , *)
 %token AMPERSAND (* & *)
@@ -58,10 +61,16 @@ let term_rec_funct :=
   | term_rec_apply
   | term_forall(term_rec_funct, term_rec_apply)
   | term_lambda(term_rec_funct, term_rec_apply)
+  | term_self(term_rec_funct, term_rec_apply)
+  | term_fix(term_rec_funct, term_rec_apply)
 
 let term_rec_apply :=
+  | term_rec_unroll
+  | term_apply(term_rec_apply, term_rec_unroll)
+
+let term_rec_unroll :=
   | term_atom
-  | term_apply(term_rec_apply, term_atom)
+  | term_unroll(term_rec_unroll)
 
 let term_atom :=
   | term_var
@@ -85,6 +94,15 @@ let term_lambda(self, lower) ==
 let term_apply(self, lower) ==
   | lambda = self; arg = lower;
     { st_apply (mk $loc) ~lambda ~arg }
+let term_self(self, lower) ==
+  | self = lower; SELF_ARROW; body = self;
+    { st_self (mk $loc) ~self ~body }
+let term_fix(self, lower) ==
+  | self = lower; FIX_ARROW; body = self;
+    { st_fix (mk $loc) ~self ~body }
+let term_unroll(self) ==
+  | UNROLL; term = self;
+    { st_unroll (mk $loc) ~term }
 let term_pair(self, lower) ==
   | left = lower; COMMA; right = self;
     { st_pair (mk $loc) ~left ~right }

--- a/syntax/stree.ml
+++ b/syntax/stree.ml
@@ -6,6 +6,9 @@ type term =
   | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
+  | ST_self of { self : term; body : term }
+  | ST_fix of { self : term; body : term }
+  | ST_unroll of { term : term }
   | ST_pair of { left : term; right : term }
   | ST_both of { left : term; right : term }
   | ST_bind of { bound : term; value : term }
@@ -22,6 +25,9 @@ let st_extension loc ~extension = st_loc loc (ST_extension { extension })
 let st_forall loc ~param ~return = st_loc loc (ST_forall { param; return })
 let st_lambda loc ~param ~return = st_loc loc (ST_lambda { param; return })
 let st_apply loc ~lambda ~arg = st_loc loc (ST_apply { lambda; arg })
+let st_self loc ~self ~body = st_loc loc (ST_self { self; body })
+let st_fix loc ~self ~body = st_loc loc (ST_fix { self; body })
+let st_unroll loc ~term = st_loc loc (ST_unroll { term })
 let st_pair loc ~left ~right = st_loc loc (ST_pair { left; right })
 let st_both loc ~left ~right = st_loc loc (ST_both { left; right })
 let st_bind loc ~bound ~value = st_loc loc (ST_bind { bound; value })

--- a/syntax/stree.mli
+++ b/syntax/stree.mli
@@ -5,6 +5,9 @@ type term =
   | ST_forall of { param : term; return : term }
   | ST_lambda of { param : term; return : term }
   | ST_apply of { lambda : term; arg : term }
+  | ST_self of { self : term; body : term }
+  | ST_fix of { self : term; body : term }
+  | ST_unroll of { term : term }
   | ST_pair of { left : term; right : term }
   | ST_both of { left : term; right : term }
   | ST_bind of { bound : term; value : term }
@@ -20,6 +23,9 @@ val st_extension : Location.t -> extension:Name.t -> term
 val st_forall : Location.t -> param:term -> return:term -> term
 val st_lambda : Location.t -> param:term -> return:term -> term
 val st_apply : Location.t -> lambda:term -> arg:term -> term
+val st_self : Location.t -> self:term -> body:term -> term
+val st_fix : Location.t -> self:term -> body:term -> term
+val st_unroll : Location.t -> term:term -> term
 val st_pair : Location.t -> left:term -> right:term -> term
 val st_both : Location.t -> left:term -> right:term -> term
 val st_bind : Location.t -> bound:term -> value:term -> term


### PR DESCRIPTION
## Goals

Support self types at the syntax level.

## Context

After #185 the syntax doesn't include support for self types, this PR improves on that.