### PR TITLE
teika: share immutable substitutions

### DIFF
--- a/teika/level.ml
+++ b/teika/level.ml
@@ -10,7 +10,10 @@ let next n =
 
 let ( < ) : level -> level -> bool = ( < )
 let of_int x = match x >= zero with true -> Some x | false -> None
-let repr x = x
+
+let level_of_index ~next ~var =
+  let var = Index.repr var in
+  of_int (next - 1 - var)
 
 let global_to_local ~size ~var ~depth =
   let top = size - 1 in

--- a/teika/level.mli
+++ b/teika/level.mli
@@ -4,9 +4,7 @@ type t = level [@@deriving show, eq]
 val zero : level
 val next : level -> level
 val ( < ) : level -> level -> bool
-
-(* TODO: bad to expose this *)
-val repr : level -> int
+val level_of_index : next:level -> var:Index.t -> level option
 
 (* TODO: better place for this *)
 val global_to_local : size:level -> var:level -> depth:Index.t -> Index.t option


### PR DESCRIPTION
## Goals

Test a faster and maybe more flexible representation.

## Context

Currently Teika uses a model with tree variables described at #210, this model is faster than the previous one but relies on a mutable stack, additionally it is not as fast as expected as `pack` is a slow'ish operation.

Here we preserve the model but use instead a immutable substitution stack, this works because it essentially make every term a "closed term".

Overall this change makes the tests around 5x faster.

## Related

- #199