### PR TITLE
syntax: location on syntax errors and big numbers

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.26.2
+version = unknown

--- a/flake.lock
+++ b/flake.lock
@@ -5,29 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -38,11 +20,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
         "type": "github"
       },
       "original": {
@@ -53,15 +35,14 @@
     },
     "nixpkgs": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1727019637,
-        "narHash": "sha256-zxfPPGSPk8ucDlEy9MZSQP0xQz6eojwfmXWsKVbaZ20=",
+        "lastModified": 1732830411,
+        "narHash": "sha256-ZQwGw5DsRLg6fRwbW9YsEI1IMEYMNqUl0yRA9uuLbHg=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "4cfa4e1578980c38ce984331dbb8b69961081fd3",
+        "rev": "d4c5d82ae569f35a77160272475b18be0936fe14",
         "type": "github"
       },
       "original": {
@@ -72,17 +53,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726972148,
-        "narHash": "sha256-LjqTgGAovaT9vcrQgZNjBO6fA4DdPfWSY1dcEn1f4cg=",
+        "lastModified": 1732780316,
+        "narHash": "sha256-NskLIz0ue4Uqbza+1+8UGHuPVr8DrUiLfZu5VS4VQxw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8e6da32d920a9dec402390e08674f2b11427c24",
+        "rev": "226216574ada4c3ecefcbbec41f39ce4655f78ef",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8e6da32d920a9dec402390e08674f2b11427c24",
+        "rev": "226216574ada4c3ecefcbbec41f39ce4655f78ef",
         "type": "github"
       }
     },
@@ -94,21 +75,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
       let pkgs = (nixpkgs.makePkgs {
         inherit system;
       }).extend (self: super: {
-        ocamlPackages = super.ocaml-ng.ocamlPackages_5_2;
+        ocamlPackages = super.ocaml-ng.ocamlPackages_5_3;
       }); in
       let teika = pkgs.callPackage ./nix {
         inherit nix-filter;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,7 @@ with ocamlPackages; buildDunePackage rec {
     eio
     eio_main
     ppx_sexp_conv
+    zarith
   ]
   # checkInputs are here because when cross compiling dune needs test dependencies
   # but they are not available for the build phase. The issue can be seen by adding strictDeps = true;.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -26,6 +26,7 @@ with ocamlPackages; buildDunePackage rec {
     eio_main
     ppx_sexp_conv
     zarith
+    lsp
   ]
   # checkInputs are here because when cross compiling dune needs test dependencies
   # but they are not available for the build phase. The issue can be seen by adding strictDeps = true;.

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -12,5 +12,6 @@ with pkgs; with ocamlPackages; mkShell {
     ocaml
     dune_3
     ocaml-lsp
+    utop
   ];
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -12,6 +12,5 @@ with pkgs; with ocamlPackages; mkShell {
     ocaml
     dune_3
     ocaml-lsp
-
   ];
 }

--- a/syntax/clexer.ml
+++ b/syntax/clexer.ml
@@ -34,7 +34,7 @@ let rec tokenizer buf =
       (* TODO: this should probably be somewhere else *)
       let literal = lexeme buf in
       (* TODO: this is dangerous *)
-      let literal = int_of_string literal in
+      let literal = Z.of_string literal in
       NUMBER literal
   | "(" -> LEFT_PARENS
   | ")" -> RIGHT_PARENS

--- a/syntax/clexer.ml
+++ b/syntax/clexer.ml
@@ -1,8 +1,18 @@
 open Cparser
 open Sedlexing.Utf8
 
-(* TODO: more information *)
-exception Lexer_unknown_token
+exception Lexer_error of { loc : Location.t }
+exception Parser_error of { loc : Location.t }
+
+let () =
+  Printexc.register_printer @@ function
+  | Lexer_error { loc = _ } -> Some "lexer: syntax error"
+  | Parser_error { loc = _ } -> Some "parser: syntax error"
+  | _ -> None
+
+let loc buf =
+  let loc_start, loc_end = Sedlexing.lexing_positions buf in
+  Location.{ loc_start; loc_end; loc_ghost = false }
 
 let whitespace = [%sedlex.regexp? Plus (' ' | '\t' | '\n')]
 let alphabet = [%sedlex.regexp? 'a' .. 'z' | 'A' .. 'Z']
@@ -41,25 +51,49 @@ let rec tokenizer buf =
   | "{" -> LEFT_BRACE
   | "}" -> RIGHT_BRACE
   | eof -> EOF
-  | _ -> raise Lexer_unknown_token
+  | _ ->
+      let loc = loc buf in
+      raise @@ Lexer_error { loc }
 
-let provider buf () =
+let next buf =
   let token = tokenizer buf in
-  let start, stop = Sedlexing.lexing_positions buf in
-  (token, start, stop)
+  let start, end_ = Sedlexing.lexing_positions buf in
+  (token, start, end_)
 
-let from_string parser string =
+open Cparser.MenhirInterpreter
+
+let rec loop buf state =
+  match state with
+  | InputNeeded _env ->
+      (* The parser needs a token. Request one from the lexer,
+         and offer it to the parser, which will produce a new
+         checkpoint. Then, repeat. *)
+      let token, start, end_ = next buf in
+      let state = offer state (token, start, end_) in
+      loop buf state
+  | Shifting _ | AboutToReduce _ ->
+      let state = resume state in
+      loop buf state
+  | HandlingError _env ->
+      let loc = loc buf in
+      raise (Parser_error { loc })
+  | Accepted value -> value
+  | Rejected -> failwith "cdriver.loop: rejected reached"
+
+let buf_from_string string =
   (* TODO: from string seems to not trigger new line, likely a bug in sedlex *)
   let index = ref 0 in
   let length = String.length string in
