### PR TITLE
teika: use slightly more principled shifts

### DIFF
--- a/teika/level.ml
+++ b/teika/level.ml
@@ -9,12 +9,6 @@ let next n =
   n
 
 let ( < ) : level -> level -> bool = ( < )
-let of_int x = match x >= zero with true -> Some x | false -> None
-
-let level_of_index ~next ~var =
-  let var = Index.repr var in
-  of_int (next - 1 - var)
-
 let repr level = level
 let offset ~from ~to_ = Index.of_int (to_ - from)
 

--- a/teika/level.mli
+++ b/teika/level.mli
@@ -4,7 +4,6 @@ type t = level [@@deriving show, eq]
 val zero : level
 val next : level -> level
 val ( < ) : level -> level -> bool
-val level_of_index : next:level -> var:Index.t -> level option
 
 (* TODO: not great to expose this *)
 val repr : level -> int


### PR DESCRIPTION
## Goals

More principled and easier to invert shifts.

## Context

The current solution for shifts is quite ad-hoc, it is more or less a level's-like approach to shifting but in an indices setting, which is weird.

Here I move to a more principled approach where a shift may be the actual shift or a lift, making so that shifts always have the following form `M[↑by : depth]` this allows to propagate shifts down by increasing the depth, while making them completely relative and not level dependent.

Also, for some reason it makes the tests 2.5x faster, combining shifts makes it improve a bit, but I'm not sure on why it increases that much.

## Related

- #165