### PR TITLE
teika: use global / local vars as representation

### DIFF
--- a/teika/index.ml
+++ b/teika/index.ml
@@ -1,0 +1,15 @@
+type index = int
+and t = index [@@deriving show, eq]
+
+let zero = 0
+
+let next n =
+  let n = n + 1 in
+  assert (n + 1 >= zero);
+  n
+
+let ( < ) : index -> index -> bool = ( < )
+let repr x = x
+let of_int x = match x >= zero with true -> Some x | false -> None
+
+module Map = Map.Make (Int)

--- a/teika/index.mli
+++ b/teika/index.mli
@@ -1,0 +1,12 @@
+type index
+type t = index [@@deriving show, eq]
+
+val zero : index
+val next : index -> index
+val ( < ) : index -> index -> bool
+
+(* TODO: exposing this is bad *)
+val repr : index -> int
+val of_int : int -> index option
+
+module Map : Map.S with type key = index

--- a/teika/level.ml
+++ b/teika/level.ml
@@ -1,7 +1,6 @@
 type level = int
 and t = level [@@deriving show, eq]
 
-let nil = -1
 let zero = 0
 
 let next n =
@@ -10,5 +9,15 @@ let next n =
   n
 
 let ( < ) : level -> level -> bool = ( < )
+let of_int x = match x >= zero with true -> Some x | false -> None
+let repr x = x
+
+let global_to_local ~size ~var ~depth =
+  let top = size - 1 in
+  Index.of_int @@ (top + Index.repr depth - var)
+
+let local_to_global ~size ~var ~depth =
+  let top = size - 1 in
+  of_int @@ (top + Index.repr depth - Index.repr var)
 
 module Map = Map.Make (Int)

--- a/teika/level.mli
+++ b/teika/level.mli
@@ -1,9 +1,15 @@
 type level
 type t = level [@@deriving show, eq]
 
-val nil : level
 val zero : level
 val next : level -> level
 val ( < ) : level -> level -> bool
+
+(* TODO: bad to expose this *)
+val repr : level -> int
+
+(* TODO: better place for this *)
+val global_to_local : size:level -> var:level -> depth:Index.t -> Index.t option
+val local_to_global : size:level -> var:Index.t -> depth:Index.t -> level option
 
 module Map : Map.S with type key = level

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -9,9 +9,7 @@ type error =
          Probably because things like macros exists *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* equal *)
-  | TError_var_clash of { left : var; right : var }
   | TError_type_clash of { left : term; right : term }
-  | TError_string_clash of { left : string; right : string }
   (* typer *)
   | TError_unknown_var of { name : Name.t }
   | TError_not_a_forall of { type_ : term }
@@ -27,12 +25,7 @@ and t = error [@@deriving show { with_path = false }]
 exception TError of { error : error }
 
 let terror error = raise (TError { error })
-let error_var_clash ~left ~right = terror @@ TError_var_clash { left; right }
 let error_type_clash ~left ~right = terror @@ TError_type_clash { left; right }
-
-let error_string_clash ~left ~right =
-  terror @@ TError_string_clash { left; right }
-
 let error_unknown_var ~name = terror @@ TError_unknown_var { name }
 let error_not_a_forall ~type_ = terror @@ TError_not_a_forall { type_ }
 let error_hoist_not_implemented () = terror @@ TError_hoist_not_implemented

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -6,9 +6,7 @@ type error =
   (* metadata *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* equal *)
-  | TError_var_clash of { left : var; right : var }
   | TError_type_clash of { left : term; right : term }
-  | TError_string_clash of { left : string; right : string }
   (* TODO: infer *)
   (* typer *)
   | TError_unknown_var of { name : Name.t }
@@ -26,9 +24,7 @@ type t = error [@@deriving show]
 exception TError of { error : error }
 
 (* TODO: error_loc *)
-val error_var_clash : left:var -> right:var -> 'a
 val error_type_clash : left:term -> right:term -> 'a
-val error_string_clash : left:string -> right:string -> 'a
 val error_unknown_var : name:Name.t -> 'a
 val error_not_a_forall : type_:term -> 'a
 val error_hoist_not_implemented : unit -> 'a

