### PR TITLE
teika: use unified tree for typed terms

### DIFF
--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -19,6 +19,9 @@ type error =
   | TError_unknown_extension of { extension : Name.t; payload : Ltree.term }
   | TError_unknown_native of { native : string }
   | TError_missing_annotation
+  (* bug *)
+  | TError_invariant_term_untyped of { term : term }
+  | TError_invariant_pat_untyped of { pat : pat }
 
 and t = error [@@deriving show { with_path = false }]
 
@@ -40,3 +43,9 @@ let error_unknown_extension ~extension ~payload =
 
 let error_unknown_native ~native = terror @@ TError_unknown_native { native }
 let error_missing_annotation () = terror @@ TError_missing_annotation
+
+let error_invariant_term_untyped term =
+  terror @@ TError_invariant_term_untyped { term }
+
+let error_invariant_pat_untyped pat =
+  terror @@ TError_invariant_pat_untyped { pat }

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -18,6 +18,9 @@ type error =
   (* TODO: native should not be a string *)
   | TError_unknown_native of { native : string }
   | TError_missing_annotation
+  (* bug *)
+  | TError_invariant_term_untyped of { term : term }
+  | TError_invariant_pat_untyped of { pat : pat }
 
 type t = error [@@deriving show]
 
@@ -33,3 +36,5 @@ val error_pairs_not_implemented : unit -> 'a
 val error_unknown_extension : extension:Name.t -> payload:Ltree.term -> 'a
 val error_unknown_native : native:string -> 'a
 val error_missing_annotation : unit -> 'a
+val error_invariant_term_untyped : term -> 'a
+val error_invariant_pat_untyped : pat -> 'a

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -2,11 +2,7 @@ open Utils
 
 type term =
   (* #(M : A) *)
-  | TTerm of { term : term_syntax; type_ : term }
-  (* #(A : U) *)
-  | TType of { term : term_syntax }
-
-and term_syntax =
+  | TT_typed of { term : term; type_ : term }
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
   (* \!+n *)
@@ -26,10 +22,9 @@ and term_syntax =
   (* ".." *)
   | TT_string of { literal : string }
 
-and pat = (* #(P : A) *)
-  | TPat of { pat : pat_syntax; type_ : term }
-
-and pat_syntax =
+and pat =
+  (* #(P : A) *)
+  | TP_typed of { pat : pat; type_ : term }
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
@@ -38,8 +33,7 @@ and pat_syntax =
 
 (* TODO: expose this? *)
 (* terms *)
-let tterm ~type_ term = TTerm { term; type_ }
-let ttype term = TType { term }
+let tt_typed ~type_ term = TT_typed { term; type_ }
 let tt_annot ~term ~annot = TT_annot { term; annot }
 let tt_rigid_var ~var = TT_rigid_var { var }
 let tt_global_var ~var = TT_global_var { var }
@@ -51,14 +45,16 @@ let tt_let ~bound ~value ~return = TT_let { bound; value; return }
 let tt_string ~literal = TT_string { literal }
 
 (* patterns *)
-let tpat ~type_ pat = TPat { pat; type_ }
+let tp_typed ~type_ pat = TP_typed { pat; type_ }
 let tp_annot ~pat ~annot = TP_annot { pat; annot }
 let tp_var ~name = TP_var { name }
 
 (* Type *)
 let level_univ = Level.zero
-let tt_global_univ = ttype @@ TT_global_var { var = level_univ }
+let tt_rigid_univ = TT_rigid_var { var = level_univ }
 
 (* String *)
 let level_string = Level.next level_univ
-let tt_global_string = ttype @@ TT_global_var { var = level_string }
+
+let tt_rigid_string =
+  tt_typed ~type_:tt_rigid_univ @@ TT_rigid_var { var = level_string }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,19 +1,11 @@
 open Utils
 
-(* TODO: reduce allocations?
-   TT_with_type and TT_with_sort is not needed in many positions *)
-(* TODO: subst to_ typed and check every time it is substituted *)
 (* TODO: which invariants to enforce here using private? *)
-
 (* TODO: return should be body *)
-(* TODO: cache normalization? *)
+
 type term = private
   (* #(M : A) *)
-  | TTerm of { term : term_syntax; type_ : term }
-  (* #(A : U) *)
-  | TType of { term : term_syntax }
-
-and term_syntax = private
+  | TT_typed of { term : term; type_ : term }
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
   (* \!+n *)
@@ -33,9 +25,9 @@ and term_syntax = private
   (* ".." *)
   | TT_string of { literal : string }
 
-and pat = private TPat (* #(P : A) *) of { pat : pat_syntax; type_ : term }
-
-and pat_syntax =
+and pat = private
+  (* #(P : A) *)
+  | TP_typed of { pat : pat; type_ : term }
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
@@ -43,27 +35,26 @@ and pat_syntax =
 [@@deriving show]
 
 (* term *)
-val tterm : type_:term -> term_syntax -> term
-val ttype : term_syntax -> term
-val tt_annot : term:term -> annot:term -> term_syntax
-val tt_rigid_var : var:Level.t -> term_syntax
-val tt_global_var : var:Level.t -> term_syntax
-val tt_local_var : var:Index.t -> term_syntax
-val tt_forall : param:pat -> return:term -> term_syntax
-val tt_lambda : param:pat -> return:term -> term_syntax
-val tt_apply : lambda:term -> arg:term -> term_syntax
-val tt_let : bound:pat -> value:term -> return:term -> term_syntax
-val tt_string : literal:string -> term_syntax
+val tt_typed : type_:term -> term -> term
+val tt_annot : term:term -> annot:term -> term
+val tt_rigid_var : var:Level.t -> term
+val tt_global_var : var:Level.t -> term
+val tt_local_var : var:Index.t -> term
+val tt_forall : param:pat -> return:term -> term
+val tt_lambda : param:pat -> return:term -> term
+val tt_apply : lambda:term -> arg:term -> term
+val tt_let : bound:pat -> value:term -> return:term -> term
+val tt_string : literal:string -> term
 
 (* pat *)
-val tpat : type_:term -> pat_syntax -> pat
-val tp_annot : pat:pat -> annot:term -> pat_syntax
-val tp_var : name:Name.t -> pat_syntax
+val tp_typed : type_:term -> pat -> pat
+val tp_annot : pat:pat -> annot:term -> pat
+val tp_var : name:Name.t -> pat
 
 (* Type *)
 val level_univ : Level.t
-val tt_global_univ : term
+val tt_rigid_univ : term
 
 (* String *)
 val level_string : Level.t
-val tt_global_string : term
+val tt_rigid_string : term


### PR DESCRIPTION
## Goals

Faster and easier to work with representation.

## Context

The model of `wrapper + desc` similar to the OCaml compiler is convenient as it provides some additional guarantees, such as that every term has a location, type annotation or another other property.

But it isn't really needed and it adds some code complexity, now every function needs an additional `tt_syntax_func`, additionally some terms don't need a wrapper.

This provided a couple meaningful % improvement on the equality check.

## Related

- #199
