### PR TITLE
syntax: drop grade and support hoist

### DIFF
--- a/syntax/clexer.ml
+++ b/syntax/clexer.ml
@@ -18,7 +18,6 @@ let rec tokenizer buf =
   | variable -> VAR (lexeme buf)
   | extension -> EXTENSION (lexeme buf)
   | ":" -> COLON
-  | "$" -> GRADE
   | "->" -> ARROW
   | "=>" -> FAT_ARROW
   | "=" -> EQUAL

--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -8,7 +8,6 @@ let mk (loc_start, loc_end) =
 %}
 %token <string> VAR (* x *)
 %token COLON (* : *)
-%token GRADE (* $ *)
 %token ARROW (* -> *)
 %token FAT_ARROW (* => *)
 %token EQUAL (* = *)
@@ -42,12 +41,8 @@ let term_rec_pair :=
   | term_pair(term_rec_pair, term_rec_both)
 
 let term_rec_both :=
-  | term_rec_grade
-  | term_both(term_rec_both, term_rec_grade)
-
-let term_rec_grade :=
   | term_rec_annot
-  | term_grade(term_rec_grade, term_rec_annot)
+  | term_both(term_rec_both, term_rec_annot)
 
 let term_rec_annot :=
   | term_rec_semi
@@ -84,9 +79,6 @@ let term_var ==
 let term_extension ==
   | extension = EXTENSION;
     { ct_extension (mk $loc) ~extension:(Name.make extension) }
-let term_grade(self, lower) ==
-  | term = lower; GRADE; grade = self;
-    { ct_grade (mk $loc) ~term ~grade }
 let term_forall(self, lower) ==
   | param = lower; ARROW; return = self;
     { ct_forall (mk $loc) ~param ~return }

--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -41,20 +41,28 @@ let term_rec_pair :=
   | term_pair(term_rec_pair, term_rec_both)
 
 let term_rec_both :=
-  | term_rec_annot
-  | term_both(term_rec_both, term_rec_annot)
+  | term_semi_or_annot
+  | term_both(term_rec_both, term_semi_or_annot)
 
-let term_rec_annot :=
-  | term_rec_semi
-  | term_annot(term_rec_annot, term_rec_funct)
+let term_semi_or_annot :=
+  | term_rec_annot
+  | term_semi(term_rec_semi, term_rec_semi_bind)
 
 let term_rec_semi :=
-  | term_rec_bind
-  | term_semi(term_rec_semi, term_rec_bind)
-
-let term_rec_bind :=
   | term_rec_funct
-  | term_bind(term_rec_funct, term_rec_funct)
+  | term_semi(term_rec_semi, term_rec_semi_bind)
+
+let term_rec_semi_bind :=
+  | term_rec_semi_annot
+  | term_bind(term_rec_semi, term_rec_semi_annot)
+
+let term_rec_semi_annot :=
+  | term_rec_funct
+  | term_annot(term_rec_semi_annot, term_rec_funct)
+
+let term_rec_annot :=
+  | term_rec_funct
+  | term_annot(term_rec_annot, term_rec_funct)
 
 let term_rec_funct :=
   | term_rec_apply

--- a/syntax/ctree.ml
+++ b/syntax/ctree.ml
@@ -5,7 +5,6 @@ type term =
   | CT_loc of { term : term; loc : Location.t [@opaque] }
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
-  | CT_grade of { term : term; grade : term }
   | CT_forall of { param : term; return : term }
   | CT_lambda of { param : term; return : term }
   | CT_apply of { lambda : term; arg : term }
@@ -23,7 +22,6 @@ type term =
 let ct_loc loc term = CT_loc { loc; term }
 let ct_var loc ~var = ct_loc loc (CT_var { var })
 let ct_extension loc ~extension = ct_loc loc (CT_extension { extension })
-let ct_grade loc ~term ~grade = ct_loc loc (CT_grade { term; grade })
 let ct_forall loc ~param ~return = ct_loc loc (CT_forall { param; return })
 let ct_lambda loc ~param ~return = ct_loc loc (CT_lambda { param; return })
 let ct_apply loc ~lambda ~arg = ct_loc loc (CT_apply { lambda; arg })

