### PR TITLE
syntax: add support for erasability

### DIFF
--- a/syntax/clexer.ml
+++ b/syntax/clexer.ml
@@ -17,6 +17,7 @@ let rec tokenizer buf =
   | variable -> VAR (lexeme buf)
   | extension -> EXTENSION (lexeme buf)
   | ":" -> COLON
+  | "$" -> GRADE
   | "->" -> ARROW
   | "=>" -> FAT_ARROW
   | "@->" -> SELF_ARROW

--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -7,6 +7,7 @@ let mk (loc_start, loc_end) =
 %}
 %token <string> VAR (* x *)
 %token COLON (* : *)
+%token GRADE (* $ *)
 %token ARROW (* -> *)
 %token FAT_ARROW (* => *)
 %token SELF_ARROW (* @-> *)
@@ -17,6 +18,7 @@ let mk (loc_start, loc_end) =
 %token AMPERSAND (* & *)
 %token SEMICOLON (* ; *)
 %token <string> STRING (* "abc" *)
+%token <int> NUMBER (* 123 *)
 %token LEFT_PARENS (* ( *)
 %token RIGHT_PARENS (* ) *)
 %token LEFT_BRACE (* { *)
@@ -46,8 +48,12 @@ let term_rec_both :=
   | term_both(term_rec_both, term_rec_annot)
 
 let term_rec_annot :=
-  | term_rec_semi
+  | term_rec_grade
   | term_annot(term_rec_annot, term_rec_funct)
+
+let term_rec_grade :=
+  | term_rec_semi
+  | term_grade(term_rec_annot, term_rec_funct)
 
 let term_rec_semi :=
   | term_rec_bind
@@ -76,6 +82,7 @@ let term_atom :=
   | term_var
   | term_extension
   | term_string
+  | term_number
   | term_parens(term)
   | term_braces(term)
 
@@ -85,6 +92,9 @@ let term_var ==
 let term_extension ==
   | extension = EXTENSION;
     { ct_extension (mk $loc) ~extension:(Name.make extension) }
+let term_grade(self, lower) ==
+  | term = lower; GRADE; grade = self;
+    { ct_grade (mk $loc) ~term ~grade }
 let term_forall(self, lower) ==
   | param = lower; ARROW; return = self;
     { ct_forall (mk $loc) ~param ~return }
@@ -121,6 +131,9 @@ let term_annot(self, lower) ==
 let term_string ==
   | literal = STRING;
     { ct_string (mk $loc) ~literal }
+let term_number ==
+  | literal = NUMBER;
+    { ct_number (mk $loc) ~literal }
 let term_parens(content) ==
   | LEFT_PARENS; content = content; RIGHT_PARENS;
     { ct_parens (mk $loc) ~content }

--- a/syntax/ctree.ml
+++ b/syntax/ctree.ml
@@ -3,6 +3,7 @@ type term =
   | CT_loc of { term : term; loc : Location.t [@opaque] }
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
+  | CT_grade of { term : term; grade : term }
   | CT_forall of { param : term; return : term }
   | CT_lambda of { param : term; return : term }
   | CT_apply of { lambda : term; arg : term }
@@ -15,6 +16,7 @@ type term =
   | CT_semi of { left : term; right : term }
   | CT_annot of { value : term; annot : term }
   | CT_string of { literal : string }
+  | CT_number of { literal : int }
   | CT_parens of { content : term }
   | CT_braces of { content : term }
 [@@deriving show { with_path = false }]
@@ -22,6 +24,7 @@ type term =
 let ct_loc loc term = CT_loc { loc; term }
 let ct_var loc ~var = ct_loc loc (CT_var { var })
 let ct_extension loc ~extension = ct_loc loc (CT_extension { extension })
+let ct_grade loc ~term ~grade = ct_loc loc (CT_grade { term; grade })
 let ct_forall loc ~param ~return = ct_loc loc (CT_forall { param; return })
 let ct_lambda loc ~param ~return = ct_loc loc (CT_lambda { param; return })
 let ct_apply loc ~lambda ~arg = ct_loc loc (CT_apply { lambda; arg })
@@ -34,5 +37,6 @@ let ct_bind loc ~bound ~value = ct_loc loc (CT_bind { bound; value })
 let ct_semi loc ~left ~right = ct_loc loc (CT_semi { left; right })
 let ct_annot loc ~value ~annot = ct_loc loc (CT_annot { value; annot })
 let ct_string loc ~literal = ct_loc loc (CT_string { literal })
+let ct_number loc ~literal = ct_loc loc (CT_number { literal })
 let ct_parens loc ~content = ct_loc loc (CT_parens { content })
 let ct_braces loc ~content = ct_loc loc (CT_braces { content })

--- a/syntax/ctree.mli
+++ b/syntax/ctree.mli
@@ -2,6 +2,7 @@ type term =
   | CT_loc of { term : term; loc : Location.t }
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
+  | CT_grade of { term : term; grade : term }
   | CT_forall of { param : term; return : term }
   | CT_lambda of { param : term; return : term }
   | CT_apply of { lambda : term; arg : term }
@@ -14,12 +15,14 @@ type term =
   | CT_semi of { left : term; right : term }
   | CT_annot of { value : term; annot : term }
   | CT_string of { literal : string }
+  | CT_number of { literal : int }
   | CT_parens of { content : term }
   | CT_braces of { content : term }
 [@@deriving show]
 
 val ct_var : Location.t -> var:Name.t -> term
 val ct_extension : Location.t -> extension:Name.t -> term
+val ct_grade : Location.t -> term:term -> grade:term -> term
 val ct_forall : Location.t -> param:term -> return:term -> term
 val ct_lambda : Location.t -> param:term -> return:term -> term
 val ct_apply : Location.t -> lambda:term -> arg:term -> term
@@ -32,5 +35,6 @@ val ct_bind : Location.t -> bound:term -> value:term -> term
 val ct_semi : Location.t -> left:term -> right:term -> term
 val ct_annot : Location.t -> value:term -> annot:term -> term
 val ct_string : Location.t -> literal:string -> term
+val ct_number : Location.t -> literal:int -> term
 val ct_parens : Location.t -> content:term -> term
 val ct_braces : Location.t -> content:term -> term

--- a/syntax/ltree.ml
+++ b/syntax/ltree.ml
@@ -15,6 +15,7 @@ type term =
 and pat =
   | LP_loc of { pat : pat; loc : Location.t [@opaque] }
   | LP_var of { var : Name.t }
+  | LP_grade of { pat : pat; erasable : bool }
   | LP_unroll of { pat : pat }
   | LP_annot of { pat : pat; annot : term }
 

--- a/syntax/ltree.mli
+++ b/syntax/ltree.mli
@@ -27,6 +27,8 @@ and pat =
   | LP_loc of { pat : pat; loc : Location.t }
   (* x *)
   | LP_var of { var : Name.t }
+  (* (p $ n) *)
+  | LP_grade of { pat : pat; erasable : bool }
   (* @p *)
   | LP_unroll of { pat : pat }
   (* (p : T) *)

--- a/syntax/name.ml
+++ b/syntax/name.ml
@@ -5,4 +5,3 @@ let make t = t
 let repr t = t
 
 module Map = Map.Make (String)
-module Tbl = Hashtbl.Make (String)

--- a/syntax/name.mli
+++ b/syntax/name.mli
@@ -6,4 +6,3 @@ val repr : name -> string
 
 (* TODO: stop exposing this? *)
 module Map : Map.S with type key = name
-module Tbl : Hashtbl.S with type key = name


### PR DESCRIPTION
## Goals

Unlock erasable parametric functions.

## Context

Currently there is no way of defining functions erasable functions, this is a main issue as functions such as identity require those `(A : Type $ 0) => (x : A $ 1) => x`.

This PR introduces it in a very limited way, allowing only erasable and non erasable functions.