### PR TITLE
teika: drop self types

### DIFF
--- a/syntax/clexer.ml
+++ b/syntax/clexer.ml
@@ -21,9 +21,6 @@ let rec tokenizer buf =
   | "$" -> GRADE
   | "->" -> ARROW
   | "=>" -> FAT_ARROW
-  | "@->" -> SELF_ARROW
-  | "@=>" -> FIX_ARROW
-  | "@" -> UNROLL
   | "=" -> EQUAL
   | "," -> COMMA
   | "&" -> AMPERSAND

--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -10,9 +10,6 @@ let mk (loc_start, loc_end) =
 %token GRADE (* $ *)
 %token ARROW (* -> *)
 %token FAT_ARROW (* => *)
-%token SELF_ARROW (* @-> *)
-%token FIX_ARROW (* @=> *)
-%token UNROLL (* @ *)
 %token EQUAL (* = *)
 %token COMMA (* , *)
 %token AMPERSAND (* & *)
@@ -67,16 +64,10 @@ let term_rec_funct :=
   | term_rec_apply
   | term_forall(term_rec_funct, term_rec_apply)
   | term_lambda(term_rec_funct, term_rec_apply)
-  | term_self(term_rec_funct, term_rec_apply)
-  | term_fix(term_rec_funct, term_rec_apply)
 
 let term_rec_apply :=
-  | term_rec_unroll
-  | term_apply(term_rec_apply, term_rec_unroll)
-
-let term_rec_unroll :=
   | term_atom
-  | term_unroll(term_rec_unroll)
+  | term_apply(term_rec_apply, term_atom)
 
 let term_atom :=
   | term_var
@@ -104,15 +95,6 @@ let term_lambda(self, lower) ==
 let term_apply(self, lower) ==
   | lambda = self; arg = lower;
     { ct_apply (mk $loc) ~lambda ~arg }
-let term_self(self, lower) ==
-  | self = lower; SELF_ARROW; body = self;
-    { ct_self (mk $loc) ~self ~body }
-let term_fix(self, lower) ==
-  | self = lower; FIX_ARROW; body = self;
-    { ct_fix (mk $loc) ~self ~body }
-let term_unroll(self) ==
-  | UNROLL; term = self;
-    { ct_unroll (mk $loc) ~term }
 let term_pair(self, lower) ==
   | left = lower; COMMA; right = self;
     { ct_pair (mk $loc) ~left ~right }

--- a/syntax/ctree.ml
+++ b/syntax/ctree.ml
@@ -7,9 +7,6 @@ type term =
   | CT_forall of { param : term; return : term }
   | CT_lambda of { param : term; return : term }
   | CT_apply of { lambda : term; arg : term }
-  | CT_self of { self : term; body : term }
-  | CT_fix of { self : term; body : term }
-  | CT_unroll of { term : term }
   | CT_pair of { left : term; right : term }
   | CT_both of { left : term; right : term }
   | CT_bind of { bound : term; value : term }
@@ -28,9 +25,6 @@ let ct_grade loc ~term ~grade = ct_loc loc (CT_grade { term; grade })
 let ct_forall loc ~param ~return = ct_loc loc (CT_forall { param; return })
 let ct_lambda loc ~param ~return = ct_loc loc (CT_lambda { param; return })
 let ct_apply loc ~lambda ~arg = ct_loc loc (CT_apply { lambda; arg })
-let ct_self loc ~self ~body = ct_loc loc (CT_self { self; body })
-let ct_fix loc ~self ~body = ct_loc loc (CT_fix { self; body })
-let ct_unroll loc ~term = ct_loc loc (CT_unroll { term })
 let ct_pair loc ~left ~right = ct_loc loc (CT_pair { left; right })
 let ct_both loc ~left ~right = ct_loc loc (CT_both { left; right })
 let ct_bind loc ~bound ~value = ct_loc loc (CT_bind { bound; value })

--- a/syntax/ctree.mli
+++ b/syntax/ctree.mli
@@ -6,9 +6,6 @@ type term =
   | CT_forall of { param : term; return : term }
   | CT_lambda of { param : term; return : term }
   | CT_apply of { lambda : term; arg : term }
-  | CT_self of { self : term; body : term }
-  | CT_fix of { self : term; body : term }
-  | CT_unroll of { term : term }
   | CT_pair of { left : term; right : term }
   | CT_both of { left : term; right : term }
   | CT_bind of { bound : term; value : term }
@@ -26,9 +23,6 @@ val ct_grade : Location.t -> term:term -> grade:term -> term
 val ct_forall : Location.t -> param:term -> return:term -> term
 val ct_lambda : Location.t -> param:term -> return:term -> term
 val ct_apply : Location.t -> lambda:term -> arg:term -> term
-val ct_self : Location.t -> self:term -> body:term -> term
-val ct_fix : Location.t -> self:term -> body:term -> term
-val ct_unroll : Location.t -> term:term -> term
 val ct_pair : Location.t -> left:term -> right:term -> term
 val ct_both : Location.t -> left:term -> right:term -> term
 val ct_bind : Location.t -> bound:term -> value:term -> term

--- a/syntax/lparser.ml
+++ b/syntax/lparser.ml
@@ -23,17 +23,6 @@ let rec parse_term ~loc term =
       let return = parse_term ~loc return in
       LT_lambda { param; return }
   | CT_apply { lambda; arg } -> parse_apply ~loc ~lambda ~arg
