### PR TITLE
teika: pipe aliases through context

### DIFF
--- a/teika/context.ml
+++ b/teika/context.ml
@@ -15,7 +15,6 @@ module Var_context = struct
     | Ok value -> f value ~level
     | Error _ as error -> error
 
-  let error_unfold_found term = fail @@ TError_misc_unfold_found { term }
   let error_annot_found term = fail @@ TError_misc_annot_found { term }
   let error_var_escape ~var = fail @@ TError_misc_var_escape { var }
 
@@ -37,9 +36,6 @@ module Unify_context = struct
     match context ~level with
     | Ok value -> f value ~level
     | Error _ as error -> error
-
-  let error_unfold_found ~expected ~received =
-    fail @@ TError_unify_unfold_found { expected; received }
 
   let error_annot_found ~expected ~received =
     fail @@ TError_unify_annot_found { expected; received }

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -11,7 +11,6 @@ module Var_context : sig
   val ( let* ) : 'a var_context -> ('a -> 'b var_context) -> 'b var_context
 
   (* errors *)
-  val error_unfold_found : term -> 'a var_context
   val error_annot_found : term -> 'a var_context
   val error_var_escape : var:Level.t -> 'a var_context
 
@@ -31,7 +30,6 @@ module Unify_context : sig
     'a unify_context -> ('a -> 'b unify_context) -> 'b unify_context
 
   (* error *)
-  val error_unfold_found : expected:term -> received:term -> 'a unify_context
   val error_annot_found : expected:term -> received:term -> 'a unify_context
 
   val error_bound_var_clash :

--- a/teika/context.mli
+++ b/teika/context.mli
@@ -2,23 +2,6 @@ open Syntax
 open Ttree
 open Terror
 
