### PR TITLE
teika: drop unification

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -17,7 +17,6 @@ module Var_context = struct
 
   let error_unfold_found term = fail @@ TError_misc_unfold_found { term }
   let error_annot_found term = fail @@ TError_misc_annot_found { term }
-  let error_var_occurs ~hole ~in_ = fail @@ TError_misc_var_occurs { hole; in_ }
   let error_var_escape ~var = fail @@ TError_misc_var_escape { var }
 
   let with_free_var f ~level =
@@ -97,6 +96,8 @@ module Typer_context = struct
     | Ok value -> f value ~level ~vars ~aliases
     | Error _ as error -> error
 
+  let error_not_a_forall ~type_ = fail @@ TError_typer_not_a_forall { type_ }
+
   let error_pairs_not_implemented () =
     fail @@ TError_typer_pairs_not_implemented
 
@@ -105,6 +106,8 @@ module Typer_context = struct
 
   let error_unknown_extension ~extension ~payload =
     fail @@ TError_typer_unknown_extension { extension; payload }
+
+  let error_missing_annotation () = fail @@ TError_typer_missing_annotation
 
   let error_unknown_native ~native =
     fail @@ TError_typer_unknown_native { native }
@@ -115,10 +118,6 @@ module Typer_context = struct
   let enter_level f ~level ~vars ~aliases =
     let level = Level.next level in
     f () ~level ~vars ~aliases
-
-  let tt_hole () ~level ~vars:_ ~aliases:_ =
-    let hole = { link = None } in
-    Ok (TT_hole { hole; level; subst = TS_id })
 
   let with_free_vars ~name ~type_ ~alias f ~level ~vars ~aliases =
     let level = Level.next level in

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -13,7 +13,6 @@ module Var_context : sig
   (* errors *)
   val error_unfold_found : term -> 'a var_context
   val error_annot_found : term -> 'a var_context
-  val error_var_occurs : hole:term hole -> in_:term hole -> 'a var_context
   val error_var_escape : var:Level.t -> 'a var_context
 
   (* TODO: this should be removed *)
@@ -66,6 +65,7 @@ module Typer_context : sig
     'a typer_context -> ('a -> 'b typer_context) -> 'b typer_context
 
   (* error *)
+  val error_not_a_forall : type_:term -> 'a typer_context
   val error_pairs_not_implemented : unit -> 'a typer_context
   val error_erasable_not_implemented : unit -> 'a typer_context
 
@@ -73,12 +73,12 @@ module Typer_context : sig
     extension:Name.t -> payload:Ltree.term -> 'a typer_context
 
   val error_unknown_native : native:string -> 'a typer_context
+  val error_missing_annotation : unit -> 'a typer_context
 
   (* TODO: this should be removed *)
   val level : unit -> Level.t typer_context
   val aliases : unit -> term Level.Map.t typer_context
   val enter_level : (unit -> 'a typer_context) -> 'a typer_context
-  val tt_hole : unit -> term typer_context
 
   (* vars *)
 

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -11,7 +11,6 @@ type error =
   | TError_misc_unfold_found of { term : term }
   | TError_misc_annot_found of { term : term }
   (* TODO: lazy names for errors *)
-  | TError_misc_var_occurs of { hole : term hole; in_ : term hole }
   | TError_misc_var_escape of { var : Level.t }
   (* unify *)
   | TError_unify_unfold_found of { expected : term; received : term }
@@ -30,5 +29,6 @@ type error =
       payload : Ltree.term;
     }
   | TError_typer_unknown_native of { native : string }
+  | TError_typer_missing_annotation
 
 and t = error [@@deriving show { with_path = false }]

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -8,7 +8,6 @@ type error =
   | TError_misc_unfold_found of { term : term }
   | TError_misc_annot_found of { term : term }
   (* TODO: lazy names for errors *)
-  | TError_misc_var_occurs of { hole : term hole; in_ : term hole }
   | TError_misc_var_escape of { var : Level.t }
   (* unify *)
   | TError_unify_unfold_found of { expected : term; received : term }
@@ -28,5 +27,6 @@ type error =
     }
   (* TODO: native should not be a string *)
   | TError_typer_unknown_native of { native : string }
+  | TError_typer_missing_annotation
 
 type t = error [@@deriving show]

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -27,10 +27,14 @@ module Typer = struct
 
   let let_id =
     check "let_id"
-      {|((id = A => (x : A) => x; id) : (A : Type) -> (x : A) -> A)|}
+      {|((
+        (id : (A : Type) -> (x : A) -> A) = A => (x : A) => x;
+        id
+      ) : (A : Type) -> (x : A) -> A)|}
 
   let id_type =