--- a/syntax/ctree.ml
+++ b/syntax/ctree.ml
@@ -2,7 +2,9 @@ open Utils
 
 type term =
   (* TODO: printer location *)
-  | CT_loc of { term : term; loc : Location.t [@opaque] }
+  | CTerm of { term : term_syntax; loc : Location.t [@opaque] }
+
+and term_syntax =
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
   | CT_forall of { param : term; return : term }
@@ -19,18 +21,18 @@ type term =
   | CT_braces of { content : term }
 [@@deriving show { with_path = false }]
 
-let ct_loc loc term = CT_loc { loc; term }
-let ct_var loc ~var = ct_loc loc (CT_var { var })
-let ct_extension loc ~extension = ct_loc loc (CT_extension { extension })
-let ct_forall loc ~param ~return = ct_loc loc (CT_forall { param; return })
-let ct_lambda loc ~param ~return = ct_loc loc (CT_lambda { param; return })
-let ct_apply loc ~lambda ~arg = ct_loc loc (CT_apply { lambda; arg })
-let ct_pair loc ~left ~right = ct_loc loc (CT_pair { left; right })
-let ct_both loc ~left ~right = ct_loc loc (CT_both { left; right })
-let ct_bind loc ~bound ~value = ct_loc loc (CT_bind { bound; value })
-let ct_semi loc ~left ~right = ct_loc loc (CT_semi { left; right })
-let ct_annot loc ~value ~annot = ct_loc loc (CT_annot { value; annot })
-let ct_string loc ~literal = ct_loc loc (CT_string { literal })
-let ct_number loc ~literal = ct_loc loc (CT_number { literal })
-let ct_parens loc ~content = ct_loc loc (CT_parens { content })
-let ct_braces loc ~content = ct_loc loc (CT_braces { content })
+let cterm loc term = CTerm { loc; term }
+let ct_var loc ~var = cterm loc (CT_var { var })
+let ct_extension loc ~extension = cterm loc (CT_extension { extension })
+let ct_forall loc ~param ~return = cterm loc (CT_forall { param; return })
+let ct_lambda loc ~param ~return = cterm loc (CT_lambda { param; return })
+let ct_apply loc ~lambda ~arg = cterm loc (CT_apply { lambda; arg })
+let ct_pair loc ~left ~right = cterm loc (CT_pair { left; right })
+let ct_both loc ~left ~right = cterm loc (CT_both { left; right })
+let ct_bind loc ~bound ~value = cterm loc (CT_bind { bound; value })
+let ct_semi loc ~left ~right = cterm loc (CT_semi { left; right })
+let ct_annot loc ~value ~annot = cterm loc (CT_annot { value; annot })
+let ct_string loc ~literal = cterm loc (CT_string { literal })
+let ct_number loc ~literal = cterm loc (CT_number { literal })
+let ct_parens loc ~content = cterm loc (CT_parens { content })
+let ct_braces loc ~content = cterm loc (CT_braces { content })

--- a/syntax/ctree.mli
+++ b/syntax/ctree.mli
@@ -4,7 +4,6 @@ type term =
   | CT_loc of { term : term; loc : Location.t }
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
-  | CT_grade of { term : term; grade : term }
   | CT_forall of { param : term; return : term }
   | CT_lambda of { param : term; return : term }
   | CT_apply of { lambda : term; arg : term }
@@ -21,7 +20,6 @@ type term =
 
 val ct_var : Location.t -> var:Name.t -> term
 val ct_extension : Location.t -> extension:Name.t -> term
-val ct_grade : Location.t -> term:term -> grade:term -> term
 val ct_forall : Location.t -> param:term -> return:term -> term
 val ct_lambda : Location.t -> param:term -> return:term -> term
 val ct_apply : Location.t -> lambda:term -> arg:term -> term

--- a/syntax/ctree.mli
+++ b/syntax/ctree.mli
@@ -1,7 +1,8 @@
 open Utils
 