--- a/teika/tprinter.mli
+++ b/teika/tprinter.mli
@@ -4,5 +4,4 @@ open Terror
 
 val pp_term : formatter -> term -> unit
 val pp_pat : formatter -> pat -> unit
-val pp_var : formatter -> var -> unit
 val pp_error : Format.formatter -> error -> unit

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -9,8 +9,12 @@ type term =
 and term_syntax =
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
-  (* x *)
-  | TT_var of { var : var }
+  (* \!+n *)
+  | TT_rigid_var of { var : Level.t }
+  (* \+n *)
+  | TT_global_var of { var : Level.t }
+  (* \-n *)
+  | TT_local_var of { var : Index.t }
   (* P -> B *)
   | TT_forall of { param : pat; return : term }
   (* P => M *)
@@ -29,9 +33,7 @@ and pat_syntax =
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
-  | TP_var of { var : var }
-
-and var = TVar of { name : Name.t; mutable link : term; mutable rename : var }
+  | TP_var of { name : Name.t }
 [@@deriving show { with_path = false }]
 
 (* TODO: expose this? *)
@@ -39,7 +41,9 @@ and var = TVar of { name : Name.t; mutable link : term; mutable rename : var }
 let tterm ~type_ term = TTerm { term; type_ }
 let ttype term = TType { term }
 let tt_annot ~term ~annot = TT_annot { term; annot }
-let tt_var ~var = TT_var { var }
+let tt_rigid_var ~var = TT_rigid_var { var }
+let tt_global_var ~var = TT_global_var { var }
+let tt_local_var ~var = TT_local_var { var }
 let tt_forall ~param ~return = TT_forall { param; return }
 let tt_lambda ~param ~return = TT_lambda { param; return }
 let tt_apply ~lambda ~arg = TT_apply { lambda; arg }
@@ -49,72 +53,12 @@ let tt_string ~literal = TT_string { literal }
 (* patterns *)
 let tpat ~type_ pat = TPat { pat; type_ }
 let tp_annot ~pat ~annot = TP_annot { pat; annot }
-let tp_var ~var = TP_var { var }
+let tp_var ~name = TP_var { name }
 
-(* constants *)
-exception TVar_already_linked of { var : var }
-exception TVar_already_renamed of { var : var }
+(* Type *)
+let level_univ = Level.zero
+let tt_global_univ = ttype @@ TT_global_var { var = level_univ }
 
-let rec tt_nil = TTerm { term = TT_var { var = tv_nil }; type_ = tt_nil }
-
-and tv_nil =
-  let tv_nil_name = Name.make "teika_internal_nil" in
-  TVar { name = tv_nil_name; link = tt_nil; rename = tv_nil }
-
-let is_tt_nil term = term == tt_nil
-let is_tv_nil var = var == tv_nil
-let tv_fresh name = TVar { name; link = tt_nil; rename = tv_nil }
-
-let is_linked var =
-  let (TVar var_content) = var in
-  not (is_tt_nil var_content.link)
-
-let is_renamed var =
-  let (TVar var_content) = var in
-  not (is_tv_nil var_content.rename)
-
-let assert_not_linked var =
-  match is_linked var with
-  | true -> raise (TVar_already_linked { var })
-  | false -> ()
-
-let assert_not_renamed var =
-  match is_renamed var with
-  | true -> raise (TVar_already_renamed { var })
-  | false -> ()
-
-let tv_link var ~to_ =
-  let () = assert_not_linked var in
-  let (TVar var) = var in
-  var.link <- to_
-
-let tv_link_reset var =
-  let (TVar var) = var in
-  var.link <- tt_nil
-
-let tv_rename var ~to_ =
-  let () = assert_not_renamed var in
-  let (TVar var) = var in
-  var.rename <- to_
-
-let tv_rename_reset var =
-  let (TVar var) = var in
-  var.rename <- tv_nil
-
-let with_tv_link var ~to_ k =
-  let () = tv_link var ~to_ in
-  let value = k () in
-  let () = tv_link_reset var in
-  value
-
-let with_tv_rename var ~to_ k =
-  let () = tv_rename var ~to_ in
-  let value = k () in
-  let () = tv_rename_reset var in
-  value
-
-(* TODO: remove duplicated names *)
-let tv_univ = tv_fresh (Name.make "Type")
-let tt_global_univ = ttype @@ TT_var { var = tv_univ }
-let tv_string = tv_fresh (Name.make "String")
-let tt_global_string = ttype @@ TT_var { var = tv_string }
+(* String *)
+let level_string = Level.next level_univ
+let tt_global_string = ttype @@ TT_global_var { var = level_string }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -16,8 +16,12 @@ type term = private
 and term_syntax = private
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
-  (* x *)
-  | TT_var of { var : var }
+  (* \!+n *)
+  | TT_rigid_var of { var : Level.t }
+  (* \+n *)
+  | TT_global_var of { var : Level.t }
+  (* \-n *)
+  | TT_local_var of { var : Index.t }
   (* P -> B *)
   | TT_forall of { param : pat; return : term }
   (* P => M *)