-    check "id_type" {|((A => (x : A) => x) Type
+    check "id_type"
+      {|(((A : Type) => (x : A) => x) Type
         : (x : Type) -> Type)|}
 
   let id_type_never =
@@ -102,8 +106,8 @@ module Typer = struct
   let let_alias =
     check "let_alias"
       {|
-        Id = (A : Type) => A;
-        (A => (x : A) => (x : Id A))
+        (Id : (A : Type) -> Type) = (A : Type) => A;
+        ((A : Type) => (x : A) => (x : Id A))
       |}
 
   let simple_string = check "simple_string" {|("simple string" : String)|}

--- a/teika/tmachinery.mli
+++ b/teika/tmachinery.mli
@@ -1,7 +1,5 @@
 open Ttree
 
-val tt_repr : term -> term
-val tt_match : term -> term
 val tt_apply_subst : term -> subst -> term
 val tt_open : term -> to_:term -> term
 val tt_close : term -> from:Level.t -> term

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -12,13 +12,6 @@ val raw_pp_term :
   term ->
   unit
 
-val raw_pp_term_hole :
-  bound_vars:Name.t list ->
-  free_vars:Name.t Level.Map.t ->
-  Format.formatter ->
-  term hole ->
-  unit
-
 val raw_pp_subst :
   bound_vars:Name.t list ->
   free_vars:Name.t Level.Map.t ->
@@ -34,6 +27,5 @@ val raw_pp_error :
   unit
 
 val pp_term : Format.formatter -> term -> unit
-val pp_term_hole : Format.formatter -> term hole -> unit
 val pp_subst : Format.formatter -> subst -> unit
 val pp_error : Format.formatter -> error -> unit

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -10,15 +10,10 @@ open Syntax
    means that this cache will probably be dependent on holes *)
 
 (* TODO: try parametric hoas *)
-type loc = Loc
-type typed = Typed
-type core = Core
-type sugar = Sugar
 
 type term =
   | TT_bound_var of { index : Index.t }
   | TT_free_var of { level : Level.t }
-  | TT_hole of { hole : term hole; level : Level.t; subst : subst }
   | TT_forall of { param : typed_pat; return : term }
   | TT_lambda of { param : typed_pat; return : term }
   | TT_apply of { lambda : term; arg : term }
@@ -29,12 +24,8 @@ type term =
 
 and typed_pat = TPat of { pat : core_pat; type_ : term }
 
-and core_pat =
-  | TP_hole of { hole : core_pat hole }
-  (* x *)
+and core_pat = (* x *)
   | TP_var of { name : Name.t }
-
-and 'a hole = { mutable link : 'a option }
 
 and subst =
   | TS_id
@@ -53,18 +44,6 @@ let nil_level = Level.zero
 let type_level = Level.next nil_level
 let string_level = Level.next type_level
 
-(* TODO: path compression *)
-
-let rec tp_repr pat =
-  match pat with
-  | TP_hole { hole } -> (
-      match hole.link with Some pat -> tp_repr pat | None -> pat)
-  | TP_var _ -> pat
-
 (* TODO: loc *)
 let tt_type = TT_free_var { level = type_level }
 let string_type = TT_free_var { level = string_level }
-
-let tp_hole () =
-  let hole = { link = None } in
-  TP_hole { hole }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,18 +1,11 @@
 open Syntax
 
-type loc = Loc
-type typed = Typed
-type core = Core
-type sugar = Sugar
-
 type term =
   (* x/-n *)
   | TT_bound_var of { index : Index.t }
   (* x/+n *)
   | TT_free_var of { level : Level.t }
   (* TODO: I really don't like this ex_term *)
-  (* _x/+n[s] *)
-  | TT_hole of { hole : term hole; level : Level.t; subst : subst }
   (* (x : A) -> B *)
   | TT_forall of { param : typed_pat; return : term }
   (* (x : A) => e *)
@@ -31,12 +24,8 @@ type term =
 (* TODO: this could probably be avoided if there were dependent types *)
 and typed_pat = TPat of { pat : core_pat; type_ : term }
 
-and core_pat =
-  | TP_hole of { hole : core_pat hole }
-  (* x *)
+and core_pat = (* x *)
   | TP_var of { name : Name.t }
-
-and 'a hole = { mutable link : 'a option }
 
 and subst =
   (* id *)
@@ -56,10 +45,6 @@ val nil_level : Level.t
 val type_level : Level.t
 val string_level : Level.t
 
-(* utils *)
-val tp_repr : core_pat -> core_pat
-
 (* constructors *)
 val tt_type : term
 val string_type : term
-val tp_hole : unit -> core_pat

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -17,81 +17,23 @@ open Tmachinery
      this would allow to violate abstractions.
    Example: (x => A => (x : A)) *)
 (* TODO: occurs should probably be on machinery *)