-type term =
-  | CT_loc of { term : term; loc : Location.t }
+type term = CTerm of { term : term_syntax; loc : Location.t }
+
+and term_syntax =
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
   | CT_forall of { param : term; return : term }

--- a/syntax/dune
+++ b/syntax/dune
@@ -1,9 +1,25 @@
 (library
  (name syntax)
  (libraries menhirLib compiler-libs.common utils)
+ (modules
+  (:standard \ Test))
  (preprocess
   (pps ppx_deriving.eq ppx_deriving.ord ppx_deriving.show sedlex.ppx)))
 
 (menhir
  (modules cparser)
  (flags --dump --explain))
+
+(executable
+ (name test)
+ (modules Test)
+ (libraries alcotest syntax)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord)))
+
+(rule
+ (alias runtest)
+ (deps
+  (:exe ./test.exe))
+ (action
+  (run %{exe})))

--- a/syntax/lparser.ml
+++ b/syntax/lparser.ml
@@ -5,85 +5,79 @@ exception Invalid_notation of { loc : Location.t }
 
 let invalid_notation loc = raise (Invalid_notation { loc })
 
-let rec parse_term ~loc term =
+let rec parse_term term =
+  let (CTerm { term; loc }) = term in
   match term with
-  | CT_loc { term; loc } ->
-      let term = parse_term ~loc term in
-      LT_loc { term; loc }
-  | CT_parens { content } -> parse_term ~loc content
-  | CT_var { var } -> LT_var { var }
+  | CT_parens { content } -> parse_term content
+  | CT_var { var } -> lterm ~loc @@ LT_var { var }
   | CT_extension _ -> invalid_notation loc
   | CT_forall { param; return } ->
-      let param = parse_pat ~loc param in
-      let return = parse_term ~loc return in
-      LT_forall { param; return }
+      let param = parse_pat param in
+      let return = parse_term return in
+      lterm ~loc @@ LT_forall { param; return }
   | CT_lambda { param; return } ->
-      let param = parse_pat ~loc param in
-      let return = parse_term ~loc return in
-      LT_lambda { param; return }
+      let param = parse_pat param in
+      let return = parse_term return in
+      lterm ~loc @@ LT_lambda { param; return }
   | CT_apply { lambda; arg } -> parse_apply ~loc ~lambda ~arg
-  | CT_pair { left = _; right = _ } ->
-      (* TODO: better error *)
-      invalid_notation loc
+  | CT_pair { left = _; right = _ } -> invalid_notation loc
   | CT_both _ -> invalid_notation loc
   | CT_bind _ -> invalid_notation loc
   | CT_semi { left; right } -> parse_semi ~loc ~left ~right
   | CT_annot { value; annot } ->
-      let term = parse_term ~loc value in
-      let annot = parse_term ~loc annot in
-      LT_annot { term; annot }
-  | CT_string { literal } -> LT_string { literal }
+      let term = parse_term value in
+      let annot = parse_term annot in
+      lterm ~loc @@ LT_annot { term; annot }
+  | CT_string { literal } -> lterm ~loc @@ LT_string { literal }
   | CT_number _ -> invalid_notation loc
   | CT_braces _ -> invalid_notation loc
 
 and parse_semi ~loc ~left ~right =
+  let (CTerm { term = left; loc = left_loc }) = left in
   match left with
-  | CT_loc { term = left; loc } -> parse_semi ~loc ~left ~right
   | CT_parens { content = left } -> parse_semi ~loc ~left ~right
   | CT_bind { bound; value } ->
-      let bound = parse_pat ~loc bound in
-      let value = parse_term ~loc value in
-      let return = parse_term ~loc right in
-      LT_let { bound; value; return }
+      let bound = parse_pat bound in
+      let value = parse_term value in
+      let return = parse_term right in
+      lterm ~loc @@ LT_let { bound; value; return }
   | CT_annot { value = bound; annot } ->