@@ -29,29 +33,22 @@ and term_syntax = private
   (* ".." *)
   | TT_string of { literal : string }
 
-and pat = private
-  (* #(P : A) *)
-  | TPat of { pat : pat_syntax; type_ : term }
+and pat = private TPat (* #(P : A) *) of { pat : pat_syntax; type_ : term }
 
 and pat_syntax =
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
-  | TP_var of { var : var }
-
-and var = private
-  | TVar of { name : Name.t; mutable link : term; mutable rename : var }
+  | TP_var of { name : Name.t }
 [@@deriving show]
-
-(* invariants *)
-exception TVar_already_linked of { var : var }
-exception TVar_already_renamed of { var : var }
 
 (* term *)
 val tterm : type_:term -> term_syntax -> term
 val ttype : term_syntax -> term
 val tt_annot : term:term -> annot:term -> term_syntax
-val tt_var : var:var -> term_syntax
+val tt_rigid_var : var:Level.t -> term_syntax
+val tt_global_var : var:Level.t -> term_syntax
+val tt_local_var : var:Index.t -> term_syntax
 val tt_forall : param:pat -> return:term -> term_syntax
 val tt_lambda : param:pat -> return:term -> term_syntax
 val tt_apply : lambda:term -> arg:term -> term_syntax
@@ -61,22 +58,12 @@ val tt_string : literal:string -> term_syntax
 (* pat *)
 val tpat : type_:term -> pat_syntax -> pat
 val tp_annot : pat:pat -> annot:term -> pat_syntax
-val tp_var : var:var -> pat_syntax
-
-(* var *)
-val is_linked : var -> bool
-val is_renamed : var -> bool
-val is_tt_nil : term -> bool
-val is_tv_nil : var -> bool
-val tv_fresh : Name.t -> var
-
-val with_tv_link : var -> to_:term -> (unit -> 'k) -> 'k
-val with_tv_rename : var -> to_:var -> (unit -> 'k) -> 'k
+val tp_var : name:Name.t -> pat_syntax
 
 (* Type *)
-val tv_univ : var
+val level_univ : Level.t
 val tt_global_univ : term
 
 (* String *)
-val tv_string : var
+val level_string : Level.t
 val tt_global_string : term


### PR DESCRIPTION
## Goals

Prepare a better and faster representation for unification.

## Context

Currently Teika uses alpha renaming for type checking, while this works nicely and is conceptually closer to the source behavior, it relies on alpha-renaming which is in general slow and it additionally makes unification considerably harder.

This representation split variables in 3, rigid, local and global vars, the first two are equivalent to locally nameless free and bound vars, while global vars are a relocatable version of local vars, the goal is that all the terms in the substitution list are packed and as such they don't require any shifting, packing has a cost, but it is paid only once when creating the substitution.

## Warning

This is likely not the final representation, just an intermediary state to show case a couple techniques, used here, namely `packing` which may be a worth optimization in the future.

## Related

- #199