### PR TITLE
teika: enforce wrapper on type level again

### DIFF
--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -19,9 +19,6 @@ type error =
   | TError_missing_annotation
   (* elaborate *)
   | TError_invalid_notation
-  (* bug *)
-  | TError_invariant_term_untyped of { term : term }
-  | TError_invariant_pat_untyped of { pat : pat }
 
 and t = error [@@deriving show { with_path = false }]
 
@@ -40,9 +37,3 @@ let error_pairs_not_implemented () = terror @@ TError_pairs_not_implemented
 let error_unknown_native ~native = terror @@ TError_unknown_native { native }
 let error_missing_annotation () = terror @@ TError_missing_annotation
 let error_invalid_notation () = terror @@ TError_invalid_notation
-
-let error_invariant_term_untyped term =
-  terror @@ TError_invariant_term_untyped { term }
-
-let error_invariant_pat_untyped pat =
-  terror @@ TError_invariant_pat_untyped { pat }

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -18,9 +18,6 @@ type error =
   | TError_missing_annotation
   (* elaborate *)
   | TError_invalid_notation
-  (* bug *)
-  | TError_invariant_term_untyped of { term : term }
-  | TError_invariant_pat_untyped of { pat : pat }
 
 type t = error [@@deriving show]
 
@@ -35,6 +32,4 @@ val error_extensions_not_implemented : unit -> 'a
 val error_pairs_not_implemented : unit -> 'a
 val error_unknown_native : native:string -> 'a
 val error_missing_annotation : unit -> 'a
-val error_invariant_term_untyped : term -> 'a
-val error_invariant_pat_untyped : pat -> 'a
 val error_invalid_notation : unit -> 'a

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -67,13 +67,12 @@ let _pt_with_type ~type_ term =
   PT_meta { term = PT_annot { term; annot = type_ } }
 
 (* TODO: extract substitutions *)
+(* TODO: rename all tt_ to term_ *)
 let rec tt_print term =
+  let term =
+    match term with TTerm { term; type_ = _ } -> term | TType { term } -> term
+  in
   match term with
-  | TT_typed { term; type_ = _ } ->
-      (* let term = tt_print term in
-         let type_ = tt_print type_ in
-         PT_annot { term; annot = type_ } *)
-      tt_print term
   | TT_annot { term; annot } ->
       let term = tt_print term in
       let annot = tt_print annot in
@@ -101,12 +100,8 @@ let rec tt_print term =
   | TT_string { literal } -> PT_string { literal }
 
 and tp_print pat =
+  let (TPat { pat; type_ = _ }) = pat in
   match pat with
-  | TP_typed { pat; type_ = _ } ->
-      (* let pat = tp_print pat in
-         let type_ = tt_print type_ in
-         pt_with_type ~type_ pat *)
-      tp_print pat
   | TP_annot { pat; annot } ->
       let pat = tp_print pat in
       let annot = tt_print annot in
@@ -137,8 +132,6 @@ module Perror = struct
     | PE_unknown_native of { native : string }
     | PE_missing_annotation
     | PE_invalid_notation
-    | PE_invariant_term_untyped of { term : term }
-    | PE_invariant_pat_untyped of { pat : term }
 
   let pp_pos fmt pos =
     let Lexing.{ pos_fname; pos_lnum; pos_bol; pos_cnum = _ } = pos in
@@ -167,10 +160,6 @@ module Perror = struct
     (* TODO: rename missing annotation *)
     | PE_missing_annotation -> fprintf fmt "not enough annotations"
     | PE_invalid_notation -> fprintf fmt "invalid notation"
-    | PE_invariant_term_untyped { term } ->
-        fprintf fmt "invariant term untyped : %a" pp_term term
-    | PE_invariant_pat_untyped { pat } ->
-        fprintf fmt "invariant pat untyped : %a" pp_term pat
 end
 
 let rec te_print error =
@@ -207,13 +196,6 @@ let rec te_print error =
   | TError_unknown_native { native } -> PE_unknown_native { native }
   | TError_missing_annotation -> PE_missing_annotation
   | TError_invalid_notation -> PE_invalid_notation
