### PR TITLE
smol: support simple erasable parameters

### DIFF
--- a/smol/stree.ml
+++ b/smol/stree.ml
@@ -20,6 +20,7 @@ and pat =
   | SP_loc of { pat : pat; loc : Location.t [@opaque] }
   (* TODO: extract Syntax.Name *)
   | SP_var of { var : Syntax.Name.t }
+  | SP_erasable of { pat : pat }
   (* TODO: SP_unroll *)
   | SP_annot of { pat : pat; annot : term }
 [@@deriving show]

--- a/smol/stree.mli
+++ b/smol/stree.mli
@@ -18,5 +18,6 @@ and ty_pat = SP_typed of { pat : pat; type_ : term }
 and pat =
   | SP_loc of { pat : pat; loc : Location.t }
   | SP_var of { var : Syntax.Name.t }
+  | SP_erasable of { pat : pat }
   | SP_annot of { pat : pat; annot : term }
 [@@deriving show]

--- a/smol/test.ml
+++ b/smol/test.ml
@@ -5,13 +5,21 @@ type test = { name : string; term : string }
 
 let type_term name term = { name; term }
 
+(* TODO: used variable still usable on type level *)
 let id =
   type_term "id"
-    {|((A : Type) => (x : A) => x
-      :(A : Type) -> (x : A) -> A)|}
+    {|((A : Type $ 0) => (x : A) => x
+      :(A : Type $ 0) -> (x : A) -> A)|}
 
 let id_propagate =
-  type_term "id_propagate" {|(A => x => x : (A : Type) -> (x : A) -> A)|}
+  type_term "id_propagate"
+    {|((A $ 0) => x => x : (A : Type $ 0) -> (x : A) -> A)|}
+
+let apply_erasable =
+  type_term "apply_erasable"
+    {|
+      (A : Type $ 0) => ((A : Type $ 0) => (x : A) => x) A
+    |}
 
 let sequence =
   type_term "sequence"
@@ -219,7 +227,7 @@ let ind_Unit =
   in
   type_term "ind_Unit" code
 
-let tests =
+let _tests =
   [
     id;
     id_propagate;
@@ -232,6 +240,8 @@ let tests =
     ind_False;
     ind_Unit;
   ]
+
+let tests = [ id; id_propagate; apply_erasable ]
 
 let type_term term =
   let term = Clexer.from_string Cparser.term_opt term in

--- a/syntax/clexer.ml
+++ b/syntax/clexer.ml
@@ -10,6 +10,7 @@ let digit = [%sedlex.regexp? '0' .. '9']
 let variable = [%sedlex.regexp? (alphabet | '_'), Star (alphabet | digit | '_')]
 let extension = [%sedlex.regexp? '%', variable]
 let string = [%sedlex.regexp? '"', Star (Sub (any, '"')), '"']
+let number = [%sedlex.regexp? Plus '0' .. '9']
 
 let rec tokenizer buf =
   match%sedlex buf with
@@ -33,6 +34,12 @@ let rec tokenizer buf =
       (* TODO: this is dangerous *)
       let literal = String.sub literal 1 (String.length literal - 2) in
       STRING literal
+  | number ->
+      (* TODO: this should probably be somewhere else *)
+      let literal = lexeme buf in
+      (* TODO: this is dangerous *)
+      let literal = int_of_string literal in
+      NUMBER literal
   | "(" -> LEFT_PARENS
   | ")" -> RIGHT_PARENS
   | "{" -> LEFT_BRACE

--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -44,16 +44,16 @@ let term_rec_pair :=
   | term_pair(term_rec_pair, term_rec_both)
 
 let term_rec_both :=
-  | term_rec_annot
-  | term_both(term_rec_both, term_rec_annot)
-
-let term_rec_annot :=
   | term_rec_grade
-  | term_annot(term_rec_annot, term_rec_funct)
+  | term_both(term_rec_both, term_rec_grade)
 
 let term_rec_grade :=
+  | term_rec_annot
+  | term_grade(term_rec_grade, term_rec_annot)
+
+let term_rec_annot :=
   | term_rec_semi
-  | term_grade(term_rec_annot, term_rec_funct)
+  | term_annot(term_rec_annot, term_rec_funct)
 
 let term_rec_semi :=
   | term_rec_bind

--- a/syntax/lparser.ml
+++ b/syntax/lparser.ml
@@ -90,8 +90,8 @@ and parse_pat ~loc pat =
   | CT_var { var } -> LP_var { var }
   | CT_grade { term = pat; grade } ->
       let pat = parse_pat ~loc pat in
-      let erasable = parse_grade ~loc grade in
-      LP_grade { pat; erasable }
+      let () = parse_grade ~loc grade in
+      LP_erasable { pat }
   | CT_unroll { term = pat } ->
       let pat = parse_pat ~loc pat in
       LP_unroll { pat }
@@ -112,10 +112,7 @@ and parse_grade ~loc grade =
       parse_grade ~loc grade
   | CT_parens { content } -> parse_grade ~loc content
   | CT_number { literal } -> (
-      match literal with
-      | 0 -> true
-      | 1 -> false
-      | _ -> invalid_notation loc (* TODO: annot *))
+      match literal with 0 -> () | _ -> invalid_notation loc (* TODO: annot *))
   | CT_var _ | CT_grade _ | CT_unroll _ | CT_extension _ | CT_forall _
   | CT_lambda _ | CT_self _ | CT_fix _ | CT_apply _ | CT_pair _ | CT_both _
   | CT_bind _ | CT_semi _ | CT_string _ | CT_annot _ | CT_braces _ ->

--- a/syntax/ltree.ml
+++ b/syntax/ltree.ml
@@ -15,7 +15,7 @@ type term =
 and pat =
   | LP_loc of { pat : pat; loc : Location.t [@opaque] }
   | LP_var of { var : Name.t }
-  | LP_grade of { pat : pat; erasable : bool }
+  | LP_erasable of { pat : pat }
   | LP_unroll of { pat : pat }
   | LP_annot of { pat : pat; annot : term }
 

--- a/syntax/ltree.mli
+++ b/syntax/ltree.mli
@@ -27,8 +27,8 @@ and pat =
   | LP_loc of { pat : pat; loc : Location.t }
   (* x *)
   | LP_var of { var : Name.t }
-  (* (p $ n) *)
-  | LP_grade of { pat : pat; erasable : bool }
+  (* (p $ 0) *)
+  | LP_erasable of { pat : pat }
   (* @p *)
   | LP_unroll of { pat : pat }
   (* (p : T) *)


### PR DESCRIPTION
## Goals

Allow for polymorphic only functions.

## Context

As Smol is a linear language, polymorphic functions cannot be trivially done without passing the type around, this prevents simple functions such as identity from working naturally.