### PR TITLE
teika: The French Approach

### DIFF
--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -155,7 +155,7 @@ module Perror = struct
     match error with
     | PE_loc { loc; error } -> fprintf fmt "%a\n%a" pp_loc loc pp_error error
     | PE_type_clash { left; right } ->
-        fprintf fmt "type clash\nexpected : %a\nreceived : %a" pp_term left
+        fprintf fmt "type clash\nreceived : %a\nexpected : %a" pp_term left
           pp_term right
     | PE_unknown_var { name } -> fprintf fmt "unknown variable %a" Name.pp name
     | PE_not_a_forall { type_ } ->

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -2,7 +2,7 @@ open Utils
 
 type term =
   (* #(M : A) *)
-  | TT_typed of { term : term; type_ : term }
+  | TT_typed of { term : term; mutable type_ : term }
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
   (* \+n *)
@@ -22,7 +22,7 @@ type term =
 
 and pat =
   (* #(P : A) *)
-  | TP_typed of { pat : pat; type_ : term }
+  | TP_typed of { pat : pat; mutable type_ : term }
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
@@ -46,8 +46,12 @@ let tp_typed ~type_ pat = TP_typed { pat; type_ }
 let tp_annot ~pat ~annot = TP_annot { pat; annot }
 let tp_var ~name = TP_var { name }
 
+(* Nil *)
+let level_nil = Level.zero
+let tt_nil = TT_free_var { var = level_nil }
+
 (* Type *)
-let level_univ = Level.zero
+let level_univ = Level.next level_nil
 let tt_type_univ = TT_free_var { var = level_univ }
 
 (* String *)

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -3,9 +3,9 @@ open Utils
 (* TODO: which invariants to enforce here using private? *)
 (* TODO: return should be body *)
 
-type term = private
+type term =
   (* #(M : A) *)
-  | TT_typed of { term : term; type_ : term }
+  | TT_typed of { term : term; mutable type_ : term }
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
   (* \+n *)
@@ -23,9 +23,9 @@ type term = private
   (* ".." *)
   | TT_string of { literal : string }
 
-and pat = private
+and pat =
   (* #(P : A) *)
-  | TP_typed of { pat : pat; type_ : term }
+  | TP_typed of { pat : pat; mutable type_ : term }
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
@@ -42,6 +42,7 @@ val tt_lambda : param:pat -> return:term -> term
 val tt_apply : lambda:term -> arg:term -> term
 val tt_let : bound:pat -> value:term -> return:term -> term
 val tt_string : literal:string -> term
+val tt_nil : term
 
 (* pat *)
 val tp_typed : type_:term -> pat -> pat

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -43,22 +43,18 @@ end
 module Machinery = struct
   open Ttree
   open Terror
-
   (* TODO: cache normalization? *)
 
-  let tt_type_of term =
+  let tt_split_term term =
     match term with
+    | TT_typed { term; type_ } -> (term, type_)
     (* sort *)
-    | TT_free_var { var } when Level.equal var level_univ -> term
-    (* wrappers *)
-    | TT_typed { term = _; type_ } -> type_
-    | TT_annot { term = _; annot } -> annot
+    | TT_free_var { var } when Level.equal var level_univ -> (term, term)
     | _ -> error_invariant_term_untyped term
 
   let tp_type_of pat =
     match pat with
     | TP_typed { pat = _; type_ } -> type_
-    | TP_annot { pat = _; annot } -> annot
     | _ -> error_invariant_pat_untyped pat
 
   (* TODO: reduce allocations? Maybe cata over term? *)
@@ -178,16 +174,6 @@ module Machinery = struct
   (* TODO: avoid allocating term nodes *)
   (* TODO: short circuit when same variable on both sides *)
   let rec tt_equal ~level ~left ~left_substs ~right ~right_substs =
-    match (left, right) with
-    | TT_free_var { var = left_var }, TT_free_var { var = right_var }
-      when Level.equal left_var right_var ->
-        ()
-    | left, right ->
-        tt_equal ~level ~left:(tt_type_of left) ~left_substs
-          ~right:(tt_type_of right) ~right_substs;
-        tt_modulo_equal ~level ~left ~left_substs ~right ~right_substs
-
-  and tt_modulo_equal ~level ~left ~left_substs ~right ~right_substs =
     let left, left_substs = tt_expand_head left ~substs:left_substs in
     let right, right_substs = tt_expand_head right ~substs:right_substs in
     tt_struct_equal ~level ~left ~left_substs ~right ~right_substs
@@ -315,31 +301,19 @@ module Machinery = struct
     (wrapped_arg_type, apply_return_type)
 end
 
-module Context : sig
-  open Ttree
-
+module Elaborate_context : sig
   type context
 
   val initial : context
 
   (* vars *)
-  val lookup_var : context -> Name.t -> Index.t * term
-  val with_bound_var : context -> Name.t -> type_:term -> (context -> 'k) -> 'k
-  val with_subst_var : context -> Name.t -> to_:term -> (context -> 'k) -> 'k
-
-  (* machinery *)
-  val tt_equal : context -> left:term -> right:term -> unit
-  val tt_split_forall : context -> term -> term * (arg:term -> term)
+  val lookup_var : context -> Name.t -> Index.t
+  val with_bound_var : context -> Name.t -> (context -> 'k) -> 'k
 end = struct
   open Ttree
   open Terror
 
-  type context = {
-    level : Level.t;
-    names : (Level.t * term) Name.Map.t;
-    left_substs : Substs.t;
-    right_substs : Substs.t;
-  }
+  type context = { level : Level.t; names : Level.t Name.Map.t }
 
   let initial =
     (* TODO: this is bad *)
@@ -347,13 +321,126 @@ end = struct
       let open Name.Map in
       let names = empty in
       (* TODO: duplicated string name *)
-      let names = add (Name.make "Type") (level_univ, tt_type_univ) names in
-      let names = add (Name.make "String") (level_string, tt_type_univ) names in
+      let names = add (Name.make "Type") level_univ names in
+      let names = add (Name.make "String") level_string names in
       names
     in
     let level = level_string in
+    { names; level }
+
+  let lookup_var ctx name =
+    let { names; level } = ctx in
+    match Name.Map.find_opt name names with
+    | Some from -> (
+        match Level.offset ~from ~to_:level with
+        | Some var -> var
+        | None -> failwith "invariant lookup")
+    | None -> error_unknown_var ~name
+
+  let with_bound_var ctx name k =
+    let { level; names } = ctx in
+    let level = Level.next level in
+    let names = Name.Map.add name level names in
+    k @@ { level; names }
+end
+
+module Elaborate = struct
+  open Ltree
+  open Ttree
+  open Terror
+  open Elaborate_context
+
+  (* TODO: does having expected_term also improves inference?
+       Maybe with self and fix? But maybe not worth it
+     Seems to help with many cases such as expected on annotation *)
+
+  let rec elaborate_term ctx term =
+    (* TODO: use this location *)
+    let (LTerm { term; loc = _ }) = term in
+    let tt_typed term =
+      (* TODO: some of those could already be typed *)
+      tt_typed ~type_:tt_nil term
+    in
+
+    match term with
+    | LT_annot { term; annot } ->
+        let annot = elaborate_term ctx annot in
+        let term = elaborate_term ctx term in
+        tt_typed @@ tt_annot ~term ~annot
+    | LT_var { var = name } ->
+        let var = lookup_var ctx name in
+        tt_typed @@ tt_bound_var ~var
+    | LT_extension _ -> error_extensions_not_implemented ()
+    | LT_forall { param; return } ->
+        with_elaborate_pat ctx param @@ fun ctx param ->
+        let return = elaborate_term ctx return in
+        tt_typed @@ tt_forall ~param ~return
+    | LT_lambda { param; return } ->
+        with_elaborate_pat ctx param @@ fun ctx param ->
+        let return = elaborate_term ctx return in
+        tt_typed @@ tt_lambda ~param ~return
+    | LT_apply { lambda; arg } ->
+        let lambda = elaborate_term ctx lambda in
+        let arg = elaborate_term ctx arg in
+        tt_typed @@ tt_apply ~lambda ~arg
+    | LT_hoist _ -> error_hoist_not_implemented ()
+    | LT_let { bound; value; return } ->
+        let value = elaborate_term ctx value in
+        (* TODO: this should be before value *)
+        with_elaborate_pat ctx bound @@ fun ctx bound ->
+        let return = elaborate_term ctx return in
+        tt_typed @@ tt_let ~bound ~value ~return
+    | LT_string { literal } -> tt_typed @@ tt_string ~literal
+
+  and with_elaborate_pat ctx pat k =
+    (* TODO: to_ here *)
+    (* TODO: use this location *)
+    let (LPat { pat; loc = _ }) = pat in
+    let tp_typed pat =
+      (* TODO: some of those could already be typed *)
+      tp_typed ~type_:tt_nil pat
+    in
+    match pat with
+    | LP_var { var = name } ->
+        with_bound_var ctx name @@ fun ctx -> k ctx @@ tp_typed @@ tp_var ~name
+    | LP_annot { pat; annot } ->
+        let annot = elaborate_term ctx annot in
+        with_elaborate_pat ctx pat @@ fun ctx pat ->
+        k ctx @@ tp_typed @@ tp_annot ~pat ~annot
+end
+
+module Infer_context : sig
+  open Ttree
+
+  type context
+
+  val initial : context
+
+  (* vars *)
+  val find_var_type : context -> Index.t -> term
+  val with_bound_var : context -> type_:term -> (context -> 'k) -> 'k
+  val with_subst_var : context -> to_:term -> (context -> 'k) -> 'k
+
+  (* machinery *)
+  val tt_equal : context -> left:term -> right:term -> unit
+  val tt_split_forall : context -> term -> term * (arg:term -> term)
+end = struct
+  open Ttree
+
+  type context = {
+    level : Level.t;
+    left_substs : Substs.t;
+    right_substs : Substs.t;
+  }
+
+  let initial =
+    let level = level_string in
     let substs =
       let substs = Substs.empty in
+      let substs =
+        let at_ = Substs.size substs in
+        Substs.push ~to_:tt_nil ~at_ substs
+      in
       let substs =
         let at_ = Substs.size substs in
         Substs.push ~to_:tt_type_univ ~at_ substs
@@ -364,25 +451,18 @@ end = struct
       in
       substs
     in
-    let left_substs = substs in
-    let right_substs = substs in
-    { names; level; left_substs; right_substs }
+    { level; left_substs = substs; right_substs = substs }
 
-  let lookup_var ctx name =
-    let { names; level; left_substs = _; right_substs = _ } = ctx in
-    match Name.Map.find_opt name names with
-    | Some (from, type_) -> (
-        match Level.offset ~from ~to_:level with
-        | Some var ->
-            let type_ = Machinery.tt_shift ~by_:(1 + Index.repr var) type_ in
-            (var, type_)
-        | None -> failwith "invariant")
-    | None -> error_unknown_var ~name
+  let find_var_type ctx var =
+    let { level = _; left_substs; right_substs = _ } = ctx in
+    let term, at_ = Substs.find_local ~var left_substs in
+    let _term, type_ = Machinery.tt_split_term term in
+    let by_ = (Level.repr @@ Substs.size left_substs) - Level.repr at_ in
+    Machinery.tt_shift ~by_ type_
 
-  let with_bound_var ctx name ~type_ k =
-    let { level; names; left_substs; right_substs } = ctx in
+  let with_bound_var ctx ~type_ k =
+    let { level; left_substs; right_substs } = ctx in
     let level = Level.next level in
-    let names = Name.Map.add name (level, type_) names in
     let to_ = tt_typed ~type_ @@ tt_free_var ~var:level in
     let left_substs =
       let at_ = Substs.size left_substs in
@@ -392,16 +472,11 @@ end = struct
       let at_ = Substs.size right_substs in
       Substs.push ~to_ ~at_ right_substs
     in
-    k @@ { level; names; left_substs; right_substs }
+    k @@ { level; left_substs; right_substs }
 
-  let with_subst_var ctx name ~to_ k =
-    let { level; names; left_substs; right_substs } = ctx in
+  let with_subst_var ctx ~to_ k =
+    let { level; left_substs; right_substs } = ctx in
     let level = Level.next level in
-    let var = level in
-    let names =
-      let type_ = Machinery.tt_type_of to_ in
-      Name.Map.add name (var, type_) names
-    in
     let left_substs =
       let at_ = Substs.size left_substs in
       Substs.push ~to_ ~at_ left_substs
@@ -410,10 +485,10 @@ end = struct
       let at_ = Substs.size right_substs in
       Substs.push ~to_ ~at_ right_substs
     in
-    k @@ { level; names; left_substs; right_substs }
+    k @@ { level; left_substs; right_substs }
 
   let tt_split_forall ctx type_ =
-    let { level = _; names = _; left_substs; right_substs = _ } = ctx in
+    let { level = _; left_substs; right_substs = _ } = ctx in
     (* TODO: left and right? *)
     let wrapped_arg_type, apply_return_type =
       Machinery.tt_split_forall type_ ~args:[] ~substs:left_substs
@@ -425,72 +500,59 @@ end = struct
     (wrapped_arg_type, apply_return_type)
 
   let tt_equal ctx ~left ~right =
-    let { level; names = _; left_substs; right_substs } = ctx in
+    let { level; left_substs; right_substs } = ctx in
+    Format.eprintf "left : %a, right : %a\n%!" Tprinter.pp_term left
+      Tprinter.pp_term right;
     Machinery.tt_equal ~level ~left ~left_substs ~right ~right_substs
 end
 
 module Infer = struct
-  open Ltree
   open Ttree
   open Terror
-  open Machinery
-  open Context
+  open Infer_context
 
   (* TODO: does having expected_term also improves inference?
        Maybe with self and fix? But maybe not worth it
      Seems to help with many cases such as expected on annotation *)
 
   let rec infer_term ctx term =
-    (* TODO: use this location *)
-    let (LTerm { term; loc = _ }) = term in
     match term with
-    | LT_annot { term; annot } ->
+    | TT_free_var { var = _ } -> failwith "unreachable"
+    | TT_typed ({ term; type_ = _ } as typed) ->
+        let type_ = infer_term ctx term in
+        typed.type_ <- type_;
+        type_
+    | TT_annot { term; annot } ->
         (* TODO: expected term could propagate here *)
-        let annot = check_annot ctx annot in
+        let () = check_annot ctx annot in
         (* TODO: unify annot before or after check term *)
-        let term = check_term ctx term ~expected:annot in
-        tt_annot ~term ~annot
-    | LT_var { var = name } ->
-        let var, type_ = lookup_var ctx name in
-        tt_typed ~type_ @@ tt_bound_var ~var
-    | LT_extension _ -> error_extensions_not_implemented ()
-    | LT_forall { param; return } ->
-        with_infer_pat ctx param @@ fun ctx param ->
-        let return = check_annot ctx return in
-        tt_typed ~type_:tt_type_univ @@ tt_forall ~param ~return
-    | LT_lambda { param; return } ->
-        with_infer_pat ctx param @@ fun ctx param ->
+        let () = check_term ctx term ~expected:annot in
+        tt_typed ~type_:tt_type_univ @@ annot
+    | TT_bound_var { var } -> find_var_type ctx var
+    | TT_forall { param; return } ->
+        with_infer_pat ctx param @@ fun ctx ->
+        let () = check_annot ctx return in
+        tt_typed ~type_:tt_type_univ @@ tt_type_univ
+    | TT_lambda { param; return } ->
+        with_infer_pat ctx param @@ fun ctx ->
         let return = infer_term ctx return in
-        let type_ =
-          let return = tt_type_of return in
-          tt_typed ~type_:tt_type_univ @@ tt_forall ~param ~return
-        in
-        tt_typed ~type_ @@ tt_lambda ~param ~return
-    | LT_apply { lambda; arg } ->
-        let lambda = infer_term ctx lambda in
+        tt_typed ~type_:tt_type_univ @@ tt_forall ~param ~return
+    | TT_apply { lambda; arg } ->
+        let forall = infer_term ctx lambda in
         (* TODO: this could be better? avoiding split forall? *)
-        let wrapped_arg_type, apply_return_type =
-          tt_split_forall ctx (tt_type_of lambda)
-        in
-        let arg = check_term ctx arg ~expected:wrapped_arg_type in
-        let type_ = apply_return_type ~arg in
-        tt_typed ~type_ @@ tt_apply ~lambda ~arg
-    | LT_hoist _ -> error_hoist_not_implemented ()
-    | LT_let { bound; value; return } ->
+        let wrapped_arg_type, apply_return_type = tt_split_forall ctx forall in
+        let () = check_term ctx arg ~expected:wrapped_arg_type in
+        tt_typed ~type_:tt_type_univ @@ apply_return_type ~arg
+    | TT_let { bound; value; return } ->
         (* TODO: use this loc *)
-        let value = infer_term ctx value in
+        let value_type = infer_term ctx value in
         (* TODO: this should be before value *)
         (* TODO: with_check_pat + subst  *)
-        with_check_pat ctx bound ~expected:(tt_type_of value) ~to_:(Some value)
-        @@ fun ctx bound ->
-        let return = infer_term ctx return in
-        let type_ =
-          tt_typed ~type_:tt_type_univ
-          @@ tt_let ~bound ~value ~return:(tt_type_of return)
-        in
-        tt_typed ~type_ @@ tt_let ~bound ~value ~return
-    | LT_string { literal } ->
-        tt_typed ~type_:tt_type_string @@ tt_string ~literal
+        with_check_pat ctx bound ~expected:value_type ~to_:value @@ fun ctx ->
+        let return_type = infer_term ctx return in
+        tt_typed ~type_:tt_type_univ @@ tt_let ~bound ~value ~return:return_type
+    | TT_string { literal = _ } ->
+        tt_typed ~type_:tt_type_univ @@ tt_type_string
 
   and check_term ctx term ~expected =
     (* TODO: let () = assert_is_tt_with_type expected in *)
@@ -500,50 +562,49 @@ module Infer = struct
     (* TODO: forall could in theory be improved by expected term *)
     (* TODO: apply could propagate when arg is var *)
     (* TODO: could propagate through let? *)
-    let term = infer_term ctx term in
-    let () =
-      let received = tt_type_of term in
-      tt_equal ctx ~left:received ~right:expected
-    in
-    term
+    let received = infer_term ctx term in
+    tt_equal ctx ~left:received ~right:expected
 
   and check_annot ctx term = check_term ctx term ~expected:tt_type_univ
 
   and with_infer_pat ctx pat k =
-    (* TODO: to_ here *)
-    (* TODO: use this location *)
-    let (LPat { pat; loc = _ }) = pat in
+    let type_ = infer_pat ctx pat in
+    with_bound_var ctx ~type_ k
+
+  and infer_pat ctx pat =
     match pat with
-    | LP_var { var = _ } -> error_missing_annotation ()
-    | LP_annot { pat; annot } ->
-        let annot = check_annot ctx annot in
-        with_check_pat ctx pat ~expected:annot ~to_:None @@ fun ctx pat ->
-        k ctx @@ tp_annot ~pat ~annot
+    | TP_typed ({ pat; type_ = _ } as typed) ->
+        let type_ = infer_pat ctx pat in
+        typed.type_ <- type_;
+        type_
+    | TP_var { name = _ } -> error_missing_annotation ()
+    | TP_annot { pat; annot } ->
+        let () = check_annot ctx annot in
+        let () = check_pat ctx pat ~expected:annot in
+        annot
 
   and with_check_pat ctx pat ~expected ~to_ k =
+    let () = check_pat ctx pat ~expected in
+    with_subst_var ctx ~to_ k
+
+  and check_pat ctx pat ~expected =
     (* TODO: let () = assert_is_tt_with_type expected in *)
     (* TODO: expected should be a pattern, to achieve strictness *)
-    (* TODO: use this location *)
-    let (LPat { pat; loc = _ }) = pat in
     match pat with
-    | LP_annot { pat; annot } ->
-        let annot = check_annot ctx annot in
+    | TP_typed ({ pat; type_ = _ } as typed) ->
+        typed.type_ <- expected;
+        check_pat ctx pat ~expected
+    | TP_annot { pat; annot } ->
+        let () = check_annot ctx annot in
         let () = tt_equal ctx ~left:annot ~right:expected in
-        with_check_pat ctx pat ~expected:annot ~to_ @@ fun ctx pat ->
-        k ctx @@ tp_typed ~type_:expected @@ tp_annot ~pat ~annot
-    | LP_var { var = name } -> (
-        (* TODO: this is bad *)
-        match to_ with
-        | Some to_ ->
-            (* TODO: expected == to_? *)
-            with_subst_var ctx name ~to_ @@ fun ctx ->
-            k ctx @@ tp_typed ~type_:expected @@ tp_var ~name
-        | None ->
-            with_bound_var ctx name ~type_:expected @@ fun ctx ->
-            k ctx @@ tp_typed ~type_:expected @@ tp_var ~name)
+        check_pat ctx pat ~expected:annot
+    | TP_var { name = _ } -> ()
 
   let infer_term term =
-    match infer_term Context.initial term with
+    match
+      let term = Elaborate.elaborate_term Elaborate_context.initial term in
+      infer_term Infer_context.initial term
+    with
     | term -> Ok term
     | exception TError { error } -> Error error
 end


### PR DESCRIPTION
## Goals

Simpler code, compiling without typing and faster compile times.

## Context

The French Approach to type inference is mostly a way of doing type checking by splitting it in two steps, elaboration, where the typed tree is produced with "holes"(unification variables) and a constraint tree, then the constraints are solved, closing all the holes and

Here, the constraint tree is the same as the typed tree, but this may change in the future, this essentially means that we're just splitting the elaboration from checking, this leads to a simpler code and it also allows to compile Teika to JS without typing, as the types are not required for the backend.

## Related

- #199