### PR TITLE
teika: just use shifting

### DIFF
--- a/teika/index.ml
+++ b/teika/index.ml
@@ -12,4 +12,9 @@ let ( < ) : index -> index -> bool = ( < )
 let repr x = x
 let of_int x = match x >= zero with true -> Some x | false -> None
 
+let shift index ~by_ =
+  (* TODO: better error message here  *)
+  assert (by_ >= 0);
+  index + by_
+
 module Map = Map.Make (Int)

--- a/teika/index.mli
+++ b/teika/index.mli
@@ -8,5 +8,6 @@ val ( < ) : index -> index -> bool
 (* TODO: exposing this is bad *)
 val repr : index -> int
 val of_int : int -> index option
+val shift : index -> by_:int -> index
 
 module Map : Map.S with type key = index

--- a/teika/level.ml
+++ b/teika/level.ml
@@ -15,12 +15,7 @@ let level_of_index ~next ~var =
   let var = Index.repr var in
   of_int (next - 1 - var)
 
-let global_to_local ~size ~var ~depth =
-  let top = size - 1 in
-  Index.of_int @@ (top + Index.repr depth - var)
-
-let local_to_global ~size ~var ~depth =
-  let top = size - 1 in
-  of_int @@ (top + Index.repr depth - Index.repr var)
+let repr level = level
+let offset ~from ~to_ = Index.of_int (to_ - from)
 
 module Map = Map.Make (Int)

--- a/teika/level.mli
+++ b/teika/level.mli
@@ -6,8 +6,8 @@ val next : level -> level
 val ( < ) : level -> level -> bool
 val level_of_index : next:level -> var:Index.t -> level option
 
-(* TODO: better place for this *)
-val global_to_local : size:level -> var:level -> depth:Index.t -> Index.t option
-val local_to_global : size:level -> var:Index.t -> depth:Index.t -> level option
+(* TODO: not great to expose this *)
+val repr : level -> int
+val offset : from:level -> to_:level -> Index.t option
 
 module Map : Map.S with type key = level

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -14,6 +14,7 @@ module Typer = struct
   (* TODO: write tests for escape check *)
   let univ_type = check "Type" {|(Type : Type)|}
   let string_type = check "String" {|(String : Type)|}
+  let false_type = check "False" {|(A : Type) -> A|}
 
   let id =
     check "id" {|((A : Type) => (x : A) => x : (A : Type) -> (x : A) -> A)|}
@@ -178,6 +179,7 @@ module Typer = struct
     [
       univ_type;
       string_type;
+      false_type;
       id;
       (*
       id_propagate;

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -7,9 +7,8 @@ module Ptree = struct
     | PT_meta of { term : term }
     | PT_annot of { term : term; annot : term }
     | PT_var of { name : Name.t }
-    | PT_rigid_var of { var : Level.t }
-    | PT_global_var of { var : Level.t }
-    | PT_local_var of { var : Index.t }
+    | PT_free_var of { var : Level.t }
+    | PT_bound_var of { var : Index.t }
     | PT_forall of { param : term; return : term }
     | PT_lambda of { param : term; return : term }
     | PT_apply of { lambda : term; arg : term }
@@ -24,9 +23,8 @@ module Ptree = struct
     | PT_annot { term; annot } ->
         fprintf fmt "%a : %a" pp_funct term pp_wrapped annot
     | PT_var { name } -> fprintf fmt "%s" (Name.repr name)
-    | PT_rigid_var { var } -> fprintf fmt "\\!+%a" Level.pp var
-    | PT_global_var { var } -> fprintf fmt "\\+%a" Level.pp var
-    | PT_local_var { var } -> fprintf fmt "\\-%a" Index.pp var
+    | PT_free_var { var } -> fprintf fmt "\\+%a" Level.pp var
+    | PT_bound_var { var } -> fprintf fmt "\\-%a" Index.pp var
     | PT_forall { param; return } ->
         fprintf fmt "%a -> %a" pp_atom param pp_funct return
     | PT_lambda { param; return } ->
@@ -46,8 +44,7 @@ module Ptree = struct
     let pp_apply fmt term = pp_term T_apply fmt term in
     let pp_atom fmt term = pp_term T_atom fmt term in
     match (term, prec) with
-    | ( ( PT_meta _ | PT_var _ | PT_rigid_var _ | PT_global_var _
-        | PT_local_var _ | PT_string _ ),
+    | ( (PT_meta _ | PT_var _ | PT_free_var _ | PT_bound_var _ | PT_string _),
         (T_wrapped | T_let | T_funct | T_apply | T_atom) )
     | PT_apply _, (T_wrapped | T_let | T_funct | T_apply)
     | (PT_forall _ | PT_lambda _), (T_wrapped | T_let | T_funct)
@@ -81,11 +78,9 @@ let rec tt_print term =
       let term = tt_print term in
       let annot = tt_print annot in
       PT_annot { term; annot }
-  | TT_rigid_var { var } -> PT_rigid_var { var }
-  | TT_global_var { var } ->
-      (* TODO: expand link sometimes? *)
-      PT_global_var { var }
-  | TT_local_var { var } -> PT_local_var { var }
+  | TT_free_var { var } -> PT_free_var { var }
+  (* TODO: expand subst sometimes? *)
+  | TT_bound_var { var } -> PT_bound_var { var }
   | TT_forall { param; return } ->
       let param = tp_print param in
       let return = tt_print return in

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -5,12 +5,10 @@ type term =
   | TT_typed of { term : term; type_ : term }
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
-  (* \!+n *)
-  | TT_rigid_var of { var : Level.t }
   (* \+n *)
-  | TT_global_var of { var : Level.t }
+  | TT_free_var of { var : Level.t }
   (* \-n *)
-  | TT_local_var of { var : Index.t }
+  | TT_bound_var of { var : Index.t }
   (* P -> B *)
   | TT_forall of { param : pat; return : term }
   (* P => M *)
@@ -35,9 +33,8 @@ and pat =
 (* terms *)
 let tt_typed ~type_ term = TT_typed { term; type_ }
 let tt_annot ~term ~annot = TT_annot { term; annot }
-let tt_rigid_var ~var = TT_rigid_var { var }
-let tt_global_var ~var = TT_global_var { var }
-let tt_local_var ~var = TT_local_var { var }
+let tt_free_var ~var = TT_free_var { var }
+let tt_bound_var ~var = TT_bound_var { var }
 let tt_forall ~param ~return = TT_forall { param; return }
 let tt_lambda ~param ~return = TT_lambda { param; return }
 let tt_apply ~lambda ~arg = TT_apply { lambda; arg }
@@ -51,10 +48,10 @@ let tp_var ~name = TP_var { name }
 
 (* Type *)
 let level_univ = Level.zero
-let tt_rigid_univ = TT_rigid_var { var = level_univ }
+let tt_type_univ = TT_free_var { var = level_univ }
 
 (* String *)
 let level_string = Level.next level_univ
 
-let tt_rigid_string =
-  tt_typed ~type_:tt_rigid_univ @@ TT_rigid_var { var = level_string }
+let tt_type_string =
+  tt_typed ~type_:tt_type_univ @@ TT_free_var { var = level_string }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -8,12 +8,10 @@ type term = private
   | TT_typed of { term : term; type_ : term }
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
-  (* \!+n *)
-  | TT_rigid_var of { var : Level.t }
   (* \+n *)
-  | TT_global_var of { var : Level.t }
+  | TT_free_var of { var : Level.t }
   (* \-n *)
-  | TT_local_var of { var : Index.t }
+  | TT_bound_var of { var : Index.t }
   (* P -> B *)
   | TT_forall of { param : pat; return : term }
   (* P => M *)
@@ -37,9 +35,8 @@ and pat = private
 (* term *)
 val tt_typed : type_:term -> term -> term
 val tt_annot : term:term -> annot:term -> term
-val tt_rigid_var : var:Level.t -> term
-val tt_global_var : var:Level.t -> term
-val tt_local_var : var:Index.t -> term
+val tt_free_var : var:Level.t -> term
+val tt_bound_var : var:Index.t -> term
 val tt_forall : param:pat -> return:term -> term
 val tt_lambda : param:pat -> return:term -> term
 val tt_apply : lambda:term -> arg:term -> term
@@ -53,8 +50,8 @@ val tp_var : name:Name.t -> pat
 
 (* Type *)
 val level_univ : Level.t
-val tt_rigid_univ : term
+val tt_type_univ : term
 
 (* String *)
 val level_string : Level.t
-val tt_rigid_string : term
+val tt_type_string : term

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -9,15 +9,14 @@ module Substs : sig
 
   val size : substs -> Level.t
   val empty : substs
-  val push : to_:term -> at_:substs -> substs -> substs
-  val find_global : var:Level.t -> substs -> term * substs
-  val find_local : var:Index.t -> substs -> term * substs
+  val push : to_:term -> at_:Level.t -> substs -> substs
+  val find_local : var:Index.t -> substs -> term * Level.t
 end = struct
   open Ttree
 
   (* TODO: especialized patricia trie *)
   type substs =
-    | Substs of { next : Level.t; content : (term * substs) Level.Map.t }
+    | Substs of { next : Level.t; content : (term * Level.t) Level.Map.t }
 
   type t = substs
 
@@ -33,11 +32,6 @@ end = struct
     let content = Level.Map.add next (to_, at_) content in
     let next = Level.next next in
     Substs { next; content }
-
-  let find_global ~var substs =
-    let (Substs { next = _; content }) = substs in
-    (* TODO: proper errors here *)
-    Level.Map.find var content
 
   let find_local ~var substs =
     let (Substs { next; content }) = substs in
@@ -55,7 +49,7 @@ module Machinery = struct
   let tt_type_of term =
     match term with
     (* sort *)
-    | TT_rigid_var { var } when Level.equal var level_univ -> term
+    | TT_free_var { var } when Level.equal var level_univ -> term
     (* wrappers *)
     | TT_typed { term = _; type_ } -> type_
     | TT_annot { term = _; annot } -> annot
@@ -72,110 +66,120 @@ module Machinery = struct
   (* TODO: tag terms without binders *)
   (* TODO: tag terms locally closed *)
   (* TODO: gas count *)
-  let rec tt_pack ~size ~depth term =
-    let tt_pack ~depth term = tt_pack ~size ~depth term in
-    let tp_pack ~depth pat = tp_pack ~size ~depth pat in
+  let rec tt_shift ~by_ ~depth term =
+    let tt_shift ~depth term = tt_shift ~by_ ~depth term in
+    let tp_shift ~depth pat = tp_shift ~by_ ~depth pat in
     match term with
     | TT_typed { term; type_ } ->
-        let type_ = tt_pack ~depth type_ in
-        tt_typed ~type_ @@ tt_pack ~depth term
+        let type_ = tt_shift ~depth type_ in
+        tt_typed ~type_ @@ tt_shift ~depth term
     | TT_annot { term; annot } ->
-        let annot = tt_pack ~depth annot in
-        let term = tt_pack ~depth term in
+        let annot = tt_shift ~depth annot in
+        let term = tt_shift ~depth term in
         tt_annot ~term ~annot
-    | TT_rigid_var { var = _ } as term -> term
-    | TT_global_var { var } as term -> (
-        match Level.(var < size) with
-        | true -> term
-        | false -> (
-            match Level.global_to_local ~size ~var ~depth with
-            | Some var -> tt_local_var ~var
-            | None -> term))
-    | TT_local_var { var } as term -> (
+    | TT_free_var { var = _ } as term -> term
+    | TT_bound_var { var } as term -> (
         match Index.(var < depth) with
         | true -> term
-        | false -> (
-            match Level.local_to_global ~size ~var ~depth with
-            | Some var -> tt_global_var ~var
-            | None -> term))
+        | false ->
+            let var = Index.shift var ~by_ in
+            tt_bound_var ~var)
     | TT_forall { param; return } ->
-        let param = tp_pack ~depth param in
+        let param = tp_shift ~depth param in
         let return =
           let depth = Index.next depth in
-          tt_pack ~depth return
+          tt_shift ~depth return
         in
         tt_forall ~param ~return
     | TT_lambda { param; return } ->
-        let param = tp_pack ~depth param in
+        let param = tp_shift ~depth param in
         let return =
           let depth = Index.next depth in
-          tt_pack ~depth return
+          tt_shift ~depth return
         in
         tt_lambda ~param ~return
     | TT_apply { lambda; arg } ->
-        let lambda = tt_pack ~depth lambda in
-        let arg = tt_pack ~depth arg in
+        let lambda = tt_shift ~depth lambda in
+        let arg = tt_shift ~depth arg in
         tt_apply ~lambda ~arg
     | TT_let { bound; value; return } ->
-        let bound = tp_pack ~depth bound in
-        let value = tt_pack ~depth value in
+        let bound = tp_shift ~depth bound in
+        let value = tt_shift ~depth value in
         let return =
           let depth = Index.next depth in
-          tt_pack ~depth return
+          tt_shift ~depth return
         in
         tt_let ~bound ~value ~return
     | TT_string { literal = _ } as term -> term
 
-  and tp_pack ~size ~depth pat =
-    let tt_pack ~depth term = tt_pack ~size ~depth term in
-    let tp_pack ~depth pat = tp_pack ~size ~depth pat in
+  and tp_shift ~by_ ~depth pat =
+    let tt_shift ~depth term = tt_shift ~by_ ~depth term in
+    let tp_shift ~depth pat = tp_shift ~by_ ~depth pat in
     match pat with
     | TP_typed { pat; type_ } ->
-        let type_ = tt_pack ~depth type_ in
-        tp_typed ~type_ @@ tp_pack ~depth pat
+        let type_ = tt_shift ~depth type_ in
+        tp_typed ~type_ @@ tp_shift ~depth pat
     | TP_annot { pat; annot } ->
-        let annot = tt_pack ~depth annot in
-        let pat = tp_pack ~depth pat in
+        let annot = tt_shift ~depth annot in
+        let pat = tp_shift ~depth pat in
         tp_annot ~annot ~pat
     | TP_var _ as pat -> pat
 
-  let tt_pack ~size term = tt_pack ~size ~depth:Index.zero term
+  let tt_shift ~by_ term = tt_shift ~by_ ~depth:Index.zero term
 
-  let rec with_tt_expand_head term ~args ~substs k =
-    match (term, args) with
-    (* annot *)
-    | TT_typed { term; type_ = _ }, _ ->
-        with_tt_expand_head term ~args ~substs k
-    | TT_annot { term; annot = _ }, _ ->
-        with_tt_expand_head term ~args ~substs k
-    (* substs *)
-    | TT_global_var { var }, _ ->
-        let term, substs = Substs.find_global ~var substs in
-        with_tt_expand_head term ~args ~substs k
-    | TT_local_var { var }, _ ->
-        let term, substs = Substs.find_local ~var substs in
-        with_tt_expand_head term ~args ~substs k
-    (* beta *)
-    | TT_lambda { param = _; return = term }, (arg, arg_substs) :: args ->
-        let substs = Substs.push ~to_:arg ~at_:arg_substs substs in
-        with_tt_expand_head term ~args ~substs k
-    | TT_apply { lambda = term; arg }, _ ->
-        let args = (arg, substs) :: args in
-        with_tt_expand_head term ~args ~substs k
-    (* let *)
-    | TT_let { bound = _; value; return = term }, _ ->
-        let substs = Substs.push ~to_:value ~at_:substs substs in
-        with_tt_expand_head term ~args ~substs k
-    (* head *)
-    | TT_rigid_var _, _ | TT_forall _, _ | TT_lambda _, [] | TT_string _, _ ->
-        k term ~args ~substs
+  let rec tt_expand_head term ~substs =
+    match term with
+    | TT_typed { term; type_ = _ } ->
+        (* typed *)
+        tt_expand_head term ~substs
+    | TT_annot { term; annot = _ } ->
+        (* annot *)
+        tt_expand_head term ~substs
+    | TT_bound_var { var } ->
+        (* subst *)
+        let term =
+          let term, at_ = Substs.find_local ~var substs in
+          let by_ = (Level.repr @@ Substs.size substs) - Level.repr at_ in
+          (* TODO: not very fast *)
+          tt_shift ~by_ term
+        in
+        tt_expand_head term ~substs
+    | TT_apply { lambda; arg } -> (
+        match tt_expand_head lambda ~substs with
+        | TT_lambda { param = _; return }, lambda_substs ->
+            (* beta *)
+            let substs =
+              let at_ = Substs.size substs in
+              Substs.push ~to_:arg ~at_ lambda_substs
+            in
+            tt_expand_head return ~substs
+        | lambda, lambda_substs ->
+            (* head *)
+            let arg =
+              let by_ =
+                (Level.repr @@ Substs.size lambda_substs)
+                - (Level.repr @@ Substs.size substs)
+              in
+              tt_shift ~by_ arg
+            in
+            (tt_apply ~lambda ~arg, lambda_substs))
+    | TT_let { bound = _; value; return = term } ->
+        (* zeta *)
+        let substs =
+          let at_ = Substs.size substs in
+          Substs.push ~to_:value ~at_ substs
+        in
+        tt_expand_head term ~substs
+    | TT_free_var _ | TT_forall _ | TT_lambda _ | TT_string _ ->
+        (* head *)
+        (term, substs)
 
   (* TODO: avoid cyclical expansion *)
   (* TODO: avoid allocating term nodes *)
   (* TODO: short circuit when same variable on both sides *)
   let rec tt_equal ~level ~left ~left_substs ~right ~right_substs =
     match (left, right) with
-    | TT_rigid_var { var = left_var }, TT_rigid_var { var = right_var }
+    | TT_free_var { var = left_var }, TT_free_var { var = right_var }
       when Level.equal left_var right_var ->
         ()
     | left, right ->
@@ -184,25 +188,17 @@ module Machinery = struct
         tt_modulo_equal ~level ~left ~left_substs ~right ~right_substs
 
   and tt_modulo_equal ~level ~left ~left_substs ~right ~right_substs =
-    with_tt_expand_head left ~args:[] ~substs:left_substs
-    @@ fun left ~args:left_args ~substs:left_substs ->
-    with_tt_expand_head right ~args:[] ~substs:right_substs
-    @@ fun right ~args:right_args ~substs:right_substs ->
-    tt_struct_equal ~level ~left ~left_substs ~right ~right_substs;
-    (* TODO: arith clash *)
-    List.iter2
-      (fun (left, left_substs) (right, right_substs) ->
-        tt_equal ~level ~left ~left_substs ~right ~right_substs)
-      left_args right_args
+    let left, left_substs = tt_expand_head left ~substs:left_substs in
+    let right, right_substs = tt_expand_head right ~substs:right_substs in
+    tt_struct_equal ~level ~left ~left_substs ~right ~right_substs
 
   and tt_struct_equal ~level ~left ~left_substs ~right ~right_substs =
     match (left, right) with
     | TT_typed _, _ | _, TT_typed _ -> failwith "invariant"
     | TT_annot _, _ | _, TT_annot _ -> failwith "invariant"
     | TT_let _, _ | _, TT_let _ -> failwith "invariant"
-    | TT_global_var _, _ | _, TT_global_var _ -> failwith "invariant"
-    | TT_local_var _, _ | _, TT_local_var _ -> failwith "invariant"
-    | TT_rigid_var { var = left }, TT_rigid_var { var = right }
+    | TT_bound_var _, _ | _, TT_bound_var _ -> failwith "invariant"
+    | TT_free_var { var = left }, TT_free_var { var = right }
       when Level.equal left right ->
         ()
     | ( TT_forall { param = left_param; return = left_return },
@@ -228,9 +224,9 @@ module Machinery = struct
     | TT_string { literal = left }, TT_string { literal = right }
       when String.equal left right ->
         ()
-    | ( (TT_rigid_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_string _),
-        (TT_rigid_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_string _)
-      ) ->
+    | ( (TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_string _),
+        (TT_free_var _ | TT_forall _ | TT_lambda _ | TT_apply _ | TT_string _) )
+      ->
         (* TODO: type clash needs substs *)
         error_type_clash ~left ~right
 
@@ -242,15 +238,19 @@ module Machinery = struct
     let level = Level.next level in
     let left_to_ =
       (* TODO: maybe pack left_type? *)
-      tt_typed ~type_:left_type @@ tt_rigid_var ~var:level
+      tt_typed ~type_:left_type @@ tt_free_var ~var:level
     in
     let right_to_ =
       (* TODO: maybe pack right_type? *)
-      tt_typed ~type_:right_type @@ tt_rigid_var ~var:level
+      tt_typed ~type_:right_type @@ tt_free_var ~var:level
     in
-    let left_substs = Substs.push ~to_:left_to_ ~at_:left_substs left_substs in
+    let left_substs =
+      let at_ = Substs.size left_substs in
+      Substs.push ~to_:left_to_ ~at_ left_substs
+    in
     let right_substs =
-      Substs.push ~to_:right_to_ ~at_:right_substs right_substs
+      let at_ = Substs.size right_substs in
+      Substs.push ~to_:right_to_ ~at_ right_substs
     in
     k ~level ~left_substs ~right_substs
 
@@ -262,9 +262,12 @@ module Machinery = struct
     match (type_, args) with
     | TT_forall { param; return }, [] ->
         let wrapped_arg_type = tp_type_of param in
-        let apply_return_type ~arg =
-          tt_typed ~type_:tt_rigid_univ
-          @@ tt_let ~bound:param ~value:arg ~return
+        let apply_return_type ~arg ~at_ =
+          let arg =
+            let by_ = (Level.repr @@ Substs.size substs) - Level.repr at_ in
+            tt_shift ~by_ arg
+          in
+          tt_typed ~type_:tt_type_univ @@ tt_let ~bound:param ~value:arg ~return
         in
         (wrapped_arg_type, apply_return_type)
     (* annot *)
@@ -273,54 +276,43 @@ module Machinery = struct
     | TT_annot { term = type_; annot = _ }, _ ->
         tt_split_forall type_ ~args ~substs
     (* substs *)
-    | TT_global_var { var }, _ ->
-        let type_, _at = Substs.find_global ~var substs in
-        tt_split_forall type_ ~args ~substs
-    | TT_local_var { var }, _ ->
-        let type_, _at = Substs.find_local ~var substs in
+    | TT_bound_var { var }, _ ->
+        let type_ =
+          let type_, at_ = Substs.find_local ~var substs in
+          let by_ = (Level.repr @@ Substs.size substs) - Level.repr at_ in
+          (* TODO: not very fast *)
+          tt_shift ~by_ type_
+        in
         tt_split_forall type_ ~args ~substs
     (* beta *)
-    | TT_lambda { param; return = type_ }, arg :: args ->
-        tt_split_forall_subst ~bound:param ~value:arg type_ ~args ~substs
-    | TT_apply { lambda = type_; arg }, _ ->
-        let args =
-          let size = Substs.size substs in
-          tt_pack ~size arg :: args
-        in
-        tt_split_forall type_ ~args ~substs
+    | TT_lambda { param; return = type_ }, (arg, at_) :: args ->
+        tt_split_forall_subst ~bound:param ~value:arg ~at_ type_ ~args ~substs
+    | TT_apply { lambda; arg }, args ->
+        let args = (arg, Substs.size substs) :: args in
+        tt_split_forall lambda ~args ~substs
     (* let *)
     | TT_let { bound; value; return = type_ }, _ ->
-        let value =
-          let size = Substs.size substs in
-          tt_pack ~size value
-        in
-        tt_split_forall_subst ~bound ~value type_ ~args ~substs
+        let at_ = Substs.size substs in
+        tt_split_forall_subst ~bound ~value ~at_ type_ ~args ~substs
     (* head *)
-    | TT_rigid_var _, _ | TT_forall _, _ | TT_lambda _, [] | TT_string _, _ ->
-        let type_ =
-          List.fold_left
-            (fun lambda arg ->
-              tt_typed ~type_:tt_rigid_univ @@ tt_apply ~lambda ~arg)
-            type_ args
-        in
+    | TT_free_var _, _ | TT_forall _, _ | TT_lambda _, [] | TT_string _, _ ->
+        (* TODO: dump substs *)
         error_not_a_forall ~type_
 
-  and tt_split_forall_subst ~bound ~value type_ ~args ~substs =
-    let substs = Substs.push ~to_:value ~at_:substs substs in
+  and tt_split_forall_subst ~bound ~value ~at_ type_ ~args ~substs =
+    let substs = Substs.push ~to_:value ~at_ substs in
     let wrapped_arg_type, apply_return_type =
       tt_split_forall type_ ~args ~substs
     in
     let wrapped_arg_type =
-      tt_typed ~type_:tt_rigid_univ
+      tt_typed ~type_:tt_type_univ
       @@ tt_let ~bound ~value ~return:wrapped_arg_type
     in
-    let apply_return_type ~arg =
-      tt_typed ~type_:tt_rigid_univ
-      @@ tt_let ~bound ~value ~return:(apply_return_type ~arg)
+    let apply_return_type ~arg ~at_ =
+      tt_typed ~type_:tt_type_univ
+      @@ tt_let ~bound ~value ~return:(apply_return_type ~arg ~at_)
     in
     (wrapped_arg_type, apply_return_type)
-
-  let tt_split_forall type_ ~substs = tt_split_forall type_ ~args:[] ~substs
 end
 
 module Context : sig
@@ -331,7 +323,7 @@ module Context : sig
   val initial : context
 
   (* vars *)
-  val lookup_var : context -> Name.t -> Level.t * term
+  val lookup_var : context -> Name.t -> Index.t * term
   val with_bound_var : context -> Name.t -> type_:term -> (context -> 'k) -> 'k
   val with_subst_var : context -> Name.t -> to_:term -> (context -> 'k) -> 'k
 
@@ -355,26 +347,20 @@ end = struct
       let open Name.Map in
       let names = empty in
       (* TODO: duplicated string name *)
-      let names = add (Name.make "Type") (level_univ, tt_rigid_univ) names in
-      let names =
-        add (Name.make "String") (level_string, tt_rigid_univ) names
-      in
+      let names = add (Name.make "Type") (level_univ, tt_type_univ) names in
+      let names = add (Name.make "String") (level_string, tt_type_univ) names in
       names
     in
     let level = level_string in
     let substs =
       let substs = Substs.empty in
       let substs =
-        let univ =
-          tt_typed ~type_:tt_rigid_univ @@ tt_rigid_var ~var:level_univ
-        in
-        Substs.push ~to_:univ ~at_:substs substs
+        let at_ = Substs.size substs in
+        Substs.push ~to_:tt_type_univ ~at_ substs
       in
       let substs =
-        let string =
-          tt_typed ~type_:tt_rigid_univ @@ tt_rigid_var ~var:level_univ
-        in
-        Substs.push ~to_:string ~at_:substs substs
+        let at_ = Substs.size substs in
+        Substs.push ~to_:tt_type_string ~at_ substs
       in
       substs
     in
@@ -383,46 +369,60 @@ end = struct
     { names; level; left_substs; right_substs }
 
   let lookup_var ctx name =
-    match Name.Map.find_opt name ctx.names with
-    | Some (var, type_) -> (var, type_)
+    let { names; level; left_substs = _; right_substs = _ } = ctx in
+    match Name.Map.find_opt name names with
+    | Some (from, type_) -> (
+        match Level.offset ~from ~to_:level with
+        | Some var ->
+            let type_ = Machinery.tt_shift ~by_:(1 + Index.repr var) type_ in
+            (var, type_)
+        | None -> failwith "invariant")
     | None -> error_unknown_var ~name
 
   let with_bound_var ctx name ~type_ k =
     let { level; names; left_substs; right_substs } = ctx in
     let level = Level.next level in
-    let type_ =
-      (* TODO: is this a good place? *)
-      (* TODO: substs should have the same size right? *)
-      let size = Substs.size left_substs in
-      Machinery.tt_pack ~size type_
-    in
     let names = Name.Map.add name (level, type_) names in
-    let to_ = tt_typed ~type_ @@ tt_rigid_var ~var:level in
-    let left_substs = Substs.push ~to_ ~at_:left_substs left_substs in
-    let right_substs = Substs.push ~to_ ~at_:right_substs right_substs in
+    let to_ = tt_typed ~type_ @@ tt_free_var ~var:level in
+    let left_substs =
+      let at_ = Substs.size left_substs in
+      Substs.push ~to_ ~at_ left_substs
+    in
+    let right_substs =
+      let at_ = Substs.size right_substs in
+      Substs.push ~to_ ~at_ right_substs
+    in
     k @@ { level; names; left_substs; right_substs }
 
   let with_subst_var ctx name ~to_ k =
     let { level; names; left_substs; right_substs } = ctx in
-    let to_ =
-      (* TODO: is this a good place? *)
-      let size = Substs.size left_substs in
-      Machinery.tt_pack ~size to_
-    in
     let level = Level.next level in
     let var = level in
     let names =
       let type_ = Machinery.tt_type_of to_ in
       Name.Map.add name (var, type_) names
     in
-    let left_substs = Substs.push ~to_ ~at_:left_substs left_substs in
-    let right_substs = Substs.push ~to_ ~at_:right_substs right_substs in
+    let left_substs =
+      let at_ = Substs.size left_substs in
+      Substs.push ~to_ ~at_ left_substs
+    in
+    let right_substs =
+      let at_ = Substs.size right_substs in
+      Substs.push ~to_ ~at_ right_substs
+    in
     k @@ { level; names; left_substs; right_substs }
 
   let tt_split_forall ctx type_ =
     let { level = _; names = _; left_substs; right_substs = _ } = ctx in
     (* TODO: left and right? *)
-    Machinery.tt_split_forall type_ ~substs:left_substs
+    let wrapped_arg_type, apply_return_type =
+      Machinery.tt_split_forall type_ ~args:[] ~substs:left_substs
+    in
+    let apply_return_type ~arg =
+      let at_ = Substs.size left_substs in
+      apply_return_type ~arg ~at_
+    in
+    (wrapped_arg_type, apply_return_type)
 
   let tt_equal ctx ~left ~right =
     let { level; names = _; left_substs; right_substs } = ctx in
@@ -452,18 +452,18 @@ module Infer = struct
         tt_annot ~term ~annot
     | LT_var { var = name } ->
         let var, type_ = lookup_var ctx name in
-        tt_typed ~type_ @@ tt_global_var ~var
+        tt_typed ~type_ @@ tt_bound_var ~var
     | LT_extension _ -> error_extensions_not_implemented ()
     | LT_forall { param; return } ->
         with_infer_pat ctx param @@ fun ctx param ->
         let return = check_annot ctx return in
-        tt_typed ~type_:tt_rigid_univ @@ tt_forall ~param ~return
+        tt_typed ~type_:tt_type_univ @@ tt_forall ~param ~return
     | LT_lambda { param; return } ->
         with_infer_pat ctx param @@ fun ctx param ->
         let return = infer_term ctx return in
         let type_ =
           let return = tt_type_of return in
-          tt_typed ~type_:tt_rigid_univ @@ tt_forall ~param ~return
+          tt_typed ~type_:tt_type_univ @@ tt_forall ~param ~return
         in
         tt_typed ~type_ @@ tt_lambda ~param ~return
     | LT_apply { lambda; arg } ->
@@ -485,12 +485,12 @@ module Infer = struct
         @@ fun ctx bound ->
         let return = infer_term ctx return in
         let type_ =
-          tt_typed ~type_:tt_rigid_univ
+          tt_typed ~type_:tt_type_univ
           @@ tt_let ~bound ~value ~return:(tt_type_of return)
         in
         tt_typed ~type_ @@ tt_let ~bound ~value ~return
     | LT_string { literal } ->
-        tt_typed ~type_:tt_rigid_univ @@ tt_string ~literal
+        tt_typed ~type_:tt_type_string @@ tt_string ~literal
 
   and check_term ctx term ~expected =
     (* TODO: let () = assert_is_tt_with_type expected in *)
@@ -507,7 +507,7 @@ module Infer = struct
     in
     term
 
-  and check_annot ctx term = check_term ctx term ~expected:tt_rigid_univ
+  and check_annot ctx term = check_term ctx term ~expected:tt_type_univ
 
   and with_infer_pat ctx pat k =
     (* TODO: to_ here *)


### PR DESCRIPTION
## Goals

A simpler and easier to optimize representation.

## Context

Elaboration and unification using the #213 approach leads to very big trees, while those trees are shared, they're still big trees, additionally `close` is required again and it ends up being a VERY slow operation.

This changes the representation to a locally nameless one and it also removes the `global_var`, as they're not needed anymore.

This makes the tests 10x slower, but on the benchmarks the fastest approach uses a lazy version of shifting, which will be implemented in the future.

## Related

- #199