-      let bound = parse_pat ~loc bound in
-      let annot = parse_term ~loc annot in
-      let return = parse_term ~loc right in
-      LT_hoist { bound; annot; return }
+      let bound = parse_pat bound in
+      let annot = parse_term annot in
+      let return = parse_term right in
+      lterm ~loc @@ LT_hoist { bound; annot; return }
   | CT_var _ | CT_extension _ | CT_forall _ | CT_lambda _ | CT_apply _
   | CT_pair _ | CT_both _ | CT_semi _ | CT_string _ | CT_number _ | CT_braces _
     ->
-      invalid_notation loc
+      invalid_notation left_loc
 
 and parse_apply ~loc ~lambda ~arg =
   (* TODO: is this fallback of locations okay? *)
-  match lambda with
-  | CT_loc { term = lambda; loc } -> parse_apply ~loc ~lambda ~arg
+  match
+    let (CTerm { term = lambda; loc = _ }) = lambda in
+    lambda
+  with
   (* TODO: CT_parens? *)
   | CT_extension { extension } ->
-      let payload = parse_term ~loc arg in
-      let term = LT_extension { extension; payload } in
-      (* TODO: this is not ideal *)
-      LT_loc { term; loc }
+      let payload = parse_term arg in
+      lterm ~loc @@ LT_extension { extension; payload }
   (* TODO: remove catch all *)
   | _ ->
-      let lambda = parse_term ~loc lambda in
-      let arg = parse_term ~loc arg in
-      LT_apply { lambda; arg }
+      let lambda = parse_term lambda in
+      let arg = parse_term arg in
+      lterm ~loc @@ LT_apply { lambda; arg }
 
-and parse_pat ~loc pat =
+and parse_pat pat =
   (* TODO: Stack of locs? *)
+  let (CTerm { term = pat; loc }) = pat in
   match pat with
-  | CT_loc { term = pat; loc } ->
-      let pat = parse_pat ~loc pat in
-      LP_loc { pat; loc }
-  | CT_parens { content } -> parse_pat ~loc content
-  | CT_var { var } -> LP_var { var }
+  | CT_parens { content } -> parse_pat content
+  | CT_var { var } -> lpat ~loc @@ LP_var { var }
   | CT_pair { left = _; right = _ } -> invalid_notation loc
   | CT_annot { value = pat; annot } ->
-      let pat = parse_pat ~loc pat in
-      let annot = parse_term ~loc annot in
-      LP_annot { pat; annot }
+      let pat = parse_pat pat in
+      let annot = parse_term annot in
+      lpat ~loc @@ LP_annot { pat; annot }
   | CT_extension _ | CT_forall _ | CT_lambda _ | CT_apply _ | CT_both _
   | CT_bind _ | CT_semi _ | CT_string _ | CT_number _ | CT_braces _ ->
       invalid_notation loc

--- a/syntax/lparser.ml
+++ b/syntax/lparser.ml
@@ -39,14 +39,20 @@ let rec parse_term ~loc term =
 and parse_semi ~loc ~left ~right =
   match left with
   | CT_loc { term = left; loc } -> parse_semi ~loc ~left ~right
+  | CT_parens { content = left } -> parse_semi ~loc ~left ~right
   | CT_bind { bound; value } ->
       let bound = parse_pat ~loc bound in
       let value = parse_term ~loc value in
       let return = parse_term ~loc right in
       LT_let { bound; value; return }
+  | CT_annot { value = bound; annot } ->
+      let bound = parse_pat ~loc bound in
+      let annot = parse_term ~loc annot in
+      let return = parse_term ~loc right in
+      LT_hoist { bound; annot; return }
   | CT_var _ | CT_extension _ | CT_forall _ | CT_lambda _ | CT_apply _
-  | CT_pair _ | CT_both _ | CT_semi _ | CT_annot _ | CT_string _ | CT_number _
-  | CT_parens _ | CT_braces _ ->
+  | CT_pair _ | CT_both _ | CT_semi _ | CT_string _ | CT_number _ | CT_braces _
+    ->
       invalid_notation loc
 
 and parse_apply ~loc ~lambda ~arg =

