### PR TITLE
teika: add locations to Ttree and solve

### DIFF
--- a/teika/solve.mli
+++ b/teika/solve.mli
@@ -1,5 +1,7 @@
 open Syntax
 
+exception Solve_error of { loc : Location.t; exn : exn }
+
 type context
 
 (* TODO: couple all the initial contexts *)

--- a/teika/ttree.ml
+++ b/teika/ttree.ml
@@ -1,6 +1,9 @@
 open Utils
 
-type term =
+(* TODO: explicit unfold for loops on terms *)
+type term = Term of { struct_ : term_struct; loc : Location.t [@opaque] }
+
+and term_struct =
   (* (M : A) *)
   | T_annot of { term : term; annot : term }
   (* \n *)
@@ -8,7 +11,7 @@ type term =
   (* P = N; M *)
   | T_let of { bound : pat; arg : term; body : term }
   (* P : A; M *)
-  | T_hoist of { bound : pat; annot : term; body : term }
+  | T_hoist of { bound : pat; body : term }
   (* P : A; ...; P = N; M *)
   | T_fix of { bound : pat; var : Index.t; arg : term; body : term }
   (* P => M *)
@@ -17,13 +20,19 @@ type term =
   | T_apply of { funct : term; arg : term }
   (* (P : A) -> B *)
   | T_forall of { bound : pat; param : term; body : term }
+  (* TODO: part of fix *)
   (* (P : A) & B *)
-  | T_self of { bound : pat; self : term; body : term }
+  | T_self of { bound : pat; body : term }
 
-and pat =
-  (* (P : A) *)
+and pat = Pat of { struct_ : pat_struct; loc : Location.t [@opaque] }
+
+and pat_struct =
+  (* (M : A) *)
   | P_annot of { pat : pat; annot : term }
   (* x *)
   (* TODO: drop names and uses receipts *)
   | P_var of { var : Name.t }
 [@@deriving show { with_path = false }]
+
+let t_wrap ~loc struct_ = Term { struct_; loc }
+let p_wrap ~loc struct_ = Pat { struct_; loc }

--- a/teika/ttree.mli
+++ b/teika/ttree.mli
@@ -1,6 +1,8 @@
 open Utils
 
-type term =
+type term = private Term of { struct_ : term_struct; loc : Location.t }
+
+and term_struct =
   (* (M : A) *)
   | T_annot of { term : term; annot : term }
   (* \n *)
@@ -8,8 +10,9 @@ type term =
   (* P = N; M *)
   | T_let of { bound : pat; arg : term; body : term }
   (* P : A; M *)
-  | T_hoist of { bound : pat; annot : term; body : term }
+  | T_hoist of { bound : pat; body : term }
   (* P : A; ...; P = N; M *)
+  (* TODO: pattern on fix? *)
   | T_fix of { bound : pat; var : Index.t; arg : term; body : term }
   (* P => M *)
   | T_lambda of { bound : pat; body : term }
@@ -17,12 +20,18 @@ type term =
   | T_apply of { funct : term; arg : term }
   (* (P : A) -> B *)
   | T_forall of { bound : pat; param : term; body : term }
+  (* TODO: part of fix *)
   (* (P : A) & B *)
-  | T_self of { bound : pat; self : term; body : term }
+  | T_self of { bound : pat; body : term }
 
-and pat =
+and pat = Pat of { struct_ : pat_struct; loc : Location.t }
+
+and pat_struct =
   (* (P : A) *)
   | P_annot of { pat : pat; annot : term }
   (* x *)
   | P_var of { var : Name.t }
 [@@deriving show]
+
+val t_wrap : loc:Location.t -> term_struct -> term
+val p_wrap : loc:Location.t -> pat_struct -> pat


### PR DESCRIPTION
## Goals

Report more precise error messages on the LSP.

## Context

Currently locations are ignored during solving. This leads to any error during solving to not include any location and additionally it means that there is no location on Ttree.

## Related

- #229