-module Var_context : sig
-  type 'a var_context
-  type 'a t = 'a var_context
-
-  (* monad *)
-  val pure : 'a -> 'a var_context
-  val ( let* ) : 'a var_context -> ('a -> 'b var_context) -> 'b var_context
-
-  (* errors *)
-  val error_annot_found : term -> 'a var_context
-  val error_var_escape : var:Level.t -> 'a var_context
-
-  (* TODO: this should be removed *)
-  val with_free_var : (unit -> 'a var_context) -> 'a var_context
-  val level : unit -> Level.t var_context
-end
-
 module Unify_context : sig
   type 'a unify_context
   type 'a t = 'a unify_context
@@ -44,11 +27,7 @@ module Unify_context : sig
     expected:string -> received:string -> 'a unify_context
 
   (* vars *)
-  val with_free_vars : (unit -> 'a unify_context) -> 'a unify_context
-
-  (* context *)
-  val with_expected_var_context : (unit -> 'a Var_context.t) -> 'a unify_context
-  val with_received_var_context : (unit -> 'a Var_context.t) -> 'a unify_context
+  val find_free_var_alias : var:Level.t -> term option unify_context
 end
 
 module Typer_context : sig
@@ -75,10 +54,9 @@ module Typer_context : sig
 
   (* TODO: this should be removed *)
   val level : unit -> Level.t typer_context
-  val aliases : unit -> term Level.Map.t typer_context
-  val enter_level : (unit -> 'a typer_context) -> 'a typer_context
 
   (* vars *)
+  val find_free_var_alias : var:Level.t -> term option typer_context
 
   (* TODO: names from both sides *)
   val with_free_vars :
@@ -99,9 +77,5 @@ module Typer_context : sig
   val pp_error : unit -> (Format.formatter -> error -> unit) typer_context
 
   (* context *)
-  val with_var_context :
-    (aliases:term Level.Map.t -> 'a Var_context.t) -> 'a typer_context
-
-  val with_unify_context :
-    (aliases:term Level.Map.t -> 'a Unify_context.t) -> 'a typer_context
+  val with_unify_context : (unit -> 'a Unify_context.t) -> 'a typer_context
 end

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -8,12 +8,10 @@ type error =
          Probably because things like macros exists *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* misc *)
-  | TError_misc_unfold_found of { term : term }
   | TError_misc_annot_found of { term : term }
   (* TODO: lazy names for errors *)
   | TError_misc_var_escape of { var : Level.t }
   (* unify *)
-  | TError_unify_unfold_found of { expected : term; received : term }
   | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }
   | TError_unify_free_var_clash of { expected : Level.t; received : Level.t }

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -5,12 +5,10 @@ type error =
   (* metadata *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* misc *)
-  | TError_misc_unfold_found of { term : term }
   | TError_misc_annot_found of { term : term }
   (* TODO: lazy names for errors *)
   | TError_misc_var_escape of { var : Level.t }
   (* unify *)
-  | TError_unify_unfold_found of { expected : term; received : term }
   | TError_unify_annot_found of { expected : term; received : term }
   | TError_unify_bound_var_clash of { expected : Index.t; received : Index.t }
   | TError_unify_free_var_clash of { expected : Level.t; received : Level.t }

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -85,24 +85,6 @@ module Typer = struct
         ) : @self(False -> (f : @self(f -> @unroll False f)) -> Type))
       |}
 
-  let unfold_false =
-    let ind_false =
-      {|
-        (@fix(False => f =>
-          (P : (f : @self(f -> @unroll False f)) -> Type) -> P f
-        ) : @self(False -> (f : @self(f -> @unroll False f)) -> Type))
-      |}
-    in
-    let code =
-      Format.sprintf
-        {|((P => x => @unfold x) : 
-          (P : (False : (f : @self(f -> @unroll (%s) f)) -> Type) -> Type) ->
-          (x : P (@unroll (%s))) -> P ((f : @self(f -> @unroll (%s) f)) =>
-              (P : (f : @self(f -> @unroll (%s) f)) -> Type) -> P f))|}
-        ind_false ind_false ind_false ind_false
-    in
-    check "unfold False" code
-
   let let_alias =
     check "let_alias"
       {|
@@ -161,7 +143,6 @@ module Typer = struct
       false_;
       ind_false_T;
       ind_false;
-      unfold_false;
       let_alias;
       simple_string;
       rank_2_propagate;

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -141,10 +141,10 @@ module Typer = struct
       true_;
       true_unify;
       false_;
-      ind_false_T;
-      ind_false;
       let_alias;
       simple_string;
+      ind_false_T;
+      ind_false;
       rank_2_propagate;
       rank_2_propagate_let;
       invalid_annotation;

--- a/teika/tmachinery.ml
+++ b/teika/tmachinery.ml
@@ -137,34 +137,6 @@ let tt_open term ~to_ =
 
 let tt_close term ~from = tt_apply_subst term @@ TS_close { from }
 
-let rec tt_expand_head ~aliases term =
-  (* TODO: aliases here is hackish *)
-  let tt_expand_head term = tt_expand_head ~aliases term in
-  match term with
-  | TT_bound_var _ -> term
-  | TT_free_var { level } -> (
-      (* TODO: possibly infinite loop, consume aliases *)
-      match Level.Map.find_opt level aliases with
-      | Some alias -> tt_expand_head alias
-      | None -> term)
-  | TT_forall _ -> term
-  | TT_lambda _ -> term
-  | TT_apply { lambda; arg } -> (
-      (* TODO: use expanded lambda? *)
-      match tt_expand_head lambda with
-      | TT_lambda { param = _; return } ->
-          tt_expand_head @@ tt_open return ~to_:arg
-      | TT_native { native } -> expand_head_native ~aliases native ~arg
-      | _lambda -> term)
-  | TT_let { bound = _; value; return } ->
-      tt_expand_head @@ tt_open return ~to_:value
-  | TT_annot { term; annot = _ } -> tt_expand_head term
-  | TT_string _ -> term
-  | TT_native _ -> term
-
-and expand_head_native ~aliases native ~arg =
-  match native with TN_debug -> tt_expand_head ~aliases arg
-
 let rec ts_inverse subst =
   match subst with
   | TS_id -> TS_id

--- a/teika/tmachinery.mli
+++ b/teika/tmachinery.mli
@@ -3,5 +3,4 @@ open Ttree
 val tt_apply_subst : term -> subst -> term
 val tt_open : term -> to_:term -> term
 val tt_close : term -> from:Level.t -> term
-val tt_expand_head : aliases:term Level.Map.t -> term -> term
 val ts_inverse : subst -> subst

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -322,12 +322,9 @@ and perror_of_error ctx error =
             PE_loc { loc; error }
       in
       loop loc error
-  | TError_misc_unfold_found _ ->
-      (* TODO: drop falback *)
-      PE_fallback { error }
+  (* TODO: drop falback *)
   | TError_misc_annot_found _ -> PE_fallback { error }
   | TError_misc_var_escape { var } -> PE_var_escape { var }
-  | TError_unify_unfold_found _ -> PE_fallback { error }
   | TError_unify_annot_found _ -> PE_fallback { error }
   | TError_unify_bound_var_clash { expected; received } ->
       PE_bound_var_clash { expected; received }

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -35,7 +35,7 @@ let rec tt_unify ~aliases ~expected ~received =
   match
     (tt_expand_head ~aliases expected, tt_expand_head ~aliases received)
   with
-  (* TODO: annot and unfold equality?  *)
+  (* TODO: annot equality?  *)
   | TT_annot _, _ | _, TT_annot _ -> error_annot_found ~expected ~received
   | TT_bound_var { index = expected }, TT_bound_var { index = received } -> (
       match Index.equal expected received with

--- a/teika/unify.ml
+++ b/teika/unify.ml
@@ -26,15 +26,41 @@ open Tmachinery
 (* TODO: for complete terms, there is no need to open during equality *)
 open Unify_context
 
-let rec tt_unify ~aliases ~expected ~received =
-  let tt_unify ~expected ~received = tt_unify ~aliases ~expected ~received in
-  let tpat_unify ~expected ~received =
-    tpat_unify ~aliases ~expected ~received
-  in
+(* TODO: duplicating this is bad *)
+let rec tt_expand_head term =
+  match term with
+  | TT_bound_var _ -> pure term
+  | TT_free_var { level = var } -> (
+      (* TODO: better errors here when equality was consumed *)
+      let* alias = find_free_var_alias ~var in
+      (* TODO: consume alias *)
+      match alias with
+      | Some expected -> tt_expand_head expected
+      | None -> pure term)
+  | TT_forall _ -> pure term
+  | TT_lambda _ -> pure term
+  | TT_apply { lambda; arg } -> (
+      (* TODO: use expanded lambda? *)
+      let* lambda = tt_expand_head lambda in
+      match lambda with
+      | TT_lambda { param = _; return } ->
+          tt_expand_head @@ tt_open return ~to_:arg
+      | TT_native { native } -> expand_head_native native ~arg
+      | _lambda -> pure term)
+  | TT_let { bound = _; value; return } ->
+      tt_expand_head @@ tt_open return ~to_:value
+  | TT_annot { term; annot = _ } -> tt_expand_head term
+  | TT_string _ -> pure term
+  | TT_native _ -> pure term
+
+and expand_head_native native ~arg =
+  match native with TN_debug -> tt_expand_head arg
+
+let rec tt_unify ~expected ~received =
   (* TODO: short circuit physical equality *)
-  match
-    (tt_expand_head ~aliases expected, tt_expand_head ~aliases received)
-  with
+  let* expected = tt_expand_head expected in
+  let* received = tt_expand_head received in
+  match (expected, received) with
   (* TODO: annot equality?  *)
   | TT_annot _, _ | _, TT_annot _ -> error_annot_found ~expected ~received
   | TT_bound_var { index = expected }, TT_bound_var { index = received } -> (
@@ -45,6 +71,20 @@ let rec tt_unify ~aliases ~expected ~received =
       match Level.equal expected received with
       | true -> pure ()
       | false -> error_free_var_clash ~expected ~received)
+  | TT_free_var { level = var }, received -> (
+      (* TODO: better errors here when equality was consumed *)
+      let* alias = find_free_var_alias ~var in
+      (* TODO: consume alias *)
+      match alias with
+      | Some expected -> tt_unify ~expected ~received
+      | None -> error_type_clash ~expected ~received)
+  | expected, TT_free_var { level = var } -> (
+      (* TODO: better errors here when equality was consumed *)
+      let* alias = find_free_var_alias ~var in
+      (* TODO: consume alias *)
+      match alias with
+      | Some received -> tt_unify ~expected ~received
+      | None -> error_type_clash ~expected ~received)
   (* TODO: track whenever it is unified and locations, visualizing inference *)
   | ( TT_forall { param = expected_param; return = expected_return },
       TT_forall { param = received_param; return = received_return } )
@@ -52,7 +92,6 @@ let rec tt_unify ~aliases ~expected ~received =
       TT_lambda { param = received_param; return = received_return } ) ->
       (* TODO: contravariance *)
       let* () = tpat_unify ~expected:expected_param ~received:received_param in
-      with_free_vars @@ fun () ->
       tt_unify ~expected:expected_return ~received:received_return
   | ( TT_apply { lambda = expected_lambda; arg = expected_arg },
       TT_apply { lambda = received_lambda; arg = received_arg } ) ->
@@ -80,18 +119,18 @@ let rec tt_unify ~aliases ~expected ~received =
       | false -> error_string_clash ~expected ~received)
   | TT_native { native = expected }, TT_native { native = received } ->
       unify_native ~expected ~received
-  | ( ( TT_bound_var _ | TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _
-      | TT_let _ | TT_string _ | TT_native _ ),
-      ( TT_bound_var _ | TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _
-      | TT_let _ | TT_string _ | TT_native _ ) ) ->
+  | ( ( TT_bound_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_let _
+      | TT_string _ | TT_native _ ),
+      ( TT_bound_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_let _
+      | TT_string _ | TT_native _ ) ) ->
       error_type_clash ~expected ~received
 
-and tpat_unify ~aliases ~expected ~received =
+and tpat_unify ~expected ~received =
   (* TODO: pat? *)
   let (TPat { pat = expected_pat; type_ = expected_type }) = expected in
   let (TPat { pat = received_pat; type_ = received_type }) = received in
   let* () = tp_unify ~expected:expected_pat ~received:received_pat in
-  tt_unify ~aliases ~expected:expected_type ~received:received_type
+  tt_unify ~expected:expected_type ~received:received_type
 
 and tp_unify ~expected ~received =
   match (expected, received) with TP_var _, TP_var _ -> pure ()

--- a/teika/unify.mli
+++ b/teika/unify.mli
@@ -2,8 +2,4 @@ open Ttree
 open Context
 open Unify_context
 
-val tt_unify :
-  aliases:term Level.Map.t ->
-  expected:term ->
-  received:term ->
-  unit unify_context
+val tt_unify : expected:term -> received:term -> unit unify_context


### PR DESCRIPTION
## Goals

Prepare for alias consumption.

## Context

Currently all the aliases are piped down by with_unify_context, this is hackish but also makes quite hard to properly consume aliases which is needed to ensure decidability of checking.

## Related

- #199