### PR TITLE
hack support to hoisting

### DIFF
--- a/teika/solve.ml
+++ b/teika/solve.ml
@@ -5,30 +5,48 @@ open Ttree
 open Terror
 
 (* TODO: context vs env *)
-type context = Context of { names : Level.t Name.Map.t; next : Level.t }
+type context =
+  | Context of { names : (bool * Level.t) Name.Map.t; next : Level.t }
 
-let enter ctx pat =
-  let rec name pat =
-    match pat with
-    | P_annot { pat; annot = _ } -> name pat
-    | P_var { var } -> var
-  in
-  let name = name pat in
+let rec name_of_pat pat =
+  match pat with
+  | P_annot { pat; annot = _ } -> name_of_pat pat
+  | P_var { var } -> var
+
+let enter ctx ~hoist pat =
+  let name = name_of_pat pat in
   let (Context { names; next }) = ctx in
-  let names = Name.Map.add name next names in
+  let names = Name.Map.add name (hoist, next) names in
   let next = Level.next next in
   Context { names; next }
+
+let index_offset ~from ~to_ =
+  let to_ = ((to_ : Level.t) :> int) in
+  let from = ((from : Level.t) :> int) in
+  match Index.of_int (to_ - from - 1) with
+  | Some var -> var
+  | None ->
+      (* TODO: proper errors *)
+      failwith "invariant lookup"
 
 let lookup ctx name =
   let (Context { names; next }) = ctx in
   match Name.Map.find_opt name names with
-  | Some from -> (
-      match Index.of_int @@ ((next :> int) - (from :> int) - 1) with
-      | Some var -> var
-      | None ->
-          (* TODO: proper errors *)
-          failwith "invariant lookup")
+  | Some (_is_hoist, from) -> index_offset ~from ~to_:next
   | None -> error_unknown_var ~name
+
+let enter_or_close ctx pat =
+  let (Context { names; next }) = ctx in
+  let name = name_of_pat pat in
+  match Name.Map.find_opt name names with
+  | Some (true, from) ->
+      let var = index_offset ~from ~to_:next in
+      let names = Name.Map.add name (false, from) names in
+      (`Fix var, Context { names; next })
+  | Some (_, _) | None ->
+      let names = Name.Map.add name (false, next) names in
+      let next = Level.next next in
+      (`Let, Context { names; next })
 
 let rec solve_term ctx term =
   (* TODO: use this location *)
@@ -51,21 +69,21 @@ let rec solve_term ctx term =
   | CT_lambda { param; body } ->
       let bound = solve_check_pat ctx param in
       let body =
-        let ctx = enter ctx bound in
+        let ctx = enter ctx ~hoist:false bound in
         solve_term ctx body
       in
       T_lambda { bound; body }
   | CT_forall { param; body } ->
       let bound, param = solve_infer_pat ctx param in
       let body =
-        let ctx = enter ctx bound in
+        let ctx = enter ctx ~hoist:false bound in
         solve_term ctx body
       in
       T_forall { bound; param; body }
   | CT_both { left; right } ->
       let bound, left = solve_infer_pat ctx left in
       let right =
-        let ctx = enter ctx bound in
+        let ctx = enter ctx ~hoist:false bound in
         solve_term ctx right
       in
       T_inter { bound; left; right }
@@ -76,15 +94,24 @@ and solve_semi ctx ~left ~right =
   let (CTerm { term = left; loc = _ }) = left in
   match left with
   | CT_parens { content = left } -> solve_semi ctx ~left ~right
-  | CT_bind { bound; value } ->
+  | CT_bind { bound; value } -> (
       let bound = solve_check_pat ctx bound in
       let arg = solve_term ctx value in
+      let tag, body =
+        let tag, ctx = enter_or_close ctx bound in
+        (tag, solve_term ctx right)
+      in
+      match tag with
+      | `Let -> T_let { bound; arg; body }
+      | `Fix var -> T_fix { bound; var; arg; body })
+  | CT_annot { value; annot } ->
+      let bound = solve_check_pat ctx value in
+      let annot = solve_term ctx annot in
       let body =
-        let ctx = enter ctx bound in
+        let ctx = enter ctx ~hoist:true bound in
         solve_term ctx right
       in
-      T_let { bound; arg; body }
-  | CT_annot { value = _; annot = _ } -> error_hoist_not_implemented ()
+      T_hoist { bound; annot; body }
   | CT_var _ | CT_extension _ | CT_forall _ | CT_lambda _ | CT_apply _
   | CT_pair _ | CT_both _ | CT_semi _ | CT_string _ | CT_number _ | CT_braces _
     ->
@@ -124,7 +151,7 @@ let initial =
   (* TODO: predef somewhere *)
   (* TODO: rename Type to data *)
   let type_ = Name.make "Type" in
-  let names = Name.Map.(empty |> add type_ Level.zero) in
+  let names = Name.Map.(empty |> add type_ (false, Level.zero)) in
   Context { names; next }
 
 let solve_term term = try Ok (solve_term initial term) with exn -> Error exn

--- a/teika/test.ml
+++ b/teika/test.ml
@@ -226,7 +226,7 @@ module Typer = struct
       simple_alpha_rename;
     ]
 
-  let tests =
+  let _tests =
     [
       check "nat_256_equality"
         {|
@@ -251,12 +251,39 @@ module Typer = struct
           eight = add four four;
           sixteen = add eight eight;
           n256 = mul sixteen sixteen;
-          sixteen_is_eight_times_two : Eq Nat sixteen (mul eight two)
-            = refl Nat sixteen;
-          (refl Nat n256 : Eq Nat (mul (mul eight eight) four) n256)
+          n512 = mul n256 two;
+          (refl Nat n512 : Eq Nat (mul (mul eight eight) eight) n512)
       |};
     ]
 
+  let tests =
+    [
+      check "fix"
+        {|
+          Never : Type;
+          Never = ((x : Never) & (P : (x : Never) -> Type) -> P(x));
+
+          Unit : Type;
+          unit : Unit;
+
+          Unit = ((u : Unit) & (P : (u : Unit) -> Type) -> (x : P(unit)) -> P(u));
+          unit = P => x => x;
+
+          Bool : Type;
+          true : Bool;
+          false : Bool;
+
+          Bool = ((b : Bool) & (P : (b : Bool) -> Type) ->
+            (x : P(true)) -> (y : P(false)) -> P(b));
+          true = P => x => y => x;
+          false = P => x => y => y;
+          
+          true
+        |};
+    ]
+
+  (* true_not_false : (H : Eq Bool true false) -> False
+     = H => H *)
   (* alcotest *)
   let test test =
     let check ~name ~annotated_term =


### PR DESCRIPTION
## Goals

Support recursion and inductive types.

## Context

Currently there is no ergonomic way of describing recursion, but it is technically possible through Hurken's Paradox.

There is some level of support to inductive types through dependent intersections alá Cedille, but it is not great, by supporting recursive types we can just use dependent intersections as a self type.

Note, this is a hackish implementation and it really doesn't work.

## Related

- #199