--- a/syntax/lparser.mli
+++ b/syntax/lparser.mli
@@ -1,1 +1,1 @@
-val parse_term : loc:Warnings.loc -> Ctree.term -> Ltree.term
+val parse_term : Ctree.term -> Ltree.term

--- a/syntax/ltree.ml
+++ b/syntax/ltree.ml
@@ -7,6 +7,7 @@ type term =
   | LT_forall of { param : pat; return : term }
   | LT_lambda of { param : pat; return : term }
   | LT_apply of { lambda : term; arg : term }
+  | LT_hoist of { bound : pat; annot : term; return : term }
   | LT_let of { bound : pat; value : term; return : term }
   | LT_annot of { term : term; annot : term }
   | LT_string of { literal : string }

--- a/syntax/ltree.ml
+++ b/syntax/ltree.ml
@@ -7,15 +7,12 @@ type term =
   | LT_forall of { param : pat; return : term }
   | LT_lambda of { param : pat; return : term }
   | LT_apply of { lambda : term; arg : term }
-  | LT_let of { bound : bind; return : term }
+  | LT_let of { bound : pat; value : term; return : term }
   | LT_annot of { term : term; annot : term }
   | LT_string of { literal : string }
 
 and pat =
   | LP_loc of { pat : pat; loc : Location.t [@opaque] }
   | LP_var of { var : Name.t }
-  | LP_erasable of { pat : pat }
   | LP_annot of { pat : pat; annot : term }
-
-and bind = LBind of { loc : Location.t; [@opaque] pat : pat; value : term }
 [@@deriving show { with_path = false }]

--- a/syntax/ltree.ml
+++ b/syntax/ltree.ml
@@ -1,7 +1,8 @@
 open Utils
 
-type term =
-  | LT_loc of { term : term; loc : Location.t [@opaque] }
+type term = LTerm of { term : term_syntax; loc : Location.t [@opaque] }
+
+and term_syntax =
   | LT_var of { var : Name.t }
   | LT_extension of { extension : Name.t; payload : term }
   | LT_forall of { param : pat; return : term }
@@ -12,8 +13,12 @@ type term =
   | LT_annot of { term : term; annot : term }
   | LT_string of { literal : string }
 
-and pat =
-  | LP_loc of { pat : pat; loc : Location.t [@opaque] }
+and pat = LPat of { pat : pat_syntax; loc : Location.t [@opaque] }
+
+and pat_syntax =
   | LP_var of { var : Name.t }
   | LP_annot of { pat : pat; annot : term }
 [@@deriving show { with_path = false }]
+
+let lterm ~loc term = LTerm { term; loc }
+let lpat ~loc pat = LPat { pat; loc }

--- a/syntax/ltree.mli
+++ b/syntax/ltree.mli
@@ -12,6 +12,8 @@ type term =
   | LT_lambda of { param : pat; return : term }
   (* l a *)
   | LT_apply of { lambda : term; arg : term }
+  (* p : A; r *)
+  | LT_hoist of { bound : pat; annot : term; return : term }
   (* p = v; r *)
   | LT_let of { bound : pat; value : term; return : term }
   (* (v : T) *)

--- a/syntax/ltree.mli
+++ b/syntax/ltree.mli
@@ -1,7 +1,9 @@
 open Utils
 
-type term =
-  | LT_loc of { term : term; loc : Location.t }
+(* TODO: location stack? *)
+type term = LTerm of { term : term_syntax; loc : Location.t }
+
+and term_syntax =
   (* x *)
   | LT_var of { var : Name.t }
   (* @x(e) *)
@@ -21,10 +23,14 @@ type term =
   (* ".." *)
   | LT_string of { literal : string }
 
-and pat =
-  | LP_loc of { pat : pat; loc : Location.t }
+and pat = LPat of { pat : pat_syntax; loc : Location.t }
+
+and pat_syntax =
   (* x *)
   | LP_var of { var : Name.t }
   (* (p : T) *)
   | LP_annot of { pat : pat; annot : term }
 [@@deriving show]