-  let buf =
-    from_gen (fun () ->
-        match !index < length with
-        | true ->
-            let char = String.get string !index in
-            incr index;
-            Some char
-        | false -> None)
-  in
-  let provider = provider buf in
-  MenhirLib.Convert.Simplified.traditional2revised parser provider
+  from_gen (fun () ->
+      match !index < length with
+      | true ->
+          let char = String.get string !index in
+          incr index;
+          Some char
+      | false -> None)
+
+let term_opt_from_string string =
+  let buf = buf_from_string string in
+  (* TODO: allow to change this *)
+  let start, _end = Sedlexing.lexing_positions buf in
+  loop buf @@ Cparser.Incremental.term_opt start

--- a/syntax/clexer.mli
+++ b/syntax/clexer.mli
@@ -1,2 +1,6 @@
-val from_string :
-  (Cparser.token, 'a) MenhirLib.Convert.traditional -> string -> 'a
+exception Lexer_error of { loc : Location.t }
+exception Parser_error of { loc : Location.t }
+
+val loc : Sedlexing.lexbuf -> Location.t
+val next : Sedlexing.lexbuf -> Cparser.token * Lexing.position * Lexing.position
+val term_opt_from_string : string -> Ctree.term option

--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -25,7 +25,6 @@ let mk (loc_start, loc_end) =
 %token EOF
 
 %start <Ctree.term option> term_opt
-
 %%
 
 let term_opt :=
@@ -78,12 +77,6 @@ let term_atom :=
   | term_parens(term)
   | term_braces(term)
 
-let term_var ==
-  | var = VAR;
-    { ct_var (mk $loc) ~var:(Name.make var) }
-let term_extension ==
-  | extension = EXTENSION;
-    { ct_extension (mk $loc) ~extension:(Name.make extension) }
 let term_forall(self, lower) ==
   | param = lower; ARROW; body = self;
     { ct_forall (mk $loc) ~param ~body }
@@ -108,6 +101,12 @@ let term_semi(self, lower) ==
 let term_annot(self, lower) ==
   | value = lower; COLON; annot = self;
     { ct_annot (mk $loc) ~value ~annot }
+let term_var ==
+  | var = VAR;
+    { ct_var (mk $loc) ~var:(Name.make var) }
+let term_extension ==
+  | extension = EXTENSION;
+    { ct_extension (mk $loc) ~extension:(Name.make extension) }
 let term_string ==
   | literal = STRING;
     { ct_string (mk $loc) ~literal }

--- a/syntax/cparser.mly
+++ b/syntax/cparser.mly
@@ -15,7 +15,7 @@ let mk (loc_start, loc_end) =
 %token AMPERSAND (* & *)
 %token SEMICOLON (* ; *)
 %token <string> STRING (* "abc" *)
-%token <int> NUMBER (* 123 *)
+%token <Z.t> NUMBER (* 123 *)
 %token LEFT_PARENS (* ( *)
 %token RIGHT_PARENS (* ) *)
 %token LEFT_BRACE (* { *)

--- a/syntax/ctree.ml
+++ b/syntax/ctree.ml
@@ -16,7 +16,7 @@ and term_syntax =
   | CT_semi of { left : term; right : term }
   | CT_annot of { value : term; annot : term }
   | CT_string of { literal : string }
-  | CT_number of { literal : int }
+  | CT_number of { literal : Z.t [@printer Z.pp_print] }
   | CT_parens of { content : term }
   | CT_braces of { content : term }
 [@@deriving show { with_path = false }]

--- a/syntax/ctree.mli
+++ b/syntax/ctree.mli
@@ -14,7 +14,7 @@ and term_syntax =
   | CT_semi of { left : term; right : term }
   | CT_annot of { value : term; annot : term }
   | CT_string of { literal : string }
-  | CT_number of { literal : int }
+  | CT_number of { literal : Z.t }
   | CT_parens of { content : term }
   | CT_braces of { content : term }
 [@@deriving show]
@@ -30,6 +30,6 @@ val ct_bind : Location.t -> bound:term -> value:term -> term
 val ct_semi : Location.t -> left:term -> right:term -> term
 val ct_annot : Location.t -> value:term -> annot:term -> term
 val ct_string : Location.t -> literal:string -> term
-val ct_number : Location.t -> literal:int -> term
+val ct_number : Location.t -> literal:Z.t -> term
 val ct_parens : Location.t -> content:term -> term
 val ct_braces : Location.t -> content:term -> term

--- a/syntax/dune
+++ b/syntax/dune
@@ -8,7 +8,7 @@
 
 (menhir
  (modules cparser)
- (flags --dump --explain))
+ (flags --dump --explain --table))
 
 (executable
  (name test)

--- a/syntax/dune
+++ b/syntax/dune
@@ -1,6 +1,6 @@
 (library
  (name syntax)
- (libraries menhirLib compiler-libs.common utils)
+ (libraries menhirLib compiler-libs.common utils zarith)
  (modules
   (:standard \ Test))
  (preprocess


### PR DESCRIPTION
## Goals

Add locations to parsing errors and support big numbers in the grammar.

## Context

This switches from the monolith API on Menhir to the incremental one, while this is not required, it makes for a more natural implementation and allows to implement error handling in some further future work.

Additionally I also added, `zarith` for big numbers, the `lsp` for future LSP work and `utop` for interactive development.

## Related

- #229