-let rec tt_occurs ~aliases ~max_level hole ~in_ =
-  let open Var_context in
-  (* TODO: this is needed because of non injective functions
-       the unification could succeed only if expand_head happened
+(* TODO: this is needed because of non injective functions
+     the unification could succeed only if expand_head happened
 
-     maybe should fail anyway ?
-  *)
-  let tt_occurs ~in_ = tt_occurs ~aliases hole ~max_level ~in_ in
-  let tpat_occurs ~in_ = tpat_occurs ~aliases hole ~max_level ~in_ in
-  match tt_match @@ tt_expand_head ~aliases in_ with
-  (* TODO: frozen and subst *)
-  | TT_annot _ -> error_annot_found in_ (* TODO: escape check *)
-  | TT_bound_var { index = _ } ->
-      (* TODO: test escape check here *)
-      pure ()
-  | TT_free_var { level } -> (
-      (* TODO: test example where they're equal *)
-      match max_level < level with
-      | true -> error_var_escape ~var:level
-      | false -> pure ())
-  (* TODO: use this substs? *)
-  | TT_hole { hole = in_; level = _; subst = _ } -> (
-      (* TODO: is it the same hole if substs are different? *)
-      match hole == in_ with
-      (* TODO: better error *)
-      | true -> error_var_occurs ~hole ~in_
-      | false ->
-          (* TODO: lower, add a test *)
-          pure ())
-  | TT_forall { param; return } | TT_lambda { param; return } ->
-      let* () = tpat_occurs ~in_:param in
-      with_free_var @@ fun () -> tt_occurs ~in_:return
-  | TT_apply { lambda; arg } ->
-      let* () = tt_occurs ~in_:lambda in
-      tt_occurs ~in_:arg
-  | TT_let { bound; value; return } ->
-      let* () = tpat_occurs ~in_:bound in
-      let* () = tt_occurs ~in_:value in
-      (* TODO: enter alias? *)
-      with_free_var @@ fun () -> tt_occurs ~in_:return
-  | TT_string { literal = _ } -> pure ()
-  | TT_native { native = _ } -> pure ()
-
-and tpat_occurs hole ~aliases ~max_level ~in_ =
-  (* TODO: occurs inside of TP_hole *)
-  let (TPat { pat = _; type_ }) = in_ in
-  tt_occurs hole ~aliases ~max_level ~in_:type_
-
-let unify_term_hole ~aliases hole ~max_level ~subst ~to_ =
-  let open Var_context in
-  match tt_match to_ with
-  (* TODO: what if subst or level is different *)
-  | TT_hole { hole = to_; level = _; subst = _ } when hole == to_ -> pure ()
-  | _ ->
-      let to_ = tt_apply_subst to_ @@ ts_inverse subst in
-      (* TODO: prefer a direction when both are holes? *)
-      let* () = tt_occurs ~aliases ~max_level hole ~in_:to_ in
-      hole.link <- Some to_;
-      pure ()
-
-open Unify_context
+   maybe should fail anyway ?
+*)
 
 (* TODO: for complete terms, there is no need to open during equality *)
+open Unify_context
+
 let rec tt_unify ~aliases ~expected ~received =
   let tt_unify ~expected ~received = tt_unify ~aliases ~expected ~received in
   let tpat_unify ~expected ~received =
     tpat_unify ~aliases ~expected ~received
   in
-  let unify_term_hole hole ~subst ~to_ =
-    unify_term_hole ~aliases hole ~subst ~to_
-  in
   (* TODO: short circuit physical equality *)
   match
-    ( tt_match @@ tt_expand_head ~aliases expected,
-      tt_match @@ tt_expand_head ~aliases received )
+    (tt_expand_head ~aliases expected, tt_expand_head ~aliases received)
   with
   (* TODO: annot and unfold equality?  *)
   | TT_annot _, _ | _, TT_annot _ -> error_annot_found ~expected ~received
@@ -103,13 +45,6 @@ let rec tt_unify ~aliases ~expected ~received =
       match Level.equal expected received with
       | true -> pure ()
       | false -> error_free_var_clash ~expected ~received)
-  | TT_hole { hole; level; subst }, _ ->
-      (* TODO: tests if wrong context is used *)
-      with_received_var_context @@ fun () ->
-      unify_term_hole hole ~max_level:level ~subst ~to_:received
-  | _, TT_hole { hole; level; subst } ->
-      with_expected_var_context @@ fun () ->
-      unify_term_hole hole ~max_level:level ~subst ~to_:expected
   (* TODO: track whenever it is unified and locations, visualizing inference *)
   | ( TT_forall { param = expected_param; return = expected_return },
       TT_forall { param = received_param; return = received_return } )
@@ -159,19 +94,7 @@ and tpat_unify ~aliases ~expected ~received =
   tt_unify ~aliases ~expected:expected_type ~received:received_type
 
 and tp_unify ~expected ~received =
-  match (tp_repr expected, tp_repr received) with
-  | TP_hole { hole }, pat | pat, TP_hole { hole } ->
-      unify_pat_hole hole ~to_:pat
-  | TP_var _, TP_var _ -> pure ()
-
-and unify_pat_hole hole ~to_ =
-  match to_ with
-  | TP_hole { hole = to_ } when hole == to_ -> pure ()
-  | _ ->
-      (* TODO: prefer a direction when both are holes? *)
-      (* TODO: occurs_pat? *)
-      hole.link <- Some to_;
-      pure ()
+  match (expected, received) with TP_var _, TP_var _ -> pure ()
 
 and unify_native ~expected ~received =
   match (expected, received) with TN_debug, TN_debug -> pure ()


### PR DESCRIPTION
## Goals

Prepare room for dependent intersections.

## Context

I'm currently not sure how dependent intersections and subtyping in general interacts with unification, so I will be removing it and adding it back.

It seems like bidirectional typing + unification can also be done considerably better.

## Related

- #199