+
+val lterm : loc:Location.t -> term_syntax -> term
+val lpat : loc:Location.t -> pat_syntax -> pat

--- a/syntax/ltree.mli
+++ b/syntax/ltree.mli
@@ -13,7 +13,7 @@ type term =
   (* l a *)
   | LT_apply of { lambda : term; arg : term }
   (* p = v; r *)
-  | LT_let of { bound : bind; return : term }
+  | LT_let of { bound : pat; value : term; return : term }
   (* (v : T) *)
   | LT_annot of { term : term; annot : term }
   (* ".." *)
@@ -23,10 +23,6 @@ and pat =
   | LP_loc of { pat : pat; loc : Location.t }
   (* x *)
   | LP_var of { var : Name.t }
-  (* (p $ 0) *)
-  | LP_erasable of { pat : pat }
   (* (p : T) *)
   | LP_annot of { pat : pat; annot : term }
-
-and bind = LBind of { loc : Location.t; pat : pat; value : term }
 [@@deriving show]

--- a/teika/level.ml
+++ b/teika/level.ml
@@ -1,0 +1,14 @@
+type level = int
+and t = level [@@deriving show, eq]
+
+let nil = -1
+let zero = 0
+
+let next n =
+  let n = n + 1 in
+  assert (n + 1 >= zero);
+  n
+
+let ( < ) : level -> level -> bool = ( < )
+
+module Map = Map.Make (Int)

--- a/teika/level.mli
+++ b/teika/level.mli
@@ -1,0 +1,9 @@
+type level
+type t = level [@@deriving show, eq]
+
+val nil : level
+val zero : level
+val next : level -> level
+val ( < ) : level -> level -> bool
+
+module Map : Map.S with type key = level

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -15,9 +15,9 @@ type error =
   (* typer *)
   | TError_unknown_var of { name : Name.t }
   | TError_not_a_forall of { type_ : term }
+  | TError_hoist_not_implemented
   | TError_extensions_not_implemented
   | TError_pairs_not_implemented
-  | TError_erasable_not_implemented
   | TError_unknown_extension of { extension : Name.t; payload : Ltree.term }
   | TError_unknown_native of { native : string }
   | TError_missing_annotation
@@ -35,14 +35,12 @@ let error_string_clash ~left ~right =
 
 let error_unknown_var ~name = terror @@ TError_unknown_var { name }
 let error_not_a_forall ~type_ = terror @@ TError_not_a_forall { type_ }
+let error_hoist_not_implemented () = terror @@ TError_hoist_not_implemented
 
 let error_extensions_not_implemented () =
   terror @@ TError_extensions_not_implemented
 
 let error_pairs_not_implemented () = terror @@ TError_pairs_not_implemented
-
-let error_erasable_not_implemented () =
-  terror @@ TError_erasable_not_implemented
 
 let error_unknown_extension ~extension ~payload =
   terror @@ TError_unknown_extension { extension; payload }

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -13,9 +13,9 @@ type error =
   (* typer *)
   | TError_unknown_var of { name : Name.t }
   | TError_not_a_forall of { type_ : term }
+  | TError_hoist_not_implemented
   | TError_extensions_not_implemented
   | TError_pairs_not_implemented
-  | TError_erasable_not_implemented
   | TError_unknown_extension of { extension : Name.t; payload : Ltree.term }
   (* TODO: native should not be a string *)
   | TError_unknown_native of { native : string }
@@ -31,9 +31,9 @@ val error_type_clash : left:term -> right:term -> 'a
 val error_string_clash : left:string -> right:string -> 'a
 val error_unknown_var : name:Name.t -> 'a
 val error_not_a_forall : type_:term -> 'a
+val error_hoist_not_implemented : unit -> 'a
 val error_extensions_not_implemented : unit -> 'a
 val error_pairs_not_implemented : unit -> 'a
-val error_erasable_not_implemented : unit -> 'a
 val error_unknown_extension : extension:Name.t -> payload:Ltree.term -> 'a
 val error_unknown_native : native:string -> 'a
 val error_missing_annotation : unit -> 'a

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -27,7 +27,7 @@ module Typer = struct
   let let_id =
     check "let_id"
       {|((
-        (id : (A : Type) -> (x : A) -> A) = A => (x : A) => x;
+        id : (A : Type) -> (x : A) -> A = A => (x : A) => x;
         id
       ) : (A : Type) -> (x : A) -> A)|}
 
@@ -87,7 +87,7 @@ module Typer = struct
   let let_alias =
     check "let_alias"
       {|
-        (Id : (A : Type) -> Type) = (A : Type) => A;
+        Id : (A : Type) -> Type = (A : Type) => A;
         ((A : Type) => (x : A) => (x : Id A))
       |}
 
@@ -104,7 +104,7 @@ module Typer = struct
     check "rank_2_propagate"
       {|
         Unit = (A : Type) -> (x : A) -> A;
-        (noop : (u : Unit) -> Unit) = u => u Unit u;
+        noop : (u : Unit) -> Unit = u => u Unit u;
         noop
       |}
 
@@ -129,13 +129,13 @@ module Typer = struct
       {|
         Eq = (A : Type) => (x : A) => (y : A) =>
           (P : (z : A) -> Type) -> (l : P x) -> P y;
-        (refl : (A : Type) -> (x : A) -> Eq A x x)
+        refl : (A : Type) -> (x : A) -> Eq A x x
           = (A : Type) => (x : A) =>
             (P : (z : A) -> Type) => (l : P x) => l;
 
         Nat = (A : Type) -> (z : A) -> (s : (acc : A) -> A) -> A;
-        (zero : Nat) = (A : Type) => (z : A) => (s : (acc : A) -> A) => z;
-        (succ : (pred : Nat) -> Nat) = (pred : Nat) => 
+        zero : Nat = (A : Type) => (z : A) => (s : (acc : A) -> A) => z;
+        succ : (pred : Nat) -> Nat = (pred : Nat) => 
           (A : Type) => (z : A) => (s : (acc : A) -> A) => s (pred A z s);
         one = succ zero;
 
@@ -148,7 +148,7 @@ module Typer = struct
         eight = add four four;
         sixteen = add eight eight;
         n256 = mul sixteen sixteen;
-        (sixteen_is_eight_times_two : Eq Nat sixteen (mul eight two))
+        sixteen_is_eight_times_two : Eq Nat sixteen (mul eight two)
           = refl Nat sixteen;
         (refl Nat n256 : Eq Nat (mul (mul eight eight) four) n256)
       |}

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -215,9 +215,7 @@ module Typer = struct
       let actual = Clexer.from_string Cparser.term_opt annotated_term in
       match actual with
       | Some stree -> (
-          (* TODO: locations *)
-          let loc = Location.none in
-          let ltree = Lparser.parse_term ~loc stree in
+          let ltree = Lparser.parse_term stree in
           match Typer.Infer.infer_term ltree with
           | Ok ttree -> Format.eprintf "%a\n%!" Tprinter.pp_term ttree
           | Error error ->
@@ -230,9 +228,7 @@ module Typer = struct
       let actual = Clexer.from_string Cparser.term_opt annotated_term in
       match actual with
       | Some stree -> (
-          (* TODO: locations *)
-          let loc = Location.none in
-          let ltree = Lparser.parse_term ~loc stree in
+          let ltree = Lparser.parse_term stree in
           match Typer.Infer.infer_term ltree with
           | Ok _ttree -> failwith "worked but should had failed"
           (* TODO: check for specific error *)

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -140,9 +140,9 @@ module Perror = struct
     | PE_string_clash of { left : string; right : string }
     | PE_unknown_var of { name : Name.t }
     | PE_not_a_forall of { type_ : term }
+    | PE_hoist_not_implemented
     | PE_extensions_not_implemented
     | PE_pairs_not_implemented
-    | PE_erasable_not_implemented
     | PE_unknown_extension of { extension : Name.t }
     | PE_unknown_native of { native : string }
     | PE_missing_annotation
@@ -172,9 +172,9 @@ module Perror = struct
     | PE_unknown_var { name } -> fprintf fmt "unknown variable %a" Name.pp name
     | PE_not_a_forall { type_ } ->
         fprintf fmt "expected forall\nreceived : %a" pp_term type_
+    | PE_hoist_not_implemented -> fprintf fmt "hoist not implemented"
     | PE_extensions_not_implemented -> fprintf fmt "extensions not implemented"
     | PE_pairs_not_implemented -> fprintf fmt "pairs not implemented"
-    | PE_erasable_not_implemented -> fprintf fmt "erasable not implemented"
     | PE_unknown_extension { extension } ->
         fprintf fmt "unknown extension : %a" Name.pp extension
     | PE_unknown_native { native } -> fprintf fmt "unknown native : %S" native
@@ -212,10 +212,9 @@ let rec te_print error =
       let type_ = tt_print type_ in
       PE_not_a_forall { type_ }
   | TError_extensions_not_implemented -> PE_extensions_not_implemented
+  | TError_hoist_not_implemented -> PE_hoist_not_implemented
   | TError_pairs_not_implemented ->
       PE_pairs_not_implemented (* TODO: print payload *)
-  | TError_erasable_not_implemented ->
-      PE_erasable_not_implemented (* TODO: print payload *)
   | TError_unknown_extension { extension; payload = _ } ->
       PE_unknown_extension { extension }
   | TError_unknown_native { native } -> PE_unknown_native { native }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -6,6 +6,7 @@ open Utils
 (* TODO: which invariants to enforce here using private? *)
 
 (* TODO: return should be body *)
+(* TODO: cache normalization? *)
 type term = private
   (* #(M : A) *)
   | TTerm of { term : term_syntax; type_ : term }

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -295,10 +295,9 @@ module Infer = struct
      Seems to help with many cases such as expected on annotation *)
 
   let rec infer_term ctx term =
+    (* TODO: use this location *)
+    let (LTerm { term; loc = _ }) = term in
     match term with
-    | LT_loc { term; loc = _ } ->
-        (* TODO: use loc *)
-        infer_term ctx term
     | LT_annot { term; annot } ->
         (* TODO: expected term could propagate here *)
         let annot = check_annot ctx annot in
@@ -364,10 +363,9 @@ module Infer = struct
   and check_annot ctx term = check_term ctx term ~expected:tt_global_univ
 
   and with_infer_pat ctx pat k =
+    (* TODO: use this location *)
+    let (LPat { pat; loc = _ }) = pat in
     match pat with
-    | LP_loc { pat; loc = _ } ->
-        (* TODO: use this loc *)
-        with_infer_pat ctx pat k
     | LP_var { var = _ } -> error_missing_annotation ()
     | LP_annot { pat; annot } ->
         (* TODO: TP_annot *)
@@ -378,10 +376,9 @@ module Infer = struct
   and with_check_pat ctx pat ~expected k =
     (* TODO: let () = assert_is_tt_with_type expected in *)
     (* TODO: expected should be a pattern, to achieve strictness *)
+    (* TODO: use this location *)
+    let (LPat { pat; loc = _ }) = pat in
     match pat with
-    | LP_loc { pat; loc = _ } ->
-        (* TODO: use this loc *)
-        with_check_pat ctx pat ~expected k
     | LP_annot { pat; annot } ->
         let annot = check_annot ctx annot in
         let () = tt_equal ~left:annot ~right:expected in


### PR DESCRIPTION
## Goals

Prepare syntax for MVP features.

## Context

One of the targets of the MVP is to support inductive types properly, those are going to be achieved through dependent intersections and fixpoints, currently there is no way of defining a fixpoint in the Teika syntax, this solves that by supporting `x : A; M`, this is very similar to Agda.

To achieve this the main change is related to allowing annotations without parens on the left side of bindings, a binding without a value is a `hoist` operation and one with the value is a `let`, maybe in the future it will be a `fix`.

Grading syntax was also dropped as it will not be initially supported.

Additionally I'm using a more standard wrapping, closer to how the typed tree is defined.

## Related

- #199