-  | CT_self { self; body } ->
-      let self = parse_pat ~loc self in
-      let body = parse_term ~loc body in
-      LT_self { self; body }
-  | CT_fix { self; body } ->
-      let self = parse_pat ~loc self in
-      let body = parse_term ~loc body in
-      LT_fix { self; body }
-  | CT_unroll { term } ->
-      let term = parse_term ~loc term in
-      LT_unroll { term }
   | CT_pair { left = _; right = _ } ->
       (* TODO: better error *)
       invalid_notation loc
@@ -59,9 +48,8 @@ and parse_bind ~loc term =
       let value = parse_term ~loc value in
       LBind { loc; pat; value }
   | CT_var _ | CT_extension _ | CT_grade _ | CT_forall _ | CT_lambda _
-  | CT_apply _ | CT_self _ | CT_fix _ | CT_unroll _ | CT_pair _ | CT_both _
-  | CT_semi _ | CT_annot _ | CT_string _ | CT_number _ | CT_parens _
-  | CT_braces _ ->
+  | CT_apply _ | CT_pair _ | CT_both _ | CT_semi _ | CT_annot _ | CT_string _
+  | CT_number _ | CT_parens _ | CT_braces _ ->
       invalid_notation loc
 
 and parse_apply ~loc ~lambda ~arg =
@@ -92,17 +80,13 @@ and parse_pat ~loc pat =
       let pat = parse_pat ~loc pat in
       let () = parse_grade ~loc grade in
       LP_erasable { pat }
-  | CT_unroll { term = pat } ->
-      let pat = parse_pat ~loc pat in
-      LP_unroll { pat }
   | CT_pair { left = _; right = _ } -> invalid_notation loc
   | CT_annot { value = pat; annot } ->
       let pat = parse_pat ~loc pat in
       let annot = parse_term ~loc annot in
       LP_annot { pat; annot }
-  | CT_extension _ | CT_forall _ | CT_lambda _ | CT_self _ | CT_fix _
-  | CT_apply _ | CT_both _ | CT_bind _ | CT_semi _ | CT_string _ | CT_number _
-  | CT_braces _ ->
+  | CT_extension _ | CT_forall _ | CT_lambda _ | CT_apply _ | CT_both _
+  | CT_bind _ | CT_semi _ | CT_string _ | CT_number _ | CT_braces _ ->
       invalid_notation loc
 
 and parse_grade ~loc grade =
@@ -113,7 +97,7 @@ and parse_grade ~loc grade =
   | CT_parens { content } -> parse_grade ~loc content
   | CT_number { literal } -> (
       match literal with 0 -> () | _ -> invalid_notation loc (* TODO: annot *))
-  | CT_var _ | CT_grade _ | CT_unroll _ | CT_extension _ | CT_forall _
-  | CT_lambda _ | CT_self _ | CT_fix _ | CT_apply _ | CT_pair _ | CT_both _
-  | CT_bind _ | CT_semi _ | CT_string _ | CT_annot _ | CT_braces _ ->
+  | CT_var _ | CT_grade _ | CT_extension _ | CT_forall _ | CT_lambda _
+  | CT_apply _ | CT_pair _ | CT_both _ | CT_bind _ | CT_semi _ | CT_string _
+  | CT_annot _ | CT_braces _ ->
       invalid_notation loc

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -402,7 +402,7 @@ module Typer = struct
         x => (A : Type) => y => (id => (_ = (id x); _ = id y; (y : A))) (x => x)
       |}
 
-  let _tests =
+  let tests =
     [
       univ_type;
       string_type;
@@ -430,8 +430,6 @@ module Typer = struct
       bound_var_escape_check;
       hole_lowering_check;
     ]
-
-  let tests = [ id ]
 
   (* alcotest *)
   let test test =

--- a/teika/tmachinery.mli
+++ b/teika/tmachinery.mli
@@ -6,5 +6,4 @@ val tt_apply_subst : term -> subst -> term
 val tt_open : term -> to_:term -> term
 val tt_close : term -> from:Level.t -> term
 val tt_expand_head : aliases:term Level.Map.t -> term -> term
-val tt_unfold_fix : aliases:term Level.Map.t -> term -> term
 val ts_inverse : subst -> subst

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -20,10 +20,6 @@ type term =
   | TT_forall of { param : typed_pat; return : term }
   | TT_lambda of { param : typed_pat; return : term }
   | TT_apply of { lambda : term; arg : term }
-  | TT_self of { var : core_pat; body : term }
-  | TT_fix of { var : core_pat; body : term }
-  | TT_unroll of { term : term }
-  | TT_unfold of { term : term }
   | TT_let of { bound : typed_pat; value : term; return : term }
   | TT_annot of { term : term; annot : term }
   | TT_string of { literal : string }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -17,17 +17,6 @@ type term =
   | TT_lambda of { param : typed_pat; return : term }
   (* l a *)
   | TT_apply of { lambda : term; arg : term }
-  (* @self(x -> e)*)
-  (* TODO: why core pat? *)
-  | TT_self of { var : core_pat; body : term }
-  (* @fix(x => e)*)
-  (* TODO: why core pat? *)
-  | TT_fix of { var : core_pat; body : term }
-  (* @unroll(e)*)
-  | TT_unroll of { term : term }
-  (* @unfold(e)*)
-  (* TODO: technically not sugar *)
-  | TT_unfold of { term : term }
   (* x = t; u *)
   | TT_let of { bound : typed_pat; value : term; return : term }
   (* (v : T) *)


### PR DESCRIPTION
## Goals

Remove self as they're not needed.

## Context

Self types are fully subsumed by dependent intersections + mutual recursion, both who will be fully supported by the language MVP.

## Related

- #199