### PR TITLE
teika: use NbE, also adds intersections

### DIFF
--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -88,14 +88,14 @@ let term_extension ==
   | extension = EXTENSION;
     { ct_extension (mk $loc) ~extension:(Name.make extension) }
 let term_forall(self, lower) ==
-  | param = lower; ARROW; return = self;
-    { ct_forall (mk $loc) ~param ~return }
+  | param = lower; ARROW; body = self;
+    { ct_forall (mk $loc) ~param ~body }
 let term_lambda(self, lower) ==
-  | param = lower; FAT_ARROW; return = self;
-    { ct_lambda (mk $loc) ~param ~return }
+  | param = lower; FAT_ARROW; body = self;
+    { ct_lambda (mk $loc) ~param ~body }
 let term_apply(self, lower) ==
-  | lambda = self; arg = lower;
-    { ct_apply (mk $loc) ~lambda ~arg }
+  | funct = self; arg = lower;
+    { ct_apply (mk $loc) ~funct ~arg }
 let term_pair(self, lower) ==
   | left = lower; COMMA; right = self;
     { ct_pair (mk $loc) ~left ~right }

--- a/syntax/ctree.ml
+++ b/syntax/ctree.ml
@@ -7,9 +7,9 @@ type term =
 and term_syntax =
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
-  | CT_forall of { param : term; return : term }
-  | CT_lambda of { param : term; return : term }
-  | CT_apply of { lambda : term; arg : term }
+  | CT_forall of { param : term; body : term }
+  | CT_lambda of { param : term; body : term }
+  | CT_apply of { funct : term; arg : term }
   | CT_pair of { left : term; right : term }
   | CT_both of { left : term; right : term }
   | CT_bind of { bound : term; value : term }
@@ -24,9 +24,9 @@ and term_syntax =
 let cterm loc term = CTerm { loc; term }
 let ct_var loc ~var = cterm loc (CT_var { var })
 let ct_extension loc ~extension = cterm loc (CT_extension { extension })
-let ct_forall loc ~param ~return = cterm loc (CT_forall { param; return })
-let ct_lambda loc ~param ~return = cterm loc (CT_lambda { param; return })
-let ct_apply loc ~lambda ~arg = cterm loc (CT_apply { lambda; arg })
+let ct_forall loc ~param ~body = cterm loc (CT_forall { param; body })
+let ct_lambda loc ~param ~body = cterm loc (CT_lambda { param; body })
+let ct_apply loc ~funct ~arg = cterm loc (CT_apply { funct; arg })
 let ct_pair loc ~left ~right = cterm loc (CT_pair { left; right })
 let ct_both loc ~left ~right = cterm loc (CT_both { left; right })
 let ct_bind loc ~bound ~value = cterm loc (CT_bind { bound; value })

--- a/syntax/ctree.mli
+++ b/syntax/ctree.mli
@@ -5,9 +5,9 @@ type term = CTerm of { term : term_syntax; loc : Location.t }
 and term_syntax =
   | CT_var of { var : Name.t }
   | CT_extension of { extension : Name.t }
-  | CT_forall of { param : term; return : term }
-  | CT_lambda of { param : term; return : term }
-  | CT_apply of { lambda : term; arg : term }
+  | CT_forall of { param : term; body : term }
+  | CT_lambda of { param : term; body : term }
+  | CT_apply of { funct : term; arg : term }
   | CT_pair of { left : term; right : term }
   | CT_both of { left : term; right : term }
   | CT_bind of { bound : term; value : term }
@@ -21,9 +21,9 @@ and term_syntax =
 
 val ct_var : Location.t -> var:Name.t -> term
 val ct_extension : Location.t -> extension:Name.t -> term
-val ct_forall : Location.t -> param:term -> return:term -> term
-val ct_lambda : Location.t -> param:term -> return:term -> term
-val ct_apply : Location.t -> lambda:term -> arg:term -> term
+val ct_forall : Location.t -> param:term -> body:term -> term
+val ct_lambda : Location.t -> param:term -> body:term -> term
+val ct_apply : Location.t -> funct:term -> arg:term -> term
 val ct_pair : Location.t -> left:term -> right:term -> term
 val ct_both : Location.t -> left:term -> right:term -> term
 val ct_bind : Location.t -> bound:term -> value:term -> term

--- a/teika/index.ml
+++ b/teika/index.ml
@@ -8,13 +8,4 @@ let next n =
   assert (n + 1 >= zero);
   n
 
-let ( < ) : index -> index -> bool = ( < )
-let repr x = x
 let of_int x = match x >= zero with true -> Some x | false -> None
-
-let shift index ~by_ =
-  (* TODO: better error message here  *)
-  assert (by_ >= 0);
-  index + by_
-
-module Map = Map.Make (Int)

--- a/teika/index.mli
+++ b/teika/index.mli
@@ -1,13 +1,6 @@
-type index
+type index = private int
 type t = index [@@deriving show, eq]
 
 val zero : index
 val next : index -> index
-val ( < ) : index -> index -> bool
-
-(* TODO: exposing this is bad *)
-val repr : index -> int
 val of_int : int -> index option
-val shift : index -> by_:int -> index
-
-module Map : Map.S with type key = index

--- a/teika/level.ml
+++ b/teika/level.ml
@@ -7,9 +7,3 @@ let next n =
   let n = n + 1 in
   assert (n + 1 >= zero);
   n
-
-let ( < ) : level -> level -> bool = ( < )
-let repr level = level
-let offset ~from ~to_ = Index.of_int (to_ - from)
-
-module Map = Map.Make (Int)

--- a/teika/level.mli
+++ b/teika/level.mli
@@ -1,12 +1,5 @@
-type level
+type level = private int
 type t = level [@@deriving show, eq]
 
 val zero : level
 val next : level -> level
-val ( < ) : level -> level -> bool
-
-(* TODO: not great to expose this *)
-val repr : level -> int
-val offset : from:level -> to_:level -> Index.t option
-
-module Map : Map.S with type key = level