-  (* TODO: term and pat  *)
-  | TError_invariant_term_untyped { term } ->
-      let term = tt_print term in
-      PE_invariant_term_untyped { term }
-  | TError_invariant_pat_untyped { pat } ->
-      let pat = tp_print pat in
-      PE_invariant_pat_untyped { pat }
 
 let pp_error fmt error =
   let error = te_print error in

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -2,7 +2,11 @@ open Utils
 
 type term =
   (* #(M : A) *)
-  | TT_typed of { term : term; mutable type_ : term }
+  | TTerm of { term : term_syntax; mutable type_ : term }
+  (* #(A : S) *)
+  | TType of { term : term_syntax }
+
+and term_syntax =
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
   (* \+n *)
@@ -20,9 +24,10 @@ type term =
   (* ".." *)
   | TT_string of { literal : string }
 
-and pat =
-  (* #(P : A) *)
-  | TP_typed of { pat : pat; mutable type_ : term }
+and pat = (* #(P : A) *)
+  | TPat of { pat : pat_syntax; mutable type_ : term }
+
+and pat_syntax =
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
@@ -31,7 +36,8 @@ and pat =
 
 (* TODO: expose this? *)
 (* terms *)
-let tt_typed ~type_ term = TT_typed { term; type_ }
+let tterm ~type_ term = TTerm { term; type_ }
+let ttype term = TType { term }
 let tt_annot ~term ~annot = TT_annot { term; annot }
 let tt_free_var ~var = TT_free_var { var }
 let tt_bound_var ~var = TT_bound_var { var }
@@ -42,21 +48,19 @@ let tt_let ~bound ~value ~return = TT_let { bound; value; return }
 let tt_string ~literal = TT_string { literal }
 
 (* patterns *)
-let tp_typed ~type_ pat = TP_typed { pat; type_ }
+let tpat ~type_ pat = TPat { pat; type_ }
 let tp_annot ~pat ~annot = TP_annot { pat; annot }
 let tp_var ~name = TP_var { name }
 
 (* Nil *)
 let level_nil = Level.zero
-let tt_nil = TT_free_var { var = level_nil }
-let tp_nil = TP_var { name = Name.make "**nil**" }
+let tterm_nil = ttype @@ TT_free_var { var = level_nil }
+let tpat_nil = tpat ~type_:tterm_nil @@ TP_var { name = Name.make "**nil**" }
 
 (* Type *)
 let level_univ = Level.next level_nil
-let tt_type_univ = TT_free_var { var = level_univ }
+let tt_type_univ = ttype @@ TT_free_var { var = level_univ }
 
 (* String *)
 let level_string = Level.next level_univ
-
-let tt_type_string =
-  tt_typed ~type_:tt_type_univ @@ TT_free_var { var = level_string }
+let tt_type_string = ttype @@ TT_free_var { var = level_string }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -5,7 +5,11 @@ open Utils
 
 type term =
   (* #(M : A) *)
-  | TT_typed of { term : term; mutable type_ : term }
+  | TTerm of { term : term_syntax; mutable type_ : term }
+  (* #(A : S) *)
+  | TType of { term : term_syntax }
+
+and term_syntax =
   (* (M : A) *)
   | TT_annot of { term : term; annot : term }
   (* \+n *)
@@ -23,9 +27,10 @@ type term =
   (* ".." *)
   | TT_string of { literal : string }
 
-and pat =
-  (* #(P : A) *)
-  | TP_typed of { pat : pat; mutable type_ : term }
+and pat = (* #(P : A) *)
+  | TPat of { pat : pat_syntax; mutable type_ : term }
+
+and pat_syntax =
   (* (P : A) *)
   | TP_annot of { pat : pat; annot : term }
   (* x *)
@@ -33,22 +38,25 @@ and pat =
 [@@deriving show]
 
 (* term *)
-val tt_typed : type_:term -> term -> term
-val tt_annot : term:term -> annot:term -> term
-val tt_free_var : var:Level.t -> term
-val tt_bound_var : var:Index.t -> term
-val tt_forall : param:pat -> return:term -> term
-val tt_lambda : param:pat -> return:term -> term
-val tt_apply : lambda:term -> arg:term -> term
-val tt_let : bound:pat -> value:term -> return:term -> term
-val tt_string : literal:string -> term
-val tt_nil : term
+val tterm : type_:term -> term_syntax -> term
+
+(* TODO: drop those nil *)
+val tterm_nil : term
+val ttype : term_syntax -> term
+val tt_annot : term:term -> annot:term -> term_syntax
+val tt_free_var : var:Level.t -> term_syntax
+val tt_bound_var : var:Index.t -> term_syntax
+val tt_forall : param:pat -> return:term -> term_syntax
+val tt_lambda : param:pat -> return:term -> term_syntax
+val tt_apply : lambda:term -> arg:term -> term_syntax
+val tt_let : bound:pat -> value:term -> return:term -> term_syntax
+val tt_string : literal:string -> term_syntax
 
 (* pat *)
-val tp_typed : type_:term -> pat -> pat
-val tp_annot : pat:pat -> annot:term -> pat
-val tp_var : name:Name.t -> pat
-val tp_nil : pat
+val tpat : type_:term -> pat_syntax -> pat
+val tpat_nil : pat
+val tp_annot : pat:pat -> annot:term -> pat_syntax
+val tp_var : name:Name.t -> pat_syntax
 
 (* Type *)
 val level_univ : Level.t


### PR DESCRIPTION
## Goals

Allows for checking types during equality and more consistent behavior.

## Context

This is a mess, I keep adding and removing this. The advantage of the wrapper is that it enforces on the type level that some constructors have some behavior, a lot of times this gets in the way or makes it a hard to enforce relationship.

But recently it seems like this is a worth it change, as there is a space to say "every term has this property". So here it goes again.

## Related

- #199