### PR TITLE
teika: uses expand head for split forall

### DIFF
--- a/teika/test.ml
+++ b/teika/test.ml
@@ -125,6 +125,23 @@ module Typer = struct
         x => (A : Type) => y => (id => (_ = (id x); _ = id y; (y : A))) (x => x)
       |}
 
+  let trivial_equality =
+    check "trivial_equality"
+      {|
+        Eq = (A : Type) => (x : A) => (y : A) =>
+          (P : (z : A) -> Type) -> (l : P x) -> P y;
+        refl = (A : Type) => (x : A) =>
+          (P : (z : A) -> Type) => (l : P x) => l;
+        (refl Type Type : Eq Type Type Type)
+      |}
+
+  let split_at_a_distance =
+    check "split_at_a_distance"
+      {|
+        (l : Type) =>
+          (f : (X = Type; (A : X) => (x : A) -> A) Type) => f l
+      |}
+
   let nat_256_equality =
     check "nat_256_equality"
       {|
@@ -206,6 +223,8 @@ module Typer = struct
       (* simplest_escape_check; *)
       bound_var_escape_check;
       hole_lowering_check;
+      trivial_equality;
+      split_at_a_distance;
       nat_256_equality;
       simple_alpha_rename;
     ]

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -49,6 +49,7 @@ let tp_var ~name = TP_var { name }
 (* Nil *)
 let level_nil = Level.zero
 let tt_nil = TT_free_var { var = level_nil }
+let tp_nil = TP_var { name = Name.make "**nil**" }
 
 (* Type *)
 let level_univ = Level.next level_nil

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -48,6 +48,7 @@ val tt_nil : term
 val tp_typed : type_:term -> pat -> pat
 val tp_annot : pat:pat -> annot:term -> pat
 val tp_var : name:Name.t -> pat
+val tp_nil : pat
 
 (* Type *)
 val level_univ : Level.t

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -1,102 +1,6 @@
 open Utils
 open Syntax
 
-module Substs : sig
-  open Ttree
-
-  type substs
-  type t = substs
-
-  val size : substs -> Level.t
-  val make : unit -> substs
-  val push : to_:term -> at_:substs -> substs -> substs
-  val find : var:Index.t -> substs -> term * Level.t
-  val apply : var:Index.t -> substs -> term * substs
-end = struct
-  open Ttree
-
-  (* TODO: especialized patricia trie *)
-  type shifts = (int * Level.t) list
-
-  type substs =
-    | Substs of {
-        next : Level.t;
-        shifts : shifts;
-        content : (term * shifts * Level.t) array;
-      }
-
-  type t = substs
-
-  let size substs =
-    let (Substs { next; shifts = _; content = _ }) = substs in
-    next
-
-  let initial_tuple = (tt_nil, [], Level.zero)
-
-  let make () =
-    let initial_size = 256 in
-    let content = Array.make initial_size initial_tuple in
-    Substs { next = Level.zero; shifts = []; content }
-
-  (* TODO: better name than at_ *)
-  let push ~to_ ~at_ substs =
-    let (Substs { next; shifts; content }) = substs in
-    (* TODO: resize content on demand *)
-    let content =
-      let length = Array.length content in
-      match Level.repr next >= length with
-      | true ->
-          (* TODO: limit memory usage *)
-          (* TODO: maybe fail with out of memory? *)
-          let new_content = Array.make (length * 2) initial_tuple in
-          Array.blit content 0 new_content 0 length;
-          new_content
-      | false -> content
-    in
-    let () =
-      let (Substs { next = at_; shifts; content = _ }) = at_ in
-      Array.set content (Level.repr next) (to_, shifts, at_)
-    in
-    let next = Level.next next in
-    Substs { next; shifts; content }
-
-  let find ~var substs =
-    let (Substs { next; shifts; content }) = substs in
-    (* TODO: this is temporary *)
-    assert (shifts = []);
-    let level = Option.get @@ Level.level_of_index ~next ~var in
-    let term, shifts, at_ = Array.get content (Level.repr level) in
-    assert (shifts = []);
-    (term, at_)
-
-  let rec apply var ~size ~shifts =
-    match shifts with
-    | [] -> var
-    | (by_, at_) :: shifts -> (
-        let distance =
-          (* TODO: should this size decreases? *)
-          Level.repr size - Level.repr at_
-        in
-        match Index.repr var >= distance with
-        | true ->
-            let var = Index.shift var ~by_ in
-            apply var ~size ~shifts
-        | false -> var)
-
-  let apply ~var substs =
-    let (Substs { next; shifts; content }) = substs in
-    (* TODO: proper errors here *)
-    let var = apply var ~size:next ~shifts in
-    let level = Option.get @@ Level.level_of_index ~next ~var in
-    let term, shifts, at_ = Array.get content (Level.repr level) in
-    let shifts =
-      let by_ = Level.repr next - Level.repr at_ in
-      (by_, next) :: shifts
-    in
-    let substs = Substs { next; shifts; content } in
-    (term, substs)
-end
-
 module Machinery = struct
   open Ttree
   open Terror
@@ -114,72 +18,223 @@ module Machinery = struct
     | TP_typed { pat = _; type_ } -> type_
     | _ -> error_invariant_pat_untyped pat
 
-  (* TODO: reduce allocations? Maybe cata over term? *)
-  (* TODO: tag terms without bound variables, aka no shifting *)
-  (* TODO: tag terms without binders *)
-  (* TODO: tag terms locally closed *)
+  module Shifts : sig
+    type shifts
+    type t = shifts
+
+    val empty : shifts
+    val shift : by_:int -> at_:Level.t -> shifts -> shifts
+    val apply : length:Level.t -> shifts -> var:Index.t -> Index.t
+    val tt_commit : length:Level.t -> shifts -> term -> term
+    val tp_commit : length:Level.t -> shifts -> pat -> pat
+  end = struct
+    type shifts = Nil | Shift of { by_ : int; at_ : int; next : shifts }
+    type t = shifts
+
+    let empty = Nil
+
+    let shift ~by_ ~at_ shifts =
+      let at_ = Level.repr at_ in
+      Shift { by_; at_; next = shifts }
+
+    let rec apply ~length shifts ~var =
+      match shifts with
+      | Nil -> var
+      | Shift { by_; at_; next = shifts } -> (
+          let depth = length - at_ in
+          match Index.repr var >= depth with
+          | true ->
+              let var = Index.shift var ~by_ in
+              apply ~length shifts ~var
+          | false -> var)
+
+    (* TODO: reduce allocations? Maybe cata over term? *)
+    (* TODO: tag terms without bound variables, aka no shifting *)
+    (* TODO: tag terms without binders *)
+    (* TODO: tag terms locally closed *)
+
+    let rec tt_shift shifts ~length term =
+      let tt_shift ~length term = tt_shift shifts ~length term in
+      let tp_shift ~length pat = tp_shift shifts ~length pat in
+      match term with
+      | TT_typed { term; type_ } ->
+          let type_ = tt_shift ~length type_ in
+          tt_typed ~type_ @@ tt_shift ~length term
+      | TT_annot { term; annot } ->
+          let annot = tt_shift ~length annot in
+          let term = tt_shift ~length term in
+          tt_annot ~term ~annot
+      | TT_free_var { var = _ } as term -> term
+      | TT_bound_var { var } ->
+          let var = apply ~length shifts ~var in
+          tt_bound_var ~var
+      | TT_forall { param; return } ->
+          let param = tp_shift ~length param in
+          let return =
+            let length = 1 + length in
+            tt_shift ~length return
+          in
+          tt_forall ~param ~return
+      | TT_lambda { param; return } ->
+          let param = tp_shift ~length param in
+          let return =
+            let length = 1 + length in
+            tt_shift ~length return
+          in
+          tt_lambda ~param ~return
+      | TT_apply { lambda; arg } ->
+          let lambda = tt_shift ~length lambda in
+          let arg = tt_shift ~length arg in
+          tt_apply ~lambda ~arg
+      | TT_let { bound; value; return } ->
+          let bound = tp_shift ~length bound in
+          let value = tt_shift ~length value in
+          let return =
+            let length = 1 + length in
+            tt_shift ~length return
+          in
+          tt_let ~bound ~value ~return
+      | TT_string { literal = _ } as term -> term
+
+    and tp_shift shifts ~length pat =
+      let tt_shift ~length term = tt_shift shifts ~length term in
+      let tp_shift ~length pat = tp_shift shifts ~length pat in
+      match pat with
+      | TP_typed { pat; type_ } ->
+          let type_ = tt_shift ~length type_ in
+          tp_typed ~type_ @@ tp_shift ~length pat
+      | TP_annot { pat; annot } ->
+          let annot = tt_shift ~length annot in
+          let pat = tp_shift ~length pat in
+          tp_annot ~annot ~pat
+      | TP_var _ as pat -> pat
+
+    let apply ~length shifts ~var =
+      let length = Level.repr length in
+      apply ~length shifts ~var
+
+    let tt_commit ~length shifts term =
+      let length = Level.repr length in
+      tt_shift shifts ~length term
+
+    let tp_commit ~length shifts pat =
+      let length = Level.repr length in
+      tp_shift shifts ~length pat
+  end
+
+  module Substs : sig
+    open Ttree
+
+    type substs
+    type t = substs
+
+    val make : unit -> substs
+    val push : pat -> to_:term -> at_:substs -> substs -> substs
+    val apply : var:Index.t -> substs -> term * substs
+
+    val capture :
+      substs ->
+      (substs -> 'a * substs) ->
+      'a * [ `Wrap of term -> term ] * [ `Shift of term -> term ]
+
+    val tt_commit_shifts : substs -> term -> term * substs
+  end = struct
+    open Ttree
+
+    type substs =
+      | Substs of {
+          next : Level.t;
+          shifts : Shifts.t;
+          content : (pat * term * Shifts.t * Level.t) array;
+        }
+
+    type t = substs
+
+    let initial_tuple = (tp_nil, tt_nil, Shifts.empty, Level.zero)
+
+    let make () =
+      let initial_size = 256 in
+      let content = Array.make initial_size initial_tuple in
+      Substs { next = Level.zero; shifts = Shifts.empty; content }
+
+    (* TODO: better name than at_ *)
+    let push pat ~to_ ~at_ substs =
+      let (Substs { next; shifts; content }) = substs in
+      let content =
+        (* resize *)
+        let length = Array.length content in
+        match Level.repr next >= length with
+        | true ->
+            (* TODO: limit memory usage *)
+            (* TODO: maybe fail with out of memory? *)
+            let new_content = Array.make (length * 2) initial_tuple in
+            Array.blit content 0 new_content 0 length;
+            new_content
+        | false -> content
+      in
+      let () =
+        let (Substs { next = at_; shifts; content = _ }) = at_ in
+        Array.set content (Level.repr next) (pat, to_, shifts, at_)
+      in
+      let next = Level.next next in
+      Substs { next; shifts; content }
+
+    let apply ~var substs =
+      let (Substs { next; shifts; content }) = substs in
+      (* TODO: proper errors here *)
+      let var = Shifts.apply ~length:next ~var shifts in
+      let level = Option.get @@ Level.level_of_index ~next ~var in
+      let _pat, term, shifts, at_ = Array.get content (Level.repr level) in
+      let shifts =
+        let by_ = Level.repr next - Level.repr at_ in
+        Shifts.shift ~by_ ~at_:next shifts
+      in
+      let substs = Substs { next; shifts; content } in
+      (term, substs)
+
+    let tt_commit_shifts substs term =
+      (* TODO: very weird function  *)
+      let (Substs { next; shifts; content }) = substs in
+      let term = Shifts.tt_commit ~length:next shifts term in
+      (term, Substs { next; shifts = Shifts.empty; content })
+
+    let capture substs f =
+      (* TODO: really ugly function *)
+      let (Substs { next = from; shifts = _; content = _ }) = substs in
+      let x, Substs { next = to_; shifts; content } = f substs in
+      (* TODO: this is weird *)
+      assert (shifts = Shifts.empty);
+      let rec find_substs ~from acc =
+        match Level.repr from < Level.repr to_ with
+        | true ->
+            let pat, term, shifts, at_ = Array.get content @@ Level.repr from in
+            let shifts =
+              let by_ = Level.repr from - Level.repr at_ in
+              Shifts.shift ~by_ ~at_ shifts
+            in
+            let term = Shifts.tt_commit ~length:from shifts term in
+            let pat = Shifts.tp_commit ~length:from shifts pat in
+            let from = Level.next from in
+            find_substs ~from ((pat, term) :: acc)
+        | false -> acc
+      in
+      let rev_substs = find_substs ~from [] in
+      let wrap term =
+        (* TODO: better than let here *)
+        List.fold_left
+          (fun return (bound, value) -> tt_let ~bound ~value ~return)
+          term rev_substs
+      in
+      let shift term =
+        let open Shifts in
+        let by_ = Level.repr to_ - Level.repr from in
+        let shifts = shift ~by_ ~at_:to_ empty in
+        Shifts.tt_commit ~length:to_ shifts term
+      in
+      (x, `Wrap wrap, `Shift shift)
+  end
+
   (* TODO: gas count *)
-  let rec tt_shift ~by_ ~depth term =
-    let tt_shift ~depth term = tt_shift ~by_ ~depth term in
-    let tp_shift ~depth pat = tp_shift ~by_ ~depth pat in
-    match term with
-    | TT_typed { term; type_ } ->
-        let type_ = tt_shift ~depth type_ in
-        tt_typed ~type_ @@ tt_shift ~depth term
-    | TT_annot { term; annot } ->
-        let annot = tt_shift ~depth annot in
-        let term = tt_shift ~depth term in
-        tt_annot ~term ~annot
-    | TT_free_var { var = _ } as term -> term
-    | TT_bound_var { var } as term -> (
-        match Index.(var < depth) with
-        | true -> term
-        | false ->
-            let var = Index.shift var ~by_ in
-            tt_bound_var ~var)
-    | TT_forall { param; return } ->
-        let param = tp_shift ~depth param in
-        let return =
-          let depth = Index.next depth in
-          tt_shift ~depth return
-        in
-        tt_forall ~param ~return
-    | TT_lambda { param; return } ->
-        let param = tp_shift ~depth param in
-        let return =
-          let depth = Index.next depth in
-          tt_shift ~depth return
-        in
-        tt_lambda ~param ~return
-    | TT_apply { lambda; arg } ->
-        let lambda = tt_shift ~depth lambda in
-        let arg = tt_shift ~depth arg in
-        tt_apply ~lambda ~arg
-    | TT_let { bound; value; return } ->
-        let bound = tp_shift ~depth bound in
-        let value = tt_shift ~depth value in
-        let return =
-          let depth = Index.next depth in
-          tt_shift ~depth return
-        in
-        tt_let ~bound ~value ~return
-    | TT_string { literal = _ } as term -> term
-
-  and tp_shift ~by_ ~depth pat =
-    let tt_shift ~depth term = tt_shift ~by_ ~depth term in
-    let tp_shift ~depth pat = tp_shift ~by_ ~depth pat in
-    match pat with
-    | TP_typed { pat; type_ } ->
-        let type_ = tt_shift ~depth type_ in
-        tp_typed ~type_ @@ tp_shift ~depth pat
-    | TP_annot { pat; annot } ->
-        let annot = tt_shift ~depth annot in
-        let pat = tp_shift ~depth pat in
-        tp_annot ~annot ~pat
-    | TP_var _ as pat -> pat
-
-  let tt_shift ~by_ term = tt_shift ~by_ ~depth:Index.zero term
-
   let rec tt_expand_head term ~args ~substs =
     match (term, args) with
     | TT_typed { term; type_ = _ }, _ ->
@@ -196,13 +251,13 @@ module Machinery = struct
         (* beta1 *)
         let args = (arg, substs) :: args in
         tt_expand_head lambda ~args ~substs
-    | TT_lambda { param = _; return }, (arg, arg_substs) :: args ->
+    | TT_lambda { param; return }, (arg, arg_substs) :: args ->
         (* beta2 *)
-        let substs = Substs.push ~to_:arg ~at_:arg_substs substs in
+        let substs = Substs.push param ~to_:arg ~at_:arg_substs substs in
         tt_expand_head return ~args ~substs
-    | TT_let { bound = _; value; return }, _ ->
+    | TT_let { bound; value; return }, _ ->
         (* zeta *)
-        let substs = Substs.push ~to_:value ~at_:substs substs in
+        let substs = Substs.push bound ~to_:value ~at_:substs substs in
         tt_expand_head return ~args ~substs
     | TT_free_var _, _ | TT_forall _, _ | TT_lambda _, [] | TT_string _, _ ->
         (* head *)
@@ -276,9 +331,11 @@ module Machinery = struct
       (* TODO: maybe pack right_type? *)
       tt_typed ~type_:right_type @@ tt_free_var ~var:level
     in
-    let left_substs = Substs.push ~to_:left_to_ ~at_:left_substs left_substs in
+    let left_substs =
+      Substs.push left ~to_:left_to_ ~at_:left_substs left_substs
+    in
     let right_substs =
-      Substs.push ~to_:right_to_ ~at_:right_substs right_substs
+      Substs.push right ~to_:right_to_ ~at_:right_substs right_substs
     in
     k ~level ~left_substs ~right_substs
 
@@ -286,62 +343,31 @@ module Machinery = struct
   (* TODO: variable expansions without args can be faster without packing *)
 
   (* TODO: this is super hackish *)
-  let rec tt_split_forall type_ ~args ~substs =
+  let tt_split_forall type_ ~substs =
+    let (type_, args), `Wrap wrap, `Shift shift =
+      Substs.capture substs @@ fun substs ->
+      let type_, args, substs = tt_expand_head type_ ~args:[] ~substs in
+      let type_, substs = Substs.tt_commit_shifts substs type_ in
+      ((type_, args), substs)
+    in
     match (type_, args) with
     | TT_forall { param; return }, [] ->
-        let wrapped_arg_type = tp_type_of param in
-        let apply_return_type ~arg ~at_ =
-          let arg =
-            let by_ = (Level.repr @@ Substs.size substs) - Level.repr at_ in
-            tt_shift ~by_ arg
-          in
-          tt_typed ~type_:tt_type_univ @@ tt_let ~bound:param ~value:arg ~return
+        let wrapped_arg_type = wrap @@ tp_type_of param in
+        let apply_return_type ~arg =
+          let arg = shift arg in
+          wrap @@ tt_let ~bound:param ~value:arg ~return
         in
         (wrapped_arg_type, apply_return_type)
-    (* annot *)
-    | TT_typed { term = type_; type_ = _ }, _ ->
-        tt_split_forall type_ ~args ~substs
-    | TT_annot { term = type_; annot = _ }, _ ->
-        tt_split_forall type_ ~args ~substs
-    (* substs *)
-    | TT_bound_var { var }, _ ->
-        let type_ =
-          let type_, at_ = Substs.find ~var substs in
-          let by_ = (Level.repr @@ Substs.size substs) - Level.repr at_ in
-          (* TODO: not very fast *)
-          tt_shift ~by_ type_
-        in
-        tt_split_forall type_ ~args ~substs
-    (* beta *)
-    | TT_lambda { param; return = type_ }, (arg, arg_substs) :: args ->
-        tt_split_forall_subst ~bound:param ~value:arg ~value_substs:arg_substs
-          type_ ~args ~substs
-    | TT_apply { lambda; arg }, args ->
-        let args = (arg, substs) :: args in
-        tt_split_forall lambda ~args ~substs
-    (* let *)
-    | TT_let { bound; value; return = type_ }, _ ->
-        tt_split_forall_subst ~bound ~value ~value_substs:substs type_ ~args
-          ~substs
     (* head *)
     | TT_free_var _, _ | TT_forall _, _ | TT_lambda _, [] | TT_string _, _ ->
         (* TODO: dump substs *)
         error_not_a_forall ~type_
-
-  and tt_split_forall_subst ~bound ~value ~value_substs type_ ~args ~substs =
-    let substs = Substs.push ~to_:value ~at_:value_substs substs in
-    let wrapped_arg_type, apply_return_type =
-      tt_split_forall type_ ~args ~substs
-    in
-    let wrapped_arg_type =
-      tt_typed ~type_:tt_type_univ
-      @@ tt_let ~bound ~value ~return:wrapped_arg_type
-    in
-    let apply_return_type ~arg ~at_ =
-      tt_typed ~type_:tt_type_univ
-      @@ tt_let ~bound ~value ~return:(apply_return_type ~arg ~at_)
-    in
-    (wrapped_arg_type, apply_return_type)
+    | TT_typed _, _ -> failwith "invariant"
+    | TT_annot _, _ -> failwith "invariant"
+    | TT_bound_var _, _ -> failwith "invariant"
+    | TT_lambda _, _ -> failwith "invariant"
+    | TT_apply _, _ -> failwith "invariant"
+    | TT_let _, _ -> failwith "invariant"
 end
 
 module Elaborate_context : sig
@@ -461,14 +487,15 @@ module Infer_context : sig
 
   (* vars *)
   val find_var_type : context -> Index.t -> term
-  val with_bound_var : context -> type_:term -> (context -> 'k) -> 'k
-  val with_subst_var : context -> to_:term -> (context -> 'k) -> 'k
+  val with_bound_var : context -> pat -> type_:term -> (context -> 'k) -> 'k
+  val with_subst_var : context -> pat -> to_:term -> (context -> 'k) -> 'k
 
   (* machinery *)
   val tt_equal : context -> left:term -> right:term -> unit
   val tt_split_forall : context -> term -> term * (arg:term -> term)
 end = struct
   open Ttree
+  open Machinery
 
   type context = {
     level : Level.t;
@@ -480,9 +507,10 @@ end = struct
     let level = level_string in
     let make_substs () =
       let substs = Substs.make () in
-      let substs = Substs.push ~to_:tt_nil ~at_:substs substs in
-      let substs = Substs.push ~to_:tt_type_univ ~at_:substs substs in
-      let substs = Substs.push ~to_:tt_type_string ~at_:substs substs in
+      let substs = Substs.push tp_nil ~to_:tt_nil ~at_:substs substs in
+      (* TODO: better than tp_nil *)
+      let substs = Substs.push tp_nil ~to_:tt_type_univ ~at_:substs substs in
+      let substs = Substs.push tp_nil ~to_:tt_type_string ~at_:substs substs in
       substs
     in
     let left_substs = make_substs () in
@@ -491,42 +519,37 @@ end = struct
 
   let find_var_type ctx var =
     let { level = _; left_substs; right_substs = _ } = ctx in
-    (* TODO: this apply here is weird *)
-    let term, _term = Substs.apply ~var left_substs in
+    let term, substs = Substs.apply ~var left_substs in
     let _term, type_ = Machinery.tt_split_term term in
-    let by_ = 1 + Index.repr var in
-    Machinery.tt_shift ~by_ type_
+    let type_, _substs = Substs.tt_commit_shifts substs type_ in
+    type_
 
-  let with_bound_var ctx ~type_ k =
+  let with_bound_var ctx pat ~type_ k =
     let { level; left_substs; right_substs } = ctx in
     let level = Level.next level in
     let to_ = tt_typed ~type_ @@ tt_free_var ~var:level in
-    let left_substs = Substs.push ~to_ ~at_:left_substs left_substs in
-    let right_substs = Substs.push ~to_ ~at_:right_substs right_substs in
+    let left_substs = Substs.push pat ~to_ ~at_:left_substs left_substs in
+    let right_substs = Substs.push pat ~to_ ~at_:right_substs right_substs in
     k @@ { level; left_substs; right_substs }
 
-  let with_subst_var ctx ~to_ k =
+  let with_subst_var ctx pat ~to_ k =
     let { level; left_substs; right_substs } = ctx in
     let level = Level.next level in
-    let left_substs = Substs.push ~to_ ~at_:left_substs left_substs in
-    let right_substs = Substs.push ~to_ ~at_:right_substs right_substs in
+    let left_substs = Substs.push pat ~to_ ~at_:left_substs left_substs in
+    let right_substs = Substs.push pat ~to_ ~at_:right_substs right_substs in
     k @@ { level; left_substs; right_substs }
 
   let tt_split_forall ctx type_ =
     let { level = _; left_substs; right_substs = _ } = ctx in
     (* TODO: left and right? *)
     let wrapped_arg_type, apply_return_type =
-      Machinery.tt_split_forall type_ ~args:[] ~substs:left_substs
-    in
-    let apply_return_type ~arg =
-      let at_ = Substs.size left_substs in
-      apply_return_type ~arg ~at_
+      tt_split_forall type_ ~substs:left_substs
     in
     (wrapped_arg_type, apply_return_type)
 
   let tt_equal ctx ~left ~right =
     let { level; left_substs; right_substs } = ctx in
-    Machinery.tt_equal ~level ~left ~left_substs ~right ~right_substs
+    tt_equal ~level ~left ~left_substs ~right ~right_substs
 end
 
 module Infer = struct
@@ -563,8 +586,11 @@ module Infer = struct
     | TT_apply { lambda; arg } ->
         let forall = infer_term ctx lambda in
         (* TODO: this could be better? avoiding split forall? *)
+        Format.eprintf "forall : %a\n%!" Tprinter.pp_term forall;
         let wrapped_arg_type, apply_return_type = tt_split_forall ctx forall in
         let () = check_term ctx arg ~expected:wrapped_arg_type in
+        Format.eprintf "return : %a\n%!" Tprinter.pp_term
+        @@ apply_return_type ~arg;
         tt_typed ~type_:tt_type_univ @@ apply_return_type ~arg
     | TT_let { bound; value; return } ->
         (* TODO: use this loc *)
@@ -586,13 +612,15 @@ module Infer = struct
     (* TODO: apply could propagate when arg is var *)
     (* TODO: could propagate through let? *)
     let received = infer_term ctx term in
+    Format.eprintf "received : %a, expected : %a\n%!" Tprinter.pp_term received
+      Tprinter.pp_term expected;
     tt_equal ctx ~left:received ~right:expected
 
   and check_annot ctx term = check_term ctx term ~expected:tt_type_univ
 
   and with_infer_pat ctx pat k =
     let type_ = infer_pat ctx pat in
-    with_bound_var ctx ~type_ k
+    with_bound_var ctx pat ~type_ k
 
   and infer_pat ctx pat =
     match pat with
@@ -608,7 +636,7 @@ module Infer = struct
 
   and with_check_pat ctx pat ~expected ~to_ k =
     let () = check_pat ctx pat ~expected in
-    with_subst_var ctx ~to_ k
+    with_subst_var ctx pat ~to_ k
 
   and check_pat ctx pat ~expected =
     (* TODO: let () = assert_is_tt_with_type expected in *)


### PR DESCRIPTION
## Goals

Faster and more solid code.

## Context

The current implementation of split forall relies on a partial copy of expand head, this is done because currently expand head is not parametrized over the substitutions.

Here instead I extend `Substs` with a capture function that allows split forall to be done with expand head and the substitutions captured. This approach will likely be used also on Check in the future.

## Related

- #199