--- a/teika/solve.ml
+++ b/teika/solve.ml
@@ -1,0 +1,130 @@
+open Utils
+open Syntax
+open Ctree
+open Ttree
+open Terror
+
+(* TODO: context vs env *)
+type context = Context of { names : Level.t Name.Map.t; next : Level.t }
+
+let enter ctx pat =
+  let rec name pat =
+    match pat with
+    | P_annot { pat; annot = _ } -> name pat
+    | P_var { var } -> var
+  in
+  let name = name pat in
+  let (Context { names; next }) = ctx in
+  let names = Name.Map.add name next names in
+  let next = Level.next next in
+  Context { names; next }
+
+let lookup ctx name =
+  let (Context { names; next }) = ctx in
+  match Name.Map.find_opt name names with
+  | Some from -> (
+      match Index.of_int @@ ((next :> int) - (from :> int) - 1) with
+      | Some var -> var
+      | None ->
+          (* TODO: proper errors *)
+          failwith "invariant lookup")
+  | None -> error_unknown_var ~name
+
+let rec solve_term ctx term =
+  (* TODO: use this location *)
+  let (CTerm { term; loc = _ }) = term in
+  match term with
+  | CT_parens { content = term } -> solve_term ctx term
+  | CT_annot { value = term; annot } ->
+      let annot = solve_term ctx annot in
+      let term = solve_term ctx term in
+      T_annot { term; annot }
+  | CT_var { var = name } ->
+      let var = lookup ctx name in
+      T_var { var }
+  | CT_semi { left; right } -> solve_semi ctx ~left ~right
+  | CT_extension _ -> error_extensions_not_implemented ()
+  | CT_apply { funct; arg } ->
+      let funct = solve_term ctx funct in
+      let arg = solve_term ctx arg in
+      T_apply { funct; arg }
+  | CT_lambda { param; body } ->
+      let bound = solve_check_pat ctx param in
+      let body =
+        let ctx = enter ctx bound in
+        solve_term ctx body
+      in
+      T_lambda { bound; body }
+  | CT_forall { param; body } ->
+      let bound, param = solve_infer_pat ctx param in
+      let body =
+        let ctx = enter ctx bound in
+        solve_term ctx body
+      in
+      T_forall { bound; param; body }
+  | CT_both { left; right } ->
+      let bound, left = solve_infer_pat ctx left in
+      let right =
+        let ctx = enter ctx bound in
+        solve_term ctx right
+      in
+      T_inter { bound; left; right }
+  | CT_pair _ | CT_bind _ | CT_number _ | CT_braces _ | CT_string _ ->
+      error_invalid_notation ()
+
+and solve_semi ctx ~left ~right =
+  let (CTerm { term = left; loc = _ }) = left in
+  match left with
+  | CT_parens { content = left } -> solve_semi ctx ~left ~right
+  | CT_bind { bound; value } ->
+      let bound = solve_check_pat ctx bound in
+      let arg = solve_term ctx value in
+      let body =
+        let ctx = enter ctx bound in
+        solve_term ctx right
+      in
+      T_let { bound; arg; body }
+  | CT_annot { value = _; annot = _ } -> error_hoist_not_implemented ()
+  | CT_var _ | CT_extension _ | CT_forall _ | CT_lambda _ | CT_apply _
+  | CT_pair _ | CT_both _ | CT_semi _ | CT_string _ | CT_number _ | CT_braces _
+    ->
+      error_invalid_notation ()
+
+and solve_infer_pat ctx pat =
+  (* TODO: duplicated *)
+  (* TODO: to_ here *)
+  (* TODO: use this location *)
+  let (CTerm { term = pat; loc = _ }) = pat in
+  match pat with
+  | CT_parens { content = pat } -> solve_infer_pat ctx pat
+  | CT_var { var = _ } -> error_missing_annotation ()
+  | CT_annot { value = pat; annot } ->
+      let annot = solve_term ctx annot in
+      let pat = solve_check_pat ctx pat in
+      (P_annot { pat; annot }, annot)
+  | _ -> error_invalid_notation ()
+
+and solve_check_pat ctx pat =
+  (* TODO: to_ here *)
+  (* TODO: use this location *)
+  let (CTerm { term = pat; loc = _ }) = pat in
+  match pat with
+  | CT_parens { content = pat } -> solve_check_pat ctx pat
+  | CT_var { var } -> P_var { var }
+  | CT_annot { value = pat; annot } ->
+      let annot = solve_term ctx annot in
+      let pat = solve_check_pat ctx pat in
+      P_annot { pat; annot }
+  | _ -> error_invalid_notation ()
+
+(* external *)
+let initial =
+  (* TODO: duplicated from Typer *)
+  let next = Level.(next zero) in
+  (* TODO: predef somewhere *)
+  (* TODO: rename Type to data *)
+  let type_ = Name.make "Type" in
+  let names = Name.Map.(empty |> add type_ Level.zero) in
+  Context { names; next }
+
+let solve_term term = try Ok (solve_term initial term) with exn -> Error exn

--- a/teika/solve.mli
+++ b/teika/solve.mli
@@ -1,0 +1,3 @@
+open Syntax
+
+val solve_term : Ctree.term -> (Ttree.term, exn) result

--- a/teika/terror.ml
+++ b/teika/terror.ml
@@ -8,7 +8,7 @@ type error =
          Probably because things like macros exists *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* equal *)
-  | TError_type_clash of { left : term; right : term }
+  | TError_type_clash
   (* typer *)
   | TError_unknown_var of { name : Name.t }
   | TError_not_a_forall of { type_ : term }
@@ -24,8 +24,13 @@ and t = error [@@deriving show { with_path = false }]
 
 exception TError of { error : error }
 
+let () =
+  Printexc.register_printer @@ function
+  | TError { error } -> Some (show_error error)
+  | _ -> None
+
 let terror error = raise (TError { error })
-let error_type_clash ~left ~right = terror @@ TError_type_clash { left; right }
+let error_type_clash () = terror @@ TError_type_clash
 let error_unknown_var ~name = terror @@ TError_unknown_var { name }
 let error_not_a_forall ~type_ = terror @@ TError_not_a_forall { type_ }
 let error_hoist_not_implemented () = terror @@ TError_hoist_not_implemented

--- a/teika/terror.mli
+++ b/teika/terror.mli
@@ -5,7 +5,7 @@ type error =
   (* metadata *)
   | TError_loc of { error : error; loc : Location.t [@opaque] }
   (* equal *)
-  | TError_type_clash of { left : term; right : term }
+  | TError_type_clash
   (* TODO: infer *)
   (* typer *)
   | TError_unknown_var of { name : Name.t }
@@ -24,7 +24,7 @@ type t = error [@@deriving show]
 exception TError of { error : error }
 
 (* TODO: error_loc *)
-val error_type_clash : left:term -> right:term -> 'a
+val error_type_clash : unit -> 'a
 val error_unknown_var : name:Name.t -> 'a
 val error_not_a_forall : type_:term -> 'a
 val error_hoist_not_implemented : unit -> 'a

--- a/teika/tprinter.ml
+++ b/teika/tprinter.ml
@@ -69,17 +69,14 @@ let _pt_with_type ~type_ term =
 (* TODO: extract substitutions *)
 (* TODO: rename all tt_ to term_ *)
 let rec tt_print term =
-  let term =
-    match term with TTerm { term; type_ = _ } -> term | TType { term } -> term
-  in
   match term with
-  | TT_annot { term; annot } ->
+  | T_annot { term; annot } ->
       let term = tt_print term in
       let annot = tt_print annot in
       PT_annot { term; annot }
-  | TT_free_var { var } -> PT_free_var { var }
+  | T_var { var } -> PT_bound_var { var }
   (* TODO: expand subst sometimes? *)
-  | TT_bound_var { var } -> PT_bound_var { var }
+  | T_bound_var { var } -> PT_bound_var { var }
   | TT_forall { param; return } ->
       let param = tp_print param in
       let return = tt_print return in
@@ -181,7 +178,7 @@ let rec te_print error =
       in
       loop loc error
   (* TODO: drop falback *)
-  | TError_type_clash { left; right } ->
+  | TError_type_clash ->
       let left = tt_print left in
       let right = tt_print right in
       PE_type_clash { left; right }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,67 +1,49 @@
 open Utils
 
-(* TODO: which invariants to enforce here using private? *)
-(* TODO: return should be body *)
-
 type term =
-  (* #(M : A) *)
-  | TTerm of { term : term_syntax; mutable type_ : term }
-  (* #(A : S) *)
-  | TType of { term : term_syntax }
-
-and term_syntax =
   (* (M : A) *)
-  | TT_annot of { term : term; annot : term }
-  (* \+n *)
-  | TT_free_var of { var : Level.t }
-  (* \-n *)
-  | TT_bound_var of { var : Index.t }
-  (* P -> B *)
-  | TT_forall of { param : pat; return : term }
-  (* P => M *)
-  | TT_lambda of { param : pat; return : term }
-  (* M N *)
-  | TT_apply of { lambda : term; arg : term }
+  | T_annot of { term : term; annot : term }
+  (* \n *)
+  | T_var of { var : Index.t }
   (* P = N; M *)
-  | TT_let of { bound : pat; value : term; return : term }
-  (* ".." *)
-  | TT_string of { literal : string }
+  | T_let of { bound : pat; arg : term; body : term }
+  (* P => M *)
+  | T_lambda of { bound : pat; body : term }
+  (* M N *)
+  | T_apply of { funct : term; arg : term }
+  (* (P : A) -> B *)
+  | T_forall of { bound : pat; param : term; body : term }
+  (* (P : A) & B *)
+  | T_inter of { bound : pat; left : term; right : term }
 
-and pat = (* #(P : A) *)
-  | TPat of { pat : pat_syntax; mutable type_ : term }
-
-and pat_syntax =
+and pat =
   (* (P : A) *)
-  | TP_annot of { pat : pat; annot : term }
+  | P_annot of { pat : pat; annot : term }
   (* x *)
-  | TP_var of { name : Name.t }
+  | P_var of { var : Name.t }
 [@@deriving show]
 
-(* term *)
-val tterm : type_:term -> term_syntax -> term
+(* TODO: write docs for this *)
+type value = private
+  (* equality *)
+  | V_var of { at : Level.t }
+  (* functions *)
+  | V_apply of { funct : value; arg : value }
+  | V_lambda of { env : env; body : term }
+  (* types *)
+  | V_univ
+  | V_forall of { param : value; env : env; body : term }
+  | V_inter of { left : value; env : env; right : term }
+  (* laziness *)
+  | V_thunk of { thunk : value Lazy.t }
 
-(* TODO: drop those nil *)
-val tterm_nil : term
-val ttype : term_syntax -> term
-val tt_annot : term:term -> annot:term -> term_syntax
-val tt_free_var : var:Level.t -> term_syntax
-val tt_bound_var : var:Index.t -> term_syntax
-val tt_forall : param:pat -> return:term -> term_syntax
-val tt_lambda : param:pat -> return:term -> term_syntax
-val tt_apply : lambda:term -> arg:term -> term_syntax
-val tt_let : bound:pat -> value:term -> return:term -> term_syntax
-val tt_string : literal:string -> term_syntax
+and env [@@deriving show]
 
-(* pat *)
-val tpat : type_:term -> pat_syntax -> pat
-val tpat_nil : pat
-val tp_annot : pat:pat -> annot:term -> pat_syntax
-val tp_var : name:Name.t -> pat_syntax
-
-(* Type *)
-val level_univ : Level.t
-val tt_type_univ : term
-
-(* String *)
-val level_string : Level.t
-val tt_type_string : term
+val empty : env
+val v_univ : value
+val skolem : at:Level.t -> value
+val append : env -> value -> env
+val shift : env -> by:Index.t -> env
+val thunk : env -> term -> value
+val eval : env -> term -> value
+val head : value -> value

--- a/teika/typer.ml
+++ b/teika/typer.ml
@@ -1,694 +1,210 @@
-open Utils
-open Syntax
+open Ttree
+open Terror
 
-module Machinery = struct
-  open Ttree
-  open Terror
-  (* TODO: cache normalization? *)
+let rec equal ~at lhs rhs =
+  match (head lhs, head rhs) with
+  | V_var { at = lhs }, V_var { at = rhs } -> (
+      match Level.equal lhs rhs with
+      | true -> ()
+      | false -> failwith "var clash")
+  | ( V_apply { funct = lhs_funct; arg = lhs_arg },
+      V_apply { funct = rhs_funct; arg = rhs_arg } ) ->
+      equal ~at lhs_funct rhs_funct;
+      equal ~at lhs_arg rhs_arg
+  | ( V_lambda { env = lhs_env; body = lhs_body },
+      V_lambda { env = rhs_env; body = rhs_body } ) ->
+      equal_under ~at lhs_env lhs_body rhs_env rhs_body
+  | V_univ, V_univ -> ()
+  | ( V_forall { param = lhs_param; env = lhs_env; body = lhs_body },
+      V_forall { param = rhs_param; env = rhs_env; body = rhs_body } ) ->
+      equal ~at lhs_param rhs_param;
+      equal_under ~at lhs_env lhs_body rhs_env rhs_body
+  | ( V_inter { left = lhs_left; env = lhs_env; right = lhs_right },
+      V_inter { left = rhs_left; env = rhs_env; right = rhs_right } ) ->
+      equal ~at lhs_left rhs_left;
+      equal_under ~at lhs_env lhs_right rhs_env rhs_right
+  | ( ( V_var _ | V_apply _ | V_lambda _ | V_univ | V_forall _ | V_inter _
+      | V_thunk _ ),
+      ( V_var _ | V_apply _ | V_lambda _ | V_univ | V_forall _ | V_inter _
+      | V_thunk _ ) ) ->
+      error_type_clash ()
 
-  let term_split_term term =
-    match term with
-    | TTerm { term; type_ } -> (term, type_)
-    | TType { term } -> (term, tt_type_univ)
+and equal_under ~at lhs_env lhs rhs_env rhs =
+  let skolem = skolem ~at in
+  let at = Level.next at in
+  let lhs =
+    let lhs_env = append lhs_env skolem in
+    eval lhs_env lhs
+  in
+  let rhs =
+    let rhs_env = append rhs_env skolem in
+    eval rhs_env rhs
+  in
+  equal ~at lhs rhs
 
-  let term_syntax_of term =
-    match term with TTerm { term; type_ = _ } -> term | TType { term } -> term
+let equal ~at lhs rhs =
+  Format.eprintf "%a == %a\n%!" pp_value lhs pp_value rhs;
+  equal ~at lhs rhs
 
-  let pat_syntax_of pat = match pat with TPat { pat; type_ = _ } -> pat
-  let pat_type_of pat = match pat with TPat { pat = _; type_ } -> type_
-
-  module Shifts : sig
-    type shifts
-    type t = shifts
-
-    val empty : shifts
-    val shift : by_:int -> shifts -> shifts
-    val lift : by_:int -> shifts -> shifts
-    val apply : shifts -> var:Index.t -> Index.t
-    val term_commit : shifts -> term -> term
-    val pat_commit : shifts -> pat -> pat
-  end = struct
-    (* TODO: make those stack allocations *)
-    (* TODO: absolute vs relative *)
-    type shifts =
-      | Nil
-      | Shift of { by_ : int; next : shifts }
-      | Lift of { by_ : int; next : shifts }
-
-    type t = shifts
-
-    let empty = Nil
-
-    let shift ~by_ next =
-      match next with
-      | Shift { by_ = base; next } ->
-          let by_ = by_ + base in
-          Shift { by_; next }
-      | (Nil | Lift _) as next -> Shift { by_; next }
-
-    let lift ~by_ next =
-      match next with
-      | Nil -> Nil
-      | Lift { by_ = base; next } ->
-          let by_ = by_ + base in
-          Lift { by_; next }
-      | Shift _ as next -> Lift { by_; next }
-
-    let rec apply shifts ~depth ~var =
-      match Index.repr var < depth with
-      | true -> var
-      | false -> (
-          match shifts with
-          | Nil -> var
-          | Shift { by_; next = shifts } ->
-              let var = Index.shift var ~by_ in
-              apply shifts ~depth ~var
-          | Lift { by_; next = shifts } ->
-              let depth = depth + by_ in
-              apply shifts ~depth ~var)
-
-    (* TODO: reduce allocations? Maybe cata over term? *)
-    (* TODO: tag terms without bound variables, aka no shifting *)
-    (* TODO: tag terms without binders *)
-    (* TODO: tag terms locally closed *)
-    (* TODO: if no var to shift was found, then avoid allocating *)
-    let rec term_shift shifts ~depth term =
-      match term with
-      | TTerm { term; type_ } ->
-          let type_ = term_shift shifts ~depth type_ in
-          tterm ~type_ @@ term_syntax_shift shifts ~depth term
-      | TType { term } -> ttype @@ term_syntax_shift shifts ~depth term
-
-    and term_syntax_shift shifts ~depth term : term_syntax =
-      match term with
-      | TT_annot { term; annot } ->
-          let annot = term_shift shifts ~depth annot in
-          let term = term_shift shifts ~depth term in
-          tt_annot ~term ~annot
-      | TT_free_var { var = _ } as term -> term
-      | TT_bound_var { var } ->
-          let var = apply ~depth shifts ~var in
-          tt_bound_var ~var
-      | TT_forall { param; return } ->
-          let param = pat_shift shifts ~depth param in
-          let return =
-            let depth = 1 + depth in
-            term_shift shifts ~depth return
-          in
-          tt_forall ~param ~return
-      | TT_lambda { param; return } ->
-          let param = pat_shift shifts ~depth param in
-          let return =
-            let depth = 1 + depth in
-            term_shift shifts ~depth return
-          in
-          tt_lambda ~param ~return
-      | TT_apply { lambda; arg } ->
-          let lambda = term_shift shifts ~depth lambda in
-          let arg = term_shift shifts ~depth arg in
-          tt_apply ~lambda ~arg
-      | TT_let { bound; value; return } ->
-          let bound = pat_shift shifts ~depth bound in
-          let value = term_shift shifts ~depth value in
-          let return =
-            let depth = 1 + depth in
-            term_shift shifts ~depth return
-          in
-          tt_let ~bound ~value ~return
-      | TT_string { literal = _ } as term -> term
-
-    and pat_shift shifts ~depth pat =
-      let (TPat { pat; type_ }) = pat in
-      let type_ = term_shift shifts ~depth type_ in
-      tpat ~type_ @@ pat_syntax_shift shifts ~depth pat
-
-    and pat_syntax_shift shifts ~depth pat =
-      match pat with
-      | TP_annot { pat; annot } ->
-          let annot = term_shift shifts ~depth annot in
-          let pat = pat_shift shifts ~depth pat in
-          tp_annot ~annot ~pat
-      | TP_var _ as pat -> pat
-
-    let apply shifts ~var = apply shifts ~depth:0 ~var
-    let term_commit shifts term = term_shift shifts ~depth:0 term
-    let pat_commit shifts pat = pat_shift shifts ~depth:0 pat
-  end
-
-  module Substs : sig
-    open Ttree
-
-    type substs
-    type t = substs
-
-    val make : unit -> substs
-    val push : pat -> to_:term -> at_:substs -> substs -> substs
-    val apply : var:Index.t -> substs -> term * substs
-
-    val capture :
-      substs ->
-      (substs -> 'a * substs) ->
-      'a * [ `Wrap of term -> term ] * [ `Shift of term -> term ]
-
-    val term_commit_shifts : substs -> term -> term * substs
-  end = struct
-    open Ttree
-
-    type substs =
-      | Substs of {
-          next : Level.t;
-          shifts : Shifts.t;
-          (* TODO: benchmark  *)
-          content : (pat * term * Shifts.t) array;
-        }
-
-    type t = substs
-
-    let initial_tuple = (tpat_nil, tterm_nil, Shifts.empty)
-
-    let make () =
-      let initial_size = 256 in
-      let content = Array.make initial_size initial_tuple in
-      Substs { next = Level.zero; shifts = Shifts.empty; content }
-
-    (* TODO: better name than at_ *)
-    let push pat ~to_ ~at_ substs =
-      let (Substs { next; shifts; content }) = substs in
-      let content =
-        (* resize *)
-        let length = Array.length content in
-        match Level.repr next >= length with
-        | true ->
-            (* TODO: limit memory usage *)
-            (* TODO: maybe fail with out of memory? *)
-            let new_content = Array.make (length * 2) initial_tuple in
-            Array.blit content 0 new_content 0 length;
-            new_content
-        | false -> content
-      in
-      let () =
-        let (Substs { next = at_; shifts; content = _ }) = at_ in
-        let by_ = Level.repr next - Level.repr at_ in
-        let shifts = Shifts.lift ~by_ shifts in
-        let shifts = Shifts.shift ~by_ shifts in
-        Array.set content (Level.repr next) (pat, to_, shifts)
-      in
-      let next = Level.next next in
-      let shifts = Shifts.lift ~by_:1 shifts in
-      Substs { next; shifts; content }
-
-    let apply ~var substs =
-      let (Substs { next; shifts; content }) = substs in
-      (* TODO: proper errors here *)
-      let var = Shifts.apply ~var shifts in
-      let _pat, term, shifts =
-        let from = Level.repr next - 1 - Index.repr var in
-        Array.get content from
-      in
-      let shifts =
-        let by_ = 1 + Index.repr var in
-        Shifts.shift ~by_ shifts
-      in
-      let substs = Substs { next; shifts; content } in
-      (term, substs)
-
-    let term_commit_shifts substs term =
-      (* TODO: very weird function  *)
-      let (Substs { next; shifts; content }) = substs in
-      let term = Shifts.term_commit shifts term in
-      (term, Substs { next; shifts = Shifts.empty; content })
-
-    let capture substs f =
-      (* TODO: really ugly function *)
-      let (Substs { next = from; shifts = _; content = _ }) = substs in
-      let x, Substs { next = to_; shifts; content } = f substs in
-      (* TODO: this is weird *)
-      assert (shifts = Shifts.empty);
-      let rec find_substs ~from acc =
-        match Level.repr from < Level.repr to_ with
-        | true ->
-            let pat, term, shifts = Array.get content @@ Level.repr from in
-            let term = Shifts.term_commit shifts term in
-            let pat = Shifts.pat_commit shifts pat in
-            let from = Level.next from in
-            find_substs ~from ((pat, term) :: acc)
-        | false -> acc
-      in
-      let rev_substs = find_substs ~from [] in
-      let wrap term =
-        (* TODO: better than let here *)
-        (* TODO: this ttype here is really weird *)
-        List.fold_left
-          (fun return (bound, value) -> ttype @@ tt_let ~bound ~value ~return)
-          term rev_substs
-      in
-      let shift term =
-        let open Shifts in
-        let by_ = Level.repr to_ - Level.repr from in
-        let shifts = shift ~by_ empty in
-        Shifts.term_commit shifts term
-      in
-      (x, `Wrap wrap, `Shift shift)
-  end
-
-  (* TODO: gas count *)
-  let rec term_expand_head term ~args ~substs =
-    match (term_syntax_of term, args) with
-    | TT_annot { term; annot = _ }, _ ->
-        (* annot *)
-        term_expand_head term ~args ~substs
-    | TT_bound_var { var }, _ ->
-        (* subst *)
-        let term, substs = Substs.apply ~var substs in
-        term_expand_head term ~args ~substs
-    | TT_apply { lambda; arg }, args ->
-        (* beta1 *)
-        let args = (arg, substs) :: args in
-        term_expand_head lambda ~args ~substs
-    | TT_lambda { param; return }, (arg, arg_substs) :: args ->
-        (* beta2 *)
-        let substs = Substs.push param ~to_:arg ~at_:arg_substs substs in
-        term_expand_head return ~args ~substs
-    | TT_let { bound; value; return }, _ ->
-        (* zeta *)
-        let substs = Substs.push bound ~to_:value ~at_:substs substs in
-        term_expand_head return ~args ~substs
-    | TT_free_var _, _ | TT_forall _, _ | TT_lambda _, [] | TT_string _, _ ->
-        (* head *)
-        (term, args, substs)
-
-  (* TODO: avoid cyclical expansion *)
-  (* TODO: avoid allocating term nodes *)
-  (* TODO: short circuit when same variable on both sides *)
-  let rec tt_equal ~level ~left ~left_substs ~right ~right_substs =
-    let left, left_args, left_substs =
-      term_expand_head left ~args:[] ~substs:left_substs
-    in
-    let right, right_args, right_substs =
-      term_expand_head right ~args:[] ~substs:right_substs
-    in
-    tt_apply_equal ~level ~left ~left_args ~left_substs ~right ~right_args
-      ~right_substs
-
-  and tt_apply_equal ~level ~left ~left_args ~left_substs ~right ~right_args
-      ~right_substs =
-    tt_struct_equal ~level ~left ~left_substs ~right ~right_substs;
-    (* TODO: arith clash *)
-    List.iter2
-      (fun (left, left_substs) (right, right_substs) ->
-        tt_equal ~level ~left ~left_substs ~right ~right_substs)
-      left_args right_args
-
-  and tt_struct_equal ~level ~left ~left_substs ~right ~right_substs =
-    match (term_syntax_of left, term_syntax_of right) with
-    | TT_annot _, _ | _, TT_annot _ -> failwith "invariant"
-    | TT_bound_var _, _ | _, TT_bound_var _ -> failwith "invariant"
-    | TT_apply _, _ | _, TT_apply _ -> failwith "invariant"
-    | TT_let _, _ | _, TT_let _ -> failwith "invariant"
-    | TT_free_var { var = left }, TT_free_var { var = right }
-      when Level.equal left right ->
-        ()
-    | ( TT_forall { param = left_param; return = left_return },
-        TT_forall { param = right_param; return = right_return } ) ->
-        with_tp_equal_contra ~level ~left:left_param ~left_substs
-          ~right:right_param ~right_substs
-        @@ fun ~level ~left_substs ~right_substs ->
-        tt_equal ~level ~left:left_return ~left_substs ~right:right_return
-          ~right_substs
-    | ( TT_lambda { param = left_param; return = left_return },
-        TT_lambda { param = right_param; return = right_return } ) ->
-        with_tp_equal_contra ~level ~left:left_param ~left_substs
-          ~right:right_param ~right_substs
-        @@ fun ~level ~left_substs ~right_substs ->
-        tt_equal ~level ~left:left_return ~left_substs ~right:right_return
-          ~right_substs
-    | TT_string { literal = left }, TT_string { literal = right }
-      when String.equal left right ->
-        ()
-    | ( (TT_free_var _ | TT_forall _ | TT_lambda _ | TT_string _),
-        (TT_free_var _ | TT_forall _ | TT_lambda _ | TT_string _) ) ->
-        (* TODO: type clash needs substs *)
-        error_type_clash ~left ~right
-
-  and with_tp_equal_contra ~level ~left ~left_substs ~right ~right_substs k =
-    (* TODO: contra? *)
-    let left_type = pat_type_of left in
-    let right_type = pat_type_of right in
-    tt_equal ~level ~left:left_type ~left_substs ~right:right_type ~right_substs;
-    let level = Level.next level in
-    let left_to_ =
-      (* TODO: maybe pack left_type? *)
-      tterm ~type_:left_type @@ tt_free_var ~var:level
-    in
-    let right_to_ =
-      (* TODO: maybe pack right_type? *)
-      tterm ~type_:right_type @@ tt_free_var ~var:level
-    in
-    let left_substs =
-      Substs.push left ~to_:left_to_ ~at_:left_substs left_substs
-    in
-    let right_substs =
-      Substs.push right ~to_:right_to_ ~at_:right_substs right_substs
-    in
-    k ~level ~left_substs ~right_substs
-
-  (* TODO: linear functions can be faster without packing *)
-  (* TODO: variable expansions without args can be faster without packing *)
-
-  (* TODO: this is super hackish *)
-  let tt_split_forall type_ ~substs =
-    let (type_, args), `Wrap wrap, `Shift shift =
-      Substs.capture substs @@ fun substs ->
-      let type_, args, substs = term_expand_head type_ ~args:[] ~substs in
-      let type_, substs = Substs.term_commit_shifts substs type_ in
-      ((type_, args), substs)
-    in
-    match (term_syntax_of type_, args) with
-    | TT_forall { param; return }, [] ->
-        let wrapped_arg_type = wrap @@ pat_type_of param in
-        let apply_return_type ~arg =
-          let arg = shift arg in
-          (* TODO: weird ttype here *)
-          wrap @@ ttype @@ tt_let ~bound:param ~value:arg ~return
+(* (M : LHS) :> RHS*)
+(* TODO: short circuits *)
+let rec coerce ~at term lhs rhs =
+  match (head lhs, head rhs) with
+  | V_inter { left = lhs_left; env = lhs_env; right = lhs_right }, rhs -> (
+      try coerce ~at term lhs_left rhs
+      with _exn ->
+        (* TODO: properly handle this exception *)
+        let lhs_right =
+          let lhs_env = append lhs_env term in
+          eval lhs_env lhs_right
         in
-        (wrapped_arg_type, apply_return_type)
-    (* head *)
-    | TT_free_var _, _ | TT_forall _, _ | TT_lambda _, [] | TT_string _, _ ->
-        (* TODO: dump substs *)
-        error_not_a_forall ~type_
-    | TT_annot _, _ -> failwith "invariant"
-    | TT_bound_var _, _ -> failwith "invariant"
-    | TT_lambda _, _ -> failwith "invariant"
-    | TT_apply _, _ -> failwith "invariant"
-    | TT_let _, _ -> failwith "invariant"
-end
-
-module Elaborate_context : sig
-  type context
-
-  val initial : context
-
-  (* vars *)
-  val lookup_var : context -> Name.t -> Index.t
-  val with_bound_var : context -> Name.t -> (context -> 'k) -> 'k
-end = struct
-  open Ttree
-  open Terror
-
-  type context = { level : Level.t; names : Level.t Name.Map.t }
-
-  let initial =
-    (* TODO: this is bad *)
-    let names =
-      let open Name.Map in
-      let names = empty in
-      (* TODO: duplicated string name *)
-      let names = add (Name.make "Type") level_univ names in
-      let names = add (Name.make "String") level_string names in
-      names
-    in
-    let level = level_string in
-    { names; level }
-
-  let lookup_var ctx name =
-    let { names; level } = ctx in
-    match Name.Map.find_opt name names with
-    | Some from -> (
-        match Level.offset ~from ~to_:level with
-        | Some var -> var
-        | None -> failwith "invariant lookup")
-    | None -> error_unknown_var ~name
-
-  let with_bound_var ctx name k =
-    let { level; names } = ctx in
-    let level = Level.next level in
-    let names = Name.Map.add name level names in
-    k @@ { level; names }
-end
-
-module Elaborate = struct
-  open Ctree
-  open Ttree
-  open Elaborate_context
-  open Terror
-
-  (* TODO: does having expected_term also improves inference?
-       Maybe with self and fix? But maybe not worth it
-     Seems to help with many cases such as expected on annotation *)
-  let tterm term =
-    (* TODO: some of those could already be typed *)
-    tterm ~type_:tterm_nil term
-
-  let rec elaborate_term ctx term =
-    (* TODO: use this location *)
-    let (CTerm { term; loc = _ }) = term in
-    match term with
-    | CT_parens { content = term } -> elaborate_term ctx term
-    | CT_annot { value = term; annot } ->
-        let annot = elaborate_term ctx annot in
-        let term = elaborate_term ctx term in
-        tterm @@ tt_annot ~term ~annot
-    | CT_var { var = name } ->
-        let var = lookup_var ctx name in
-        tterm @@ tt_bound_var ~var
-    | CT_extension _ -> error_extensions_not_implemented ()
-    | CT_forall { param; return } ->
-        with_elaborate_pat ctx param @@ fun ctx param ->
-        let return = elaborate_term ctx return in
-        tterm @@ tt_forall ~param ~return
-    | CT_lambda { param; return } ->
-        with_elaborate_pat ctx param @@ fun ctx param ->
-        let return = elaborate_term ctx return in
-        tterm @@ tt_lambda ~param ~return
-    | CT_apply { lambda; arg } ->
-        let lambda = elaborate_term ctx lambda in
-        let arg = elaborate_term ctx arg in
-        tterm @@ tt_apply ~lambda ~arg
-    | CT_semi { left; right } -> elaborate_semi ctx ~left ~right
-    | CT_string { literal } -> tterm @@ tt_string ~literal
-    | CT_pair _ | CT_both _ | CT_bind _ | CT_number _ | CT_braces _ ->
-        error_invalid_notation ()
-
-  and elaborate_semi ctx ~left ~right =
-    let (CTerm { term = left; loc = _ }) = left in
-    match left with
-    | CT_parens { content = left } -> elaborate_semi ctx ~left ~right
-    | CT_bind { bound; value } ->
-        let value = elaborate_term ctx value in
-        (* TODO: this should be before value *)
-        with_elaborate_pat ctx bound @@ fun ctx bound ->
-        let return = elaborate_term ctx right in
-        tterm @@ tt_let ~bound ~value ~return
-    | CT_annot { value = _; annot = _ } -> error_hoist_not_implemented ()
-    | CT_var _ | CT_extension _ | CT_forall _ | CT_lambda _ | CT_apply _
-    | CT_pair _ | CT_both _ | CT_semi _ | CT_string _ | CT_number _
-    | CT_braces _ ->
-        error_invalid_notation ()
-
-  and with_elaborate_pat ctx pat k =
-    (* TODO: to_ here *)
-    (* TODO: use this location *)
-    let (CTerm { term = pat; loc = _ }) = pat in
-    let tp_typed pat =
-      (* TODO: some of those could already be typed *)
-      tpat ~type_:tterm_nil pat
-    in
-    match pat with
-    | CT_parens { content = pat } -> with_elaborate_pat ctx pat k
-    | CT_var { var = name } ->
-        with_bound_var ctx name @@ fun ctx -> k ctx @@ tp_typed @@ tp_var ~name
-    | CT_annot { value = pat; annot } ->
-        let annot = elaborate_term ctx annot in
-        with_elaborate_pat ctx pat @@ fun ctx pat ->
-        k ctx @@ tp_typed @@ tp_annot ~pat ~annot
-    | _ -> error_invalid_notation ()
-end
-
-module Infer_context : sig
-  open Ttree
-
-  type context
-
-  val make_initial : unit -> context
-
-  (* vars *)
-  val find_var_type : context -> Index.t -> term
-  val with_bound_var : context -> pat -> type_:term -> (context -> 'k) -> 'k
-  val with_subst_var : context -> pat -> to_:term -> (context -> 'k) -> 'k
-
-  (* machinery *)
-  val tt_equal : context -> left:term -> right:term -> unit
-  val tt_split_forall : context -> term -> term * (arg:term -> term)
-end = struct
-  open Ttree
-  open Machinery
-
-  type context = {
-    level : Level.t;
-    left_substs : Substs.t;
-    right_substs : Substs.t;
-  }
-
-  let make_initial () =
-    let level = level_string in
-    let make_substs () =
-      let substs = Substs.make () in
-      let substs = Substs.push tpat_nil ~to_:tterm_nil ~at_:substs substs in
-      (* TODO: better than tp_nil *)
-      let substs = Substs.push tpat_nil ~to_:tt_type_univ ~at_:substs substs in
-      let substs =
-        Substs.push tpat_nil ~to_:tt_type_string ~at_:substs substs
+        coerce ~at term lhs_right rhs)
+  | lhs, V_inter { left = rhs_left; env = rhs_env; right = rhs_right } ->
+      coerce ~at term lhs rhs_left;
+      let rhs_right =
+        let rhs_env = append rhs_env term in
+        eval rhs_env rhs_right
       in
-      substs
-    in
-    let left_substs = make_substs () in
-    let right_substs = make_substs () in
-    { level; left_substs; right_substs }
+      coerce ~at term lhs rhs_right
+  | ( (V_var _ | V_apply _ | V_lambda _ | V_univ | V_forall _ | V_thunk _),
+      (V_var _ | V_apply _ | V_lambda _ | V_univ | V_forall _ | V_thunk _) ) ->
+      equal ~at lhs rhs
 
-  let find_var_type ctx var =
-    let { level = _; left_substs; right_substs = _ } = ctx in
-    let term, substs = Substs.apply ~var left_substs in
-    let _term, type_ = Machinery.term_split_term term in
-    let type_, _substs = Substs.term_commit_shifts substs type_ in
-    type_
+(* TODO: where to do path compression? *)
+let split_forall value =
+  match value with
+  | V_forall { param; env; body } ->
+      let param = head param in
+      (param, env, body)
+  | V_var _ | V_apply _ | V_lambda _ | V_univ | V_inter _ | V_thunk _ ->
+      failwith "not a forall"
 
-  let with_bound_var ctx pat ~type_ k =
-    let { level; left_substs; right_substs } = ctx in
-    let level = Level.next level in
-    let to_ = tterm ~type_ @@ tt_free_var ~var:level in
-    let left_substs = Substs.push pat ~to_ ~at_:left_substs left_substs in
-    let right_substs = Substs.push pat ~to_ ~at_:right_substs right_substs in
-    k @@ { level; left_substs; right_substs }
+(* infer *)
+type vars = Vars of { types : value list } [@@ocaml.unboxed]
 
-  let with_subst_var ctx pat ~to_ k =
-    let { level; left_substs; right_substs } = ctx in
-    let level = Level.next level in
-    let left_substs = Substs.push pat ~to_ ~at_:left_substs left_substs in
-    let right_substs = Substs.push pat ~to_ ~at_:right_substs right_substs in
-    k @@ { level; left_substs; right_substs }
+let enter vars ~type_ =
+  let (Vars { types }) = vars in
+  let types = type_ :: types in
+  Vars { types }
 
-  let tt_split_forall ctx type_ =
-    let { level = _; left_substs; right_substs = _ } = ctx in
-    (* TODO: left and right? *)
-    let wrapped_arg_type, apply_return_type =
-      tt_split_forall type_ ~substs:left_substs
-    in
-    (wrapped_arg_type, apply_return_type)
+let solve vars var =
+  let rec solve types var =
+    match (types, var) with
+    | type_ :: _types, 0 -> type_
+    | _type :: types, var -> solve types (var - 1)
+    | [], _var ->
+        (* TODO: this is a problem *)
+        failwith "unexpected unbound variable"
+  in
+  let (Vars { types }) = vars in
+  let var = ((var : Index.t) :> int) in
+  solve types var
 
-  let tt_equal ctx ~left ~right =
-    let { level; left_substs; right_substs } = ctx in
-    tt_equal ~level ~left ~left_substs ~right ~right_substs
-end
+let rec infer_term ~at vars env term =
+  match term with
+  | T_annot { term; annot } ->
+      let annot = check_annot ~at vars env annot in
+      check_term ~at vars env term ~expected:annot;
+      annot
+  | T_var { var } ->
+      Format.eprintf "var (%a) %a\n%!" Index.pp var pp_value @@ solve vars var;
+      solve vars var
+  | T_let { bound; arg; body } ->
+      let value_type =
+        match infer_pat ~at vars env bound with
+        | Some value_type ->
+            check_term ~at vars env arg ~expected:value_type;
+            value_type
+        | None -> infer_term ~at vars env arg
+      in
+      let vars = enter vars ~type_:value_type in
+      let env =
+        let value = thunk env arg in
+        append env value
+      in
+      infer_term ~at vars env body
+  | T_lambda { bound = _; body = _ } -> failwith "infer not supported"
+  | T_apply { funct; arg } ->
+      let funct_type = infer_term ~at vars env funct in
+      let param_type, body_env, body_type = split_forall funct_type in
+      Format.eprintf "forall, (%a) (%a)\n%!" pp_term funct pp_term arg;
+      check_term ~at vars env arg ~expected:param_type;
+      let body_env =
+        let thunk = thunk env arg in
+        append body_env thunk
+      in
+      eval body_env body_type
+  | T_forall { bound; param; body } ->
+      let param = check_annot ~at vars env param in
+      check_pat ~at vars env bound ~expected:param;
+      let () =
+        let skolem = skolem ~at in
+        let at = Level.next at in
+        let vars = enter vars ~type_:param in
+        let env = append env skolem in
+        check_term ~at vars env body ~expected:v_univ
+      in
+      v_univ
+  | T_inter { bound; left; right } ->
+      let left = check_annot ~at vars env left in
+      check_pat ~at vars env bound ~expected:left;
+      let () =
+        let skolem = skolem ~at in
+        let at = Level.next at in
+        let vars = enter vars ~type_:left in
+        let env = append env skolem in
+        check_term ~at vars env right ~expected:v_univ
+      in
+      v_univ
 
-module Infer = struct
-  open Ttree
-  open Terror
-  open Machinery
-  open Infer_context
+and check_term ~at vars env term ~expected =
+  match (term, expected) with
+  | ( T_lambda { bound; body },
+      V_forall { param; env = expected_env; body = expected_body } ) ->
+      check_pat ~at vars env bound ~expected:param;
+      let skolem = skolem ~at in
+      let at = Level.next at in
+      let vars = enter vars ~type_:param in
+      let env = append env skolem in
+      let expected_body =
+        let expected_env = append expected_env skolem in
+        eval expected_env expected_body
+      in
+      check_term ~at vars env body ~expected:expected_body
+  | term, expected ->
+      let received = infer_term ~at vars env term in
+      Format.eprintf "(%a : %a) :> %a\n%!" pp_term term pp_value received
+        pp_value expected;
+      let term = eval env term in
+      coerce ~at term received expected
 
-  (* TODO: does having expected_term also improves inference?
-       Maybe with self and fix? But maybe not worth it
-     Seems to help with many cases such as expected on annotation *)
+and check_annot ~at vars env term =
+  check_term ~at vars env term ~expected:v_univ;
+  eval env term
 
-  let rec infer_term ctx term =
-    match term with
-    | TTerm typed ->
-        let type_ = infer_term_syntax ctx term in
-        typed.type_ <- type_;
-        type_
-    | TType { term = _ } -> failwith "unreachable"
+and infer_pat ~at vars env pat =
+  match pat with
+  | P_annot { pat; annot } ->
+      let annot = check_annot ~at vars env annot in
+      check_pat ~at vars env pat ~expected:annot;
+      Some annot
+  | P_var { var = _ } -> None
 
-  and infer_term_syntax ctx term =
-    match term_syntax_of term with
-    | TT_free_var { var = _ } -> failwith "unreachable"
-    | TT_annot { term; annot } ->
-        (* TODO: expected term could propagate here *)
-        let () = check_annot ctx annot in
-        (* TODO: unify annot before or after check term *)
-        let () = check_term ctx term ~expected:annot in
-        annot
-    | TT_bound_var { var } -> find_var_type ctx var
-    | TT_forall { param; return } ->
-        with_infer_pat ctx param @@ fun ctx ->
-        let () = check_annot ctx return in
-        tt_type_univ
-    | TT_lambda { param; return } ->
-        with_infer_pat ctx param @@ fun ctx ->
-        let return = infer_term ctx return in
-        ttype @@ tt_forall ~param ~return
-    | TT_apply { lambda; arg } ->
-        let forall = infer_term ctx lambda in
-        (* TODO: this could be better? avoiding split forall? *)
-        let wrapped_arg_type, apply_return_type = tt_split_forall ctx forall in
-        let () = check_term ctx arg ~expected:wrapped_arg_type in
-        apply_return_type ~arg
-    | TT_let { bound; value; return } ->
-        (* TODO: use this loc *)
-        let value_type = infer_term ctx value in
-        (* TODO: this should be before value *)
-        (* TODO: with_check_pat + subst  *)
-        with_check_pat ctx bound ~expected:value_type ~to_:value @@ fun ctx ->
-        let return_type = infer_term ctx return in
-        ttype @@ tt_let ~bound ~value ~return:return_type
-    | TT_string { literal = _ } -> tt_type_string
+and check_pat ~at vars env pat ~expected =
+  match pat with
+  | P_annot { pat; annot } ->
+      let annot = check_annot ~at vars env annot in
+      (* TODO: coercion here? *)
+      equal ~at annot expected;
+      check_pat ~at vars env pat ~expected:annot
+  | P_var { var = _ } -> ()
 
-  and check_term ctx term ~expected =
-    (* TODO: let () = assert_is_tt_with_type expected in *)
-    (* TODO: expected should be a pattern? *)
-    (* TODO: propagation through dependent things
-        aka substitution inversion *)
-    (* TODO: forall could in theory be improved by expected term *)
-    (* TODO: apply could propagate when arg is var *)
-    (* TODO: could propagate through let? *)
-    let received = infer_term ctx term in
-    tt_equal ctx ~left:received ~right:expected
-
-  and check_annot ctx term = check_term ctx term ~expected:tt_type_univ
-
-  and with_infer_pat ctx pat k =
-    let type_ = infer_pat ctx pat in
-    with_bound_var ctx pat ~type_ k
-
-  and infer_pat ctx pat =
-    match pat with
-    | TPat typed ->
-        let type_ = infer_pat_syntax ctx pat in
-        typed.type_ <- type_;
-        type_
-
-  and infer_pat_syntax ctx pat =
-    match pat_syntax_of pat with
-    | TP_var { name = _ } -> error_missing_annotation ()
-    | TP_annot { pat; annot } ->
-        let () = check_annot ctx annot in
-        let () = check_pat ctx pat ~expected:annot in
-        annot
-
-  and with_check_pat ctx pat ~expected ~to_ k =
-    let () = check_pat ctx pat ~expected in
-    with_subst_var ctx pat ~to_ k
-
-  and check_pat ctx pat ~expected =
-    (* TODO: let () = assert_is_tt_with_type expected in *)
-    (* TODO: expected should be a pattern, to achieve strictness *)
-    let (TPat typed) = pat in
-    typed.type_ <- expected;
-    check_pat_syntax ctx pat ~expected
-
-  and check_pat_syntax ctx pat ~expected =
-    match pat_syntax_of pat with
-    | TP_annot { pat; annot } ->
-        let () = check_annot ctx annot in
-        let () = tt_equal ctx ~left:annot ~right:expected in
-        check_pat ctx pat ~expected:annot
-    | TP_var { name = _ } -> ()
-
-  let infer_term term =
-    match
-      let ctx = Infer_context.make_initial () in
-      let term = Elaborate.elaborate_term Elaborate_context.initial term in
-      infer_term ctx term
-    with
-    | term -> Ok term
-    | exception TError { error } -> Error error
-end
+(* external *)
+let infer_term term =
+  let at = Level.(next zero) in
+  let vars =
+    let types = [ v_univ ] in
+    Vars { types }
+  in
+  let env = append empty v_univ in
+  try Ok (infer_term ~at vars env term) with exn -> Error exn

--- a/teika/typer.mli
+++ b/teika/typer.mli
@@ -1,5 +1,3 @@
-open Syntax
+open Ttree
 
-module Infer : sig
-  val infer_term : Ctree.term -> (Ttree.term, Terror.error) result
-end
+val infer_term : term -> (value, exn) result


### PR DESCRIPTION
## Goals

Use a standard technique for lazy values that relies on the OCaml GC. Also add intersections as an example.

## Context

The current Teika typer uses a more or less novel model, where terms and values are integrated in the same structure as such, the difference between a value to a term is if it uses levels or indices.

While this works and is likely faster as it provides more control, it incurs in a huge cognitive overhead without dependent types.

Additionally, the type level should likely be lazy as that makes working with recursive types much easier.

This PR addresses both of those by moving to NbE traditional. The current implementation is very close to the following example:
 
https://github.com/AndrasKovacs/elaboration-zoo/blob/master/01-eval-closures-debruijn/Main.hs

## Related

- #